### PR TITLE
add pre-build script for building barrier on windows from SSH

### DIFF
--- a/pre-build.bat
+++ b/pre-build.bat
@@ -1,0 +1,1 @@
+%comspec% /k "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat"


### PR DESCRIPTION
I build barrier on windows from SSH, as such, I need a way to invoke the "Developer Command Prompt for VS 2017" without a GUI. This simple one-line batch script gets the job done. I thought it might be handy to upstream it.

process I use to build on windows:

```shell
$ ssh owner@10.0.0.209
owner@DESKTOP-C2IV8E5 C:\Users\Owner> cd Documents\GitHub\barrier\
owner@DESKTOP-C2IV8E5 C:\Users\Owner\Documents\GitHub\barrier> pre-build.bat
owner@DESKTOP-C2IV8E5 C:\Users\Owner\Documents\GitHub\barrier> clean_build.bat
```