### PR TITLE
Update openssl key size in barrier.conf

### DIFF
--- a/res/openssl/barrier.conf
+++ b/res/openssl/barrier.conf
@@ -31,7 +31,7 @@ commonName = supplied
 emailAddress = optional
 
 [req]
-default_bits = 1024 # Size of keys
+default_bits = 2048 # Size of keys
 default_keyfile = key.pem # name of generated keys
 default_md = md5 # message digest algorithm
 string_mask = nombstr # permitted characters


### PR DESCRIPTION
Done in order to match the size specified in src/gui/src/SslCertificate.cpp

Also see Debian bug #907528 http://bugs.debian.org/907528

Related to Barrier Issue #126 