### PR TITLE
Make Barrier work over Bluetooth sockets.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,7 @@ if (UNIX)
         check_library_exists ("Xinerama" XineramaQueryExtension "" HAVE_Xinerama)
         check_library_exists ("Xi" XISelectEvents "" HAVE_Xi)
         check_library_exists ("Xrandr" XRRQueryExtension "" HAVE_Xrandr)
+        check_library_exists ("bluetooth" hci_open_dev "" HAVE_BLUETOOTH)
 
         if (HAVE_ICE)
 
@@ -239,6 +240,13 @@ if (UNIX)
         # not sure why, moving it back inside.
         if (HAVE_Xi)
             list (APPEND libs Xi)
+        endif()
+
+        if (HAVE_BLUETOOTH)
+            list (APPEND libs bluetooth)
+            add_definitions( -DHAVE_BLUETOOTH )
+        else()
+            message (Warning "Missing library: bluetooth, disabled")
         endif()
 
     endif()

--- a/src/lib/arch/IArchNetwork.h
+++ b/src/lib/arch/IArchNetwork.h
@@ -65,6 +65,7 @@ public:
         kUNKNOWN,
         kINET,
         kINET6,
+        kBLUETOOTH,
     };
 
     //! Supported socket types

--- a/src/lib/arch/unix/ArchNetworkBSD.h
+++ b/src/lib/arch/unix/ArchNetworkBSD.h
@@ -27,9 +27,12 @@
 #if HAVE_SYS_SOCKET_H
 #    include <sys/socket.h>
 #endif
-
 #if !HAVE_SOCKLEN_T
 typedef int socklen_t;
+#endif
+#if HAVE_BLUETOOTH
+#    include <bluetooth/sdp.h>
+#    include <bluetooth/sdp_lib.h>
 #endif
 
 // old systems may use char* for [gs]etsockopt()'s optval argument.
@@ -44,6 +47,7 @@ class ArchSocketImpl {
 public:
     int                    m_fd;
     int                    m_refCount;
+    IArchNetwork::EAddressFamily                 m_family;
 };
 
 class ArchNetAddressImpl {
@@ -100,6 +104,16 @@ private:
     void                throwError(int);
     void                throwNameError(int);
 
+#if HAVE_BLUETOOTH
+    sdp_session_t        *register_service(uint8_t rfcomm_channel);
+    ArchNetAddress      find_channel(ArchNetAddress addr);
+    ArchNetAddress      find_service(ArchNetAddress addr);
+#endif
+
 private:
     ArchMutex            m_mutex;
+
+#if HAVE_BLUETOOTH
+    sdp_session_t *      sdp_session;
+#endif
 };

--- a/src/lib/barrier/ArgParser.cpp
+++ b/src/lib/barrier/ArgParser.cpp
@@ -117,9 +117,12 @@ ArgParser::parseClientArgs(ClientArgs& args, int argc, const char* const* argv)
 
     // exactly one non-option argument (server-address)
     if (i == argc) {
-        LOG((CLOG_PRINT "%s: a server address or name is required" BYE,
-            args.m_pname, args.m_pname));
-        return false;
+        // breaking
+        args.m_barrierAddress = "00:00:00:00:00:00";
+
+        //LOG((CLOG_PRINT "%s: a server address or name is required" BYE,
+        //    args.m_pname, args.m_pname));
+        //return false;
     }
 
     if (checkUnexpectedArgs()) {

--- a/src/lib/ipc/IpcClient.cpp
+++ b/src/lib/ipc/IpcClient.cpp
@@ -28,7 +28,7 @@
 
 IpcClient::IpcClient(IEventQueue* events, SocketMultiplexer* socketMultiplexer) :
     m_serverAddress(NetworkAddress(IPC_HOST, IPC_PORT)),
-    m_socket(events, socketMultiplexer, IArchNetwork::kINET),
+    m_socket(events, socketMultiplexer, IArchNetwork::kBLUETOOTH),
     m_server(nullptr),
     m_events(events)
 {
@@ -37,7 +37,7 @@ IpcClient::IpcClient(IEventQueue* events, SocketMultiplexer* socketMultiplexer) 
 
 IpcClient::IpcClient(IEventQueue* events, SocketMultiplexer* socketMultiplexer, int port) :
     m_serverAddress(NetworkAddress(IPC_HOST, port)),
-    m_socket(events, socketMultiplexer, IArchNetwork::kINET),
+    m_socket(events, socketMultiplexer, IArchNetwork::kBLUETOOTH),
     m_server(nullptr),
     m_events(events)
 {

--- a/src/lib/ipc/IpcServer.cpp
+++ b/src/lib/ipc/IpcServer.cpp
@@ -54,7 +54,7 @@ IpcServer::IpcServer(IEventQueue* events, SocketMultiplexer* socketMultiplexer, 
 void
 IpcServer::init()
 {
-    m_socket = new TCPListenSocket(m_events, m_socketMultiplexer, IArchNetwork::kINET);
+    m_socket = new TCPListenSocket(m_events, m_socketMultiplexer, IArchNetwork::kBLUETOOTH);
 
     m_clientsMutex = ARCH->newMutex();
     m_address.resolve();

--- a/src/lib/net/NetworkAddress.cpp
+++ b/src/lib/net/NetworkAddress.cpp
@@ -45,7 +45,7 @@ NetworkAddress::NetworkAddress(int port) :
     m_port(port)
 {
     checkPort();
-    m_address = ARCH->newAnyAddr(IArchNetwork::kINET);
+    m_address = ARCH->newAnyAddr(IArchNetwork::kBLUETOOTH);
     ARCH->setAddrPort(m_address, m_port);
 }
 
@@ -145,7 +145,7 @@ NetworkAddress::resolve()
         // if hostname is empty then use wildcard address otherwise look
         // up the name.
         if (m_hostname.empty()) {
-            m_address = ARCH->newAnyAddr(IArchNetwork::kINET);
+            m_address = ARCH->newAnyAddr(IArchNetwork::kBLUETOOTH);
         }
         else {
             m_address = ARCH->nameToAddr(m_hostname);


### PR DESCRIPTION
I don't expect you to merge this but I wanted to draw your attention to it, and ask if you are interested in this functionality.

This patch makes barrier run over RFCOMM bluetooth sockets. This is useful for a number of reasons:    

 * It is encrypted by default.
 * It is "out of band" - meaning you won't lose control if the network connection goes down or is swamped by a large file transfer.
 * SDP allows a laptop running the client to "roam" between two or more servers, eg home and work.

It is adapted from synergy-bluetooth which I created nearly 10 years ago with assistance from Valmantas Palikša aka @walmis, who was the maintainer of Blueman at the time. I had thought the code lost, but I was inspired to go looking again with the release of Barrier. I have ported the old code to Barrier and tested that it still works. Unfortunately the change history and attribution is definitely lost, unless walmis has it.


This is Linux-only, and currently breaks TCP socket implementation.

To use it you must run bluetoothd with --compat and give yourself
write access to /var/run/sdp. The SDP code will need to be ported
to the new DBUS implementation to fix this.

No changes are needed in the server config file.

The client can be run with no arguments. It will scan for a server
using SDP. Alternatively a BDADDR can be supplied (run hciconfig
on the server to find it). This mode of operation is more reliable
and does not require the server to be discoverable. However, SDP
scanning allows a client to roam between servers seamlessly.

The SDP code is copyright (C) 2009 Valmantas Palikša.


The trick here is that bluetooth sockets are nearly interchangable with AF_INET sockets on Linux. Also, since the addition of ipv6, there is already support for two different AF socket families and the ability to select which address family to use in many (but not all) parts of the code. AF_BLUETOOTH only really requires slightly different name resolution and everything else works the same. In fact TCPListenSocket already works with AF_BLUETOOTH with no modifications, so maybe its name is not entirely accurate. ;)

The most obvious problem with this patch is that it currently replaces TCP/IP function. In the Ipc classes, and in some other places, the choice of address family is hardcoded. Rather than try to add run time selection like the old version did, I have simply changed them all to kBLUETOOTH. However, in many other places, adding support is as simple as adding another case: to a switch statement.

There is also the issue of SDP. This makes up the bulk of the patch. In Bluez 5 the API used here is deprecated, replaced by a DBus protocol. This may mean a dependency on glib or some other DBus handling library.

