### PR TITLE
Travis: Add OSX build config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,11 @@ matrix:
         - sudo port -N install qt5-qtbase openssl
         - sh -x ./clean_build.sh
 
+    - os: osx
+      osx_image: xcode9
+      script:
+        - brew update
+        - brew install qt openssl
+        - sh -x ./clean_build.sh
+
 install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: cpp
-before_install:
-- sudo apt-get update -qq
-- sudo apt-get install -qq libxtst-dev
-- sudo apt-get install -qq qtdeclarative5-dev
-- sudo apt-get install -qq libavahi-compat-libdnssd-dev
-script: sh -x ./clean_build.sh
-# skip install phase since we have a customized install package
-# creation tool for each supported platform
+
+matrix:
+  include:
+    - os: linux
+      addons:
+        apt:
+          packages:
+            - libxtst-dev
+            - qtdeclarative5-dev
+            - libavahi-compat-libdnssd-dev
+      script: sh -x ./clean_build.sh
+
 install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,15 @@ matrix:
             - libavahi-compat-libdnssd-dev
       script: sh -x ./clean_build.sh
 
+    - os: osx
+      osx_image: xcode9
+      script:
+        - export COLUMNS=80
+        - curl -LO https://raw.githubusercontent.com/GiovanniBussi/macports-ci/master/macports-ci
+        - chmod +x ./macports-ci
+        - ./macports-ci install
+        - PATH="$PATH:/opt/local/bin"
+        - sudo port -N install qt5-qtbase openssl
+        - sh -x ./clean_build.sh
+
 install: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,13 +302,28 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
         ${OPENSSL_ROOT}/lib/ssleay32.lib
     )
 elseif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    set (OPENSSL_ROOT /usr/local/opt/openssl)
 
-    include_directories (BEFORE SYSTEM ${OPENSSL_ROOT}/include)
-    set (OPENSSL_LIBS
-        ${OPENSSL_ROOT}/lib/libssl.a
-        ${OPENSSL_ROOT}/lib/libcrypto.a
-    )
+    if (IS_DIRECTORY /usr/local/opt/openssl)
+        # brew
+        set (OPENSSL_ROOT /usr/local/opt/openssl)
+
+        include_directories (BEFORE SYSTEM ${OPENSSL_ROOT}/include)
+
+        set (OPENSSL_LIBS
+            ${OPENSSL_ROOT}/lib/libssl.a
+            ${OPENSSL_ROOT}/lib/libcrypto.a
+        )
+    else(IS_DIRECTORY /opt/local)
+        # macports
+        set (OPENSSL_ROOT /opt/local)
+
+        set (OPENSSL_LIBS
+            ${OPENSSL_ROOT}/lib/libssl.a
+            ${OPENSSL_ROOT}/lib/libcrypto.a
+            z
+        )
+    endif()
+
 elseif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     set (OPENSSL_LIBS ssl crypto)
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,7 +303,16 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     )
 elseif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
-    if (IS_DIRECTORY /usr/local/opt/openssl)
+    if (IS_DIRECTORY /opt/local)
+        # macports
+        set (OPENSSL_ROOT /opt/local)
+
+        set (OPENSSL_LIBS
+            ${OPENSSL_ROOT}/lib/libssl.a
+            ${OPENSSL_ROOT}/lib/libcrypto.a
+            z
+        )
+    elseif (IS_DIRECTORY /usr/local/opt/openssl)
         # brew
         set (OPENSSL_ROOT /usr/local/opt/openssl)
 
@@ -312,15 +321,6 @@ elseif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
         set (OPENSSL_LIBS
             ${OPENSSL_ROOT}/lib/libssl.a
             ${OPENSSL_ROOT}/lib/libcrypto.a
-        )
-    else(IS_DIRECTORY /opt/local)
-        # macports
-        set (OPENSSL_ROOT /opt/local)
-
-        set (OPENSSL_LIBS
-            ${OPENSSL_ROOT}/lib/libssl.a
-            ${OPENSSL_ROOT}/lib/libcrypto.a
-            z
         )
     endif()
 

--- a/osx_environment.sh
+++ b/osx_environment.sh
@@ -1,16 +1,36 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ ! $BARRIER_BUILD_ENV ]; then
 
     printf "Modifying environment for Barrier build..."
 
-    QT_PATH=$(brew --prefix qt)
-    OPENSSL_PATH=$(brew --prefix openssl)
+    if command -v brew; then
+        printf "Detected Homebrew"
+        QT_PATH=$(brew --prefix qt)
+        OPENSSL_PATH=$(brew --prefix openssl)
 
-    export CMAKE_PREFIX_PATH="$QT_PATH:$CMAKE_PREFIX_PATH"
-    export LD_LIBRARY_PATH="$OPENSSL_PATH/lib:$LD_LIBRARY_PATH"
-    export CPATH="$OPENSSL_PATH/include:$CPATH"
-    export PKG_CONFIG_PATH="$OPENSSL_PATH/lib/pkgconfig:$PKG_CONFIG_PATH"
+		export BARRIER_BUILD_BREW=1
+        export CMAKE_PREFIX_PATH="$QT_PATH:$CMAKE_PREFIX_PATH"
+        export LD_LIBRARY_PATH="$OPENSSL_PATH/lib:$LD_LIBRARY_PATH"
+        export CPATH="$OPENSSL_PATH/include:$CPATH"
+        export PKG_CONFIG_PATH="$OPENSSL_PATH/lib/pkgconfig:$PKG_CONFIG_PATH"
+
+    elif command -v port; then
+        printf "Detected Macports"
+
+		if [ ! -d /opt/local/lib/cmake/Qt5 ]; then
+            printf "Please install qt5-qtbase port"
+        fi
+		export BARRIER_BUILD_MACPORTS=1
+		export CMAKE_PREFIX_PATH="/opt/local/lib/cmake/Qt5:$CMAKE_PREFIX_PATH"
+		export LD_LIBRARY_PATH="/opt/local/lib:$LD_LIBRARY_PATH"
+		export CPATH="/opt/local/include:$CPATH"
+        export PKG_CONFIG_PATH="/opt/local/libexec/qt5/lib/pkgconfig:$PKG_CONFIG_PATH"
+    else
+        printf "Neither Homebrew nor Macports is installed. Can't get dependency paths"
+        exit 1
+    fi
+
     export BARRIER_BUILD_ENV=1
 
     printf "done\n"

--- a/osx_environment.sh
+++ b/osx_environment.sh
@@ -4,28 +4,29 @@ if [ ! $BARRIER_BUILD_ENV ]; then
 
     printf "Modifying environment for Barrier build..."
 
-    if command -v brew; then
+    if command -v port; then
+        printf "Detected Macports"
+
+        if [ ! -d /opt/local/lib/cmake/Qt5 ]; then
+            printf "Please install qt5-qtbase port"
+        fi
+        export BARRIER_BUILD_MACPORTS=1
+        export CMAKE_PREFIX_PATH="/opt/local/lib/cmake/Qt5:$CMAKE_PREFIX_PATH"
+        export LD_LIBRARY_PATH="/opt/local/lib:$LD_LIBRARY_PATH"
+        export CPATH="/opt/local/include:$CPATH"
+        export PKG_CONFIG_PATH="/opt/local/libexec/qt5/lib/pkgconfig:$PKG_CONFIG_PATH"
+
+    elif command -v brew; then
         printf "Detected Homebrew"
         QT_PATH=$(brew --prefix qt)
         OPENSSL_PATH=$(brew --prefix openssl)
 
-		export BARRIER_BUILD_BREW=1
+        export BARRIER_BUILD_BREW=1
         export CMAKE_PREFIX_PATH="$QT_PATH:$CMAKE_PREFIX_PATH"
         export LD_LIBRARY_PATH="$OPENSSL_PATH/lib:$LD_LIBRARY_PATH"
         export CPATH="$OPENSSL_PATH/include:$CPATH"
         export PKG_CONFIG_PATH="$OPENSSL_PATH/lib/pkgconfig:$PKG_CONFIG_PATH"
 
-    elif command -v port; then
-        printf "Detected Macports"
-
-		if [ ! -d /opt/local/lib/cmake/Qt5 ]; then
-            printf "Please install qt5-qtbase port"
-        fi
-		export BARRIER_BUILD_MACPORTS=1
-		export CMAKE_PREFIX_PATH="/opt/local/lib/cmake/Qt5:$CMAKE_PREFIX_PATH"
-		export LD_LIBRARY_PATH="/opt/local/lib:$LD_LIBRARY_PATH"
-		export CPATH="/opt/local/include:$CPATH"
-        export PKG_CONFIG_PATH="/opt/local/libexec/qt5/lib/pkgconfig:$PKG_CONFIG_PATH"
     else
         printf "Neither Homebrew nor Macports is installed. Can't get dependency paths"
         exit 1


### PR DESCRIPTION
This PR adds support for building barrier on OSX Macports. Also, OSX travis configuration is added for building with both Homebrew and Macports.

