### PR TITLE
Port to Qt 5.11

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -22,13 +22,12 @@ add_executable (barrier WIN32
 
 include_directories (./src)
 
-qt5_use_modules (barrier Core Widgets Network)
 target_compile_definitions (barrier PRIVATE -DBARRIER_VERSION_STAGE="${BARRIER_VERSION_STAGE}")
 target_compile_definitions (barrier PRIVATE -DBARRIER_REVISION="${BARRIER_REVISION}")
 
 if (WIN32)
     include_directories ($ENV{BONJOUR_SDK_HOME}/Include)
-    find_library (DNSSD_LIB dnssd.lib 
+    find_library (DNSSD_LIB dnssd.lib
                   HINTS ENV BONJOUR_SDK_HOME
                   PATH_SUFFIXES "Lib/x64")
     set_target_properties (barrier PROPERTIES LINK_FLAGS "/NODEFAULTLIB:LIBCMT")
@@ -46,6 +45,7 @@ if (HAVE_X11)
 endif()
 
 target_link_libraries (barrier common)
+target_link_libraries (barrier Qt5::Core Qt5::Widgets Qt5::Network)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     install (TARGETS barrier DESTINATION ${BARRIER_BUNDLE_BINARY_DIR})

--- a/src/gui/src/ActionDialog.cpp
+++ b/src/gui/src/ActionDialog.cpp
@@ -25,6 +25,7 @@
 
 #include <QtCore>
 #include <QtGui>
+#include <QButtonGroup>
 
 ActionDialog::ActionDialog(QWidget* parent, ServerConfig& config, Hotkey& hotkey, Action& action) :
     QDialog(parent, Qt::WindowTitleHint | Qt::WindowSystemMenuHint),

--- a/src/gui/src/ScreenSetupView.cpp
+++ b/src/gui/src/ScreenSetupView.cpp
@@ -22,6 +22,7 @@
 
 #include <QtCore>
 #include <QtGui>
+#include <QHeaderView>
 
 ScreenSetupView::ScreenSetupView(QWidget* parent) :
     QTableView(parent)


### PR DESCRIPTION
This commit ports the code to be compatible with Qt 5.11.

In Qt 5.11 qt5_use_modules was removed and the correct way is by using target_link_libraries to link against the Qt modules.

Moreover, some implicit includes do not work now. I added the missing includes
