### PR TITLE
fix(macos-build): Use standard methods for detecting XCode installation and macOS SDK

### DIFF
--- a/clean_build.sh
+++ b/clean_build.sh
@@ -14,7 +14,7 @@ if [ "$(uname)" = "Darwin" ]; then
     # OSX needs a lot of extra help, poor thing
     # run the osx_environment.sh script to fix paths
     . ./osx_environment.sh
-    B_CMAKE_FLAGS="-DCMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 $B_CMAKE_FLAGS"
+    B_CMAKE_FLAGS="-DCMAKE_OSX_SYSROOT=$(xcode-select --print-path)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 $B_CMAKE_FLAGS"
 fi
 # allow local customizations to build environment
 [ -r ./build_env.sh ] && . ./build_env.sh


### PR DESCRIPTION
This Pull Request replaces the
 1. hard-coded XCode installation path (`/Applications/Xcode.app`)
 1. hard-coded macOS SDK (`MacOSX10.13.sdk`)
by standard macOS methods for automatic lookup of both requirements.

Kind regards & Thank you for a great fork,
S