### PR TITLE
Change version to use default short git rev length

### DIFF
--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -41,7 +41,7 @@ if (NOT DEFINED BARRIER_REVISION)
         string (SUBSTRING $ENV{GIT_COMMIT} 0 8 BARRIER_REVISION)
     elseif (BARRIER_VERSION_STAGE STREQUAL "snapshot")
         execute_process (
-            COMMAND git rev-parse --short=8 HEAD
+            COMMAND git rev-parse --short HEAD
             WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
             OUTPUT_VARIABLE BARRIER_REVISION
             OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
This is defined by core.abbrev in git-config, which is 7 by default.

This will line up the version number with the short version used on the github site.

As far as I know, it will automatically grow beyond 7 to stay unique as the project grows.