### PR TITLE
Added preserveFocus fix

### DIFF
--- a/src/gui/src/BaseConfig.cpp
+++ b/src/gui/src/BaseConfig.cpp
@@ -33,7 +33,8 @@ const char* BaseConfig::m_FixNames[] =
     "halfDuplexCapsLock",
     "halfDuplexNumLock",
     "halfDuplexScrollLock",
-    "xtestIsXineramaUnaware"
+    "xtestIsXineramaUnaware",
+    "preserveFocus"
 };
 
 const char* BaseConfig::m_SwitchCornerNames[] =

--- a/src/gui/src/BaseConfig.h
+++ b/src/gui/src/BaseConfig.h
@@ -29,7 +29,7 @@ class BaseConfig
     public:
         enum Modifier { DefaultMod = -1, Shift, Ctrl, Alt, Meta, Super, None, NumModifiers };
         enum SwitchCorner { TopLeft, TopRight, BottomLeft, BottomRight, NumSwitchCorners };
-        enum Fix { CapsLock, NumLock, ScrollLock, XTest, NumFixes };
+        enum Fix { CapsLock, NumLock, ScrollLock, XTest, PreserveFocus, NumFixes };
 
     protected:
         BaseConfig() {}

--- a/src/gui/src/ScreenSettingsDialog.cpp
+++ b/src/gui/src/ScreenSettingsDialog.cpp
@@ -68,6 +68,7 @@ ScreenSettingsDialog::ScreenSettingsDialog(QWidget* parent, Screen* pScreen) :
     m_pCheckBoxNumLock->setChecked(m_pScreen->fix(Screen::NumLock));
     m_pCheckBoxScrollLock->setChecked(m_pScreen->fix(Screen::ScrollLock));
     m_pCheckBoxXTest->setChecked(m_pScreen->fix(Screen::XTest));
+    m_pCheckBoxPreserveFocus->setChecked(m_pScreen->fix(Screen::PreserveFocus));
 }
 
 void ScreenSettingsDialog::accept()
@@ -115,6 +116,7 @@ void ScreenSettingsDialog::accept()
     m_pScreen->setFix(Screen::NumLock, m_pCheckBoxNumLock->isChecked());
     m_pScreen->setFix(Screen::ScrollLock, m_pCheckBoxScrollLock->isChecked());
     m_pScreen->setFix(Screen::XTest, m_pCheckBoxXTest->isChecked());
+    m_pScreen->setFix(Screen::PreserveFocus, m_pCheckBoxPreserveFocus->isChecked());
 
     QDialog::accept();
 }

--- a/src/gui/src/ScreenSettingsDialogBase.ui
+++ b/src/gui/src/ScreenSettingsDialogBase.ui
@@ -462,7 +462,17 @@
           </property>
          </widget>
         </item>
-        <item row="4" column="0">
+	<item row="4" column="0">
+         <widget class="QCheckBox" name="m_pCheckBoxPreserveFocus">
+          <property name="text">
+           <string>Fix Preserve Focus</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="0">
          <spacer>
           <property name="orientation">
            <enum>Qt::Vertical</enum>


### PR DESCRIPTION
Adds the [preserveFocus configuration](https://github.com/symless/synergy-core/wiki/Text-Config#Focus_Preservation) item to the GUI configuration screen. 

This is useful if you want to control a system that you are not the only user of. For example, I use barrier to control my HTPC computer sometimes, but I don't want Kodi to lose focus when my cursor leaves the screen since it will cause other inputs (i.e. CEC Remote) to stop working. 