### PR TITLE
gui: Fix auto hide behavior

### DIFF
--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -88,15 +88,19 @@ int main(int argc, char* argv[])
 	}
 #endif
 
-	if (!waitForTray())
-	{
-		return -1;
-	}
+	int trayAvailable = waitForTray();
 
 	QApplication::setQuitOnLastWindowClosed(false);
 
 	QSettings settings;
 	AppConfig appConfig (&settings);
+
+	if (appConfig.getAutoHide() && !trayAvailable)
+	{
+		// force auto hide to false - otherwise there is no way to get the GUI back
+		fprintf(stdout, "System tray not available, force disabling auto hide!\n");
+		appConfig.setAutoHide(false);
+	}
 
 	app.switchTranslator(appConfig.language());
 
@@ -131,7 +135,7 @@ int waitForTray()
 		{
 			QMessageBox::critical(NULL, "Barrier",
 				QObject::tr("System tray is unavailable, don't close your window."));
-			return true;
+			return false;
 		}
 
 		QThreadImpl::msleep(TRAY_RETRY_WAIT);


### PR DESCRIPTION
 * make waitForTray() report a proper status - the return value was not
   used until now anyway (it would always return true)
 * depend on the system tray availability for auto hide

On my system (Fedora 29 with Pantheon Desktop), on a clean install the GUI
would auto hide itself on startup, but due to no system tray being
available I could never make the GUI appear again.

This change disallows auto hide if the system tray is not available.
Users who don't want the GUI can just start barriers/barrierc instead of
the main barrier executable, so this should not break existing workflows.