### PR TITLE
Improve precision of grabbed scroll events on OSX server

### DIFF
--- a/src/lib/platform/OSXScreen.h
+++ b/src/lib/platform/OSXScreen.h
@@ -144,10 +144,10 @@ private:
     ButtonID            mapMacButtonToBarrier(UInt16) const;
 
     // map mac scroll wheel value to a barrier scroll wheel value
-    SInt32                mapScrollWheelToBarrier(SInt32) const;
+    SInt32                mapScrollWheelToBarrier(float) const;
 
     // map barrier scroll wheel value to a mac scroll wheel value
-    SInt32                mapScrollWheelFromBarrier(SInt32) const;
+    SInt32                mapScrollWheelFromBarrier(float) const;
 
     // get the current scroll wheel speed
     double                getScrollSpeed() const;

--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -1421,7 +1421,7 @@ OSXScreen::mapMacButtonToBarrier(UInt16 macButton) const
 }
 
 SInt32
-OSXScreen::mapScrollWheelToBarrier(SInt32 x) const
+OSXScreen::mapScrollWheelToBarrier(float x) const
 {
 	// return accelerated scrolling but not exponentially scaled as it is
 	// on the mac.
@@ -1430,7 +1430,7 @@ OSXScreen::mapScrollWheelToBarrier(SInt32 x) const
 }
 
 SInt32
-OSXScreen::mapScrollWheelFromBarrier(SInt32 x) const
+OSXScreen::mapScrollWheelFromBarrier(float x) const
 {
 	// use server's acceleration with a little boost since other platforms
 	// take one wheel step as a larger step than the mac does.
@@ -1948,9 +1948,9 @@ OSXScreen::handleCGInputEvent(CGEventTapProxy proxy,
 			break;
 		case kCGEventScrollWheel:
 			screen->onMouseWheel(screen->mapScrollWheelToBarrier(
-								 CGEventGetIntegerValueField(event, kCGScrollWheelEventDeltaAxis2)),
+								 CGEventGetIntegerValueField(event, kCGScrollWheelEventFixedPtDeltaAxis2) / 65536.0f),
 								 screen->mapScrollWheelToBarrier(
-								 CGEventGetIntegerValueField(event, kCGScrollWheelEventDeltaAxis1)));
+								 CGEventGetIntegerValueField(event, kCGScrollWheelEventFixedPtDeltaAxis1) / 65536.0f));
 			break;
 		case kCGEventKeyDown:
 		case kCGEventKeyUp:


### PR DESCRIPTION
This fixes barrier issue #63 which is a copy of https://github.com/symless/synergy-core/issues/5672. Even though I did a PR more than a year ago and pinged multiple times, symless did not merge it...