### PR TITLE
OSX: Add support for building on macports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,13 +302,28 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
         ${OPENSSL_ROOT}/lib/ssleay32.lib
     )
 elseif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    set (OPENSSL_ROOT /usr/local/opt/openssl)
 
-    include_directories (BEFORE SYSTEM ${OPENSSL_ROOT}/include)
-    set (OPENSSL_LIBS
-        ${OPENSSL_ROOT}/lib/libssl.a
-        ${OPENSSL_ROOT}/lib/libcrypto.a
-    )
+    if (IS_DIRECTORY /usr/local/opt/openssl)
+        # brew
+        set (OPENSSL_ROOT /usr/local/opt/openssl)
+
+        include_directories (BEFORE SYSTEM ${OPENSSL_ROOT}/include)
+
+        set (OPENSSL_LIBS
+            ${OPENSSL_ROOT}/lib/libssl.a
+            ${OPENSSL_ROOT}/lib/libcrypto.a
+        )
+    else(IS_DIRECTORY /opt/local)
+        # macports
+        set (OPENSSL_ROOT /opt/local)
+
+        set (OPENSSL_LIBS
+            ${OPENSSL_ROOT}/lib/libssl.a
+            ${OPENSSL_ROOT}/lib/libcrypto.a
+            z
+        )
+    endif()
+
 elseif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     set (OPENSSL_LIBS ssl crypto)
 else()

--- a/osx_environment.sh
+++ b/osx_environment.sh
@@ -1,16 +1,36 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ ! $BARRIER_BUILD_ENV ]; then
 
     printf "Modifying environment for Barrier build..."
 
-    QT_PATH=$(brew --prefix qt)
-    OPENSSL_PATH=$(brew --prefix openssl)
+    if command -v brew; then
+        printf "Detected Homebrew"
+        QT_PATH=$(brew --prefix qt)
+        OPENSSL_PATH=$(brew --prefix openssl)
 
-    export CMAKE_PREFIX_PATH="$QT_PATH:$CMAKE_PREFIX_PATH"
-    export LD_LIBRARY_PATH="$OPENSSL_PATH/lib:$LD_LIBRARY_PATH"
-    export CPATH="$OPENSSL_PATH/include:$CPATH"
-    export PKG_CONFIG_PATH="$OPENSSL_PATH/lib/pkgconfig:$PKG_CONFIG_PATH"
+		export BARRIER_BUILD_BREW=1
+        export CMAKE_PREFIX_PATH="$QT_PATH:$CMAKE_PREFIX_PATH"
+        export LD_LIBRARY_PATH="$OPENSSL_PATH/lib:$LD_LIBRARY_PATH"
+        export CPATH="$OPENSSL_PATH/include:$CPATH"
+        export PKG_CONFIG_PATH="$OPENSSL_PATH/lib/pkgconfig:$PKG_CONFIG_PATH"
+
+    elif command -v port; then
+        printf "Detected Macports"
+
+		if [ ! -d /opt/local/lib/cmake/Qt5 ]; then
+            printf "Please install qt5-qtbase port"
+        fi
+		export BARRIER_BUILD_MACPORTS=1
+		export CMAKE_PREFIX_PATH="/opt/local/lib/cmake/Qt5:$CMAKE_PREFIX_PATH"
+		export LD_LIBRARY_PATH="/opt/local/lib:$LD_LIBRARY_PATH"
+		export CPATH="/opt/local/include:$CPATH"
+        export PKG_CONFIG_PATH="/opt/local/libexec/qt5/lib/pkgconfig:$PKG_CONFIG_PATH"
+    else
+        printf "Neither Homebrew nor Macports is installed. Can't get dependency paths"
+        exit 1
+    fi
+
     export BARRIER_BUILD_ENV=1
 
     printf "done\n"


### PR DESCRIPTION
Currently Barrier only supports building on Homebrew. This PR adds support for Macports.