### PR TITLE
Mention clipboard support in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Barrier is KVM software forked from Symless's synergy 1.9 codebase. Synergy was 
 
 Whereas synergy has moved beyond its goals from the 1.x era, barrier aims to maintain that simplicity.
 Barrier will let you use your keyboard and mouse from one computer to control one or more other computers.
+Clipboard sharing is supported.
 That's it.
 
 ### Project goals

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Barrier is KVM software forked from Symless's synergy 1.9 codebase. Synergy was 
 
 ### What's different?
 
-Whereas synergy has moved beyond its goals from the 1.x era, barrier aims to maintain that simplicity. Barrier will let you use your keyboard and mouse from machine A to control machine B (or more). That's it.
+Whereas synergy has moved beyond its goals from the 1.x era, barrier aims to maintain that simplicity.
+Barrier will let you use your keyboard and mouse from one computer to control one or more other computers.
+That's it.
 
 ### Project goals
 


### PR DESCRIPTION
When I was first looking into this repository, the "barrier only supports sharing keyboard and mouse and that's it" information from the README confused me, because it implied no clipboard sharing which is a required feature for me. Only after looking into commit history and diffs I was able to figure out that barrier still supports clipboard sharing. This PR states clipboard support explicitly in the README.