### PR TITLE
Add fake changelog so that debian package may be built

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,0 +1,5 @@
+barrier (2.1-1) unstable; urgency=low
+
+  * Initial release (Closes: #123456)
+
+ -- Debauchee Open Source Group <todo@mail.com>  Sat, 01 Apr 2018 00:00:00 +0000


### PR DESCRIPTION
This allows barrier to be built out of the box with dpkg-buildpackage.