### PR TITLE
Build full installer via clean_build.sh

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -388,6 +388,13 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set (BARRIER_BUNDLE_BINARY_DIR ${BARRIER_BUNDLE_APP_DIR}/Contents/MacOS)
 
     configure_files (${BARRIER_BUNDLE_SOURCE_DIR} ${BARRIER_BUNDLE_DIR})
+
+    if (CMAKE_BUILD_TYPE STREQUAL "Release")
+        add_custom_target(Barrier_dmg ALL
+                          bash build_installer.sh
+                          DEPENDS barrier barriers barrierc
+                          WORKING_DIRECTORY ${BARRIER_BUNDLE_DIR})
+    endif()
 endif()
 
 #

--- a/dist/macos/bundle/build_installer.sh.in
+++ b/dist/macos/bundle/build_installer.sh.in
@@ -41,7 +41,10 @@ cp @CMAKE_RUNTIME_OUTPUT_DIRECTORY@/* . || exit 1
 # TODO: this is hacky and will probably break if there is more than one qt
 # version installed. need a better way to find this library
 B_COCOA=$(find /usr/local/Cellar/qt -type f -name libqcocoa.dylib | head -1)
-if [ $? -ne 0 ] || [ "x$B_COCOA" = "x" ]; then
+if [ "x$B_COCOA" = "x" ]; then
+    B_COCOA=$(find /opt/local/libexec/qt5/plugins -type f -name libqcocoa.dylib | head -1)
+fi
+if [ "x$B_COCOA" = "x" ]; then
     echo "Could not find cocoa platform plugin"
     exit 1
 fi

--- a/osx_environment.sh
+++ b/osx_environment.sh
@@ -2,13 +2,13 @@
 
 if [ ! $BARRIER_BUILD_ENV ]; then
 
-    printf "Modifying environment for Barrier build..."
+    printf "Modifying environment for Barrier build...\n"
 
     if command -v port; then
-        printf "Detected Macports"
+        printf "Detected Macports\n"
 
         if [ ! -d /opt/local/lib/cmake/Qt5 ]; then
-            printf "Please install qt5-qtbase port"
+            printf "Please install qt5-qtbase port\n"
         fi
         export BARRIER_BUILD_MACPORTS=1
         export CMAKE_PREFIX_PATH="/opt/local/lib/cmake/Qt5:$CMAKE_PREFIX_PATH"
@@ -17,7 +17,7 @@ if [ ! $BARRIER_BUILD_ENV ]; then
         export PKG_CONFIG_PATH="/opt/local/libexec/qt5/lib/pkgconfig:$PKG_CONFIG_PATH"
 
     elif command -v brew; then
-        printf "Detected Homebrew"
+        printf "Detected Homebrew\n"
         QT_PATH=$(brew --prefix qt)
         OPENSSL_PATH=$(brew --prefix openssl)
 
@@ -28,7 +28,7 @@ if [ ! $BARRIER_BUILD_ENV ]; then
         export PKG_CONFIG_PATH="$OPENSSL_PATH/lib/pkgconfig:$PKG_CONFIG_PATH"
 
     else
-        printf "Neither Homebrew nor Macports is installed. Can't get dependency paths"
+        printf "Neither Homebrew nor Macports is installed. Can't get dependency paths\n"
         exit 1
     fi
 


### PR DESCRIPTION
Currently doing `env B_BUILD_TYPE=Release ./clean_build.sh` won't build full installer on OSX as build_installer.sh script won't be run. This PR reduces the possible confusion by including the installer into the regular build process handled by cmake. Tested the resulting dmg on all of OSX 10.12, 10.13 and 10.14.