### PR TITLE
add debug notes to help identify where trusted fingerprints file is

### DIFF
--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -723,7 +723,7 @@ SecureSocket::verifyCertFingerprint()
         getline(file,fileLine);
         if (!fileLine.empty()) {
             if (fileLine.compare(fingerprint) == 0) {
-                LOG((CLOG_NOTE "Fingerprint matchs trusted fingerprint"));
+                LOG((CLOG_NOTE "Fingerprint matches trusted fingerprint"));
                 isValid = true;
                 break;
             } else {

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -712,10 +712,10 @@ SecureSocket::verifyCertFingerprint()
     std::ifstream file;
     file.open(trustedServersFilename.c_str());
 
-    if ( ! file.is_open() ) {
-      LOG((CLOG_NOTE "Unable to open trustedServersFile: %s", trustedServersFilename.c_str() ));
+    if (!file.is_open()) {
+        LOG((CLOG_NOTE "Unable to open trustedServersFile: %s", trustedServersFilename.c_str() ));
     } else {
-      LOG((CLOG_NOTE "Opened trustedServersFilename: %s", trustedServersFilename.c_str() ));
+        LOG((CLOG_NOTE "Opened trustedServersFilename: %s", trustedServersFilename.c_str() ));
     }
 
     bool isValid = false;

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -704,18 +704,30 @@ SecureSocket::verifyCertFingerprint()
         kFingerprintDirName,
         kFingerprintTrustedServersFilename);
 
+    // Provide debug hint as to what file is being used to verify fingerprint trust
+    LOG((CLOG_NOTE "trustedServersFilename: %s", trustedServersFilename.c_str() ));
+
     // check if this fingerprint exist
     String fileLine;
     std::ifstream file;
     file.open(trustedServersFilename.c_str());
+
+    if ( ! file.is_open() ) {
+      LOG((CLOG_NOTE "Unable to open trustedServersFile: %s", trustedServersFilename.c_str() ));
+    } else {
+      LOG((CLOG_NOTE "Opened trustedServersFilename: %s", trustedServersFilename.c_str() ));
+    }
 
     bool isValid = false;
     while (!file.eof() && file.is_open()) {
         getline(file,fileLine);
         if (!fileLine.empty()) {
             if (fileLine.compare(fingerprint) == 0) {
+                LOG((CLOG_NOTE "Fingerprint matchs trusted fingerprint"));
                 isValid = true;
                 break;
+            } else {
+                LOG((CLOG_NOTE "Fingerprint does not match trusted fingerprint"));
             }
         }
     }


### PR DESCRIPTION


Debugging on a client where the TrustedServers fingerprint is being loaded from can be confusing.  It appears different systems store it in different locations, and this location can change a bit over time.

Currently if you don't correctly identify the right file to populate, or populate it with the wrong fingerprint you aren't given any hints.  Just a message `failed to verify server certificate fingerprint`. 

This PR adds a few additional debug notes to help folks identify the specific file being loaded for use in checking server fingerprint trust and should improve self-debugging by users.

With the additional messages a user can:
* identify what file `barrierc` is trying to open to look for trustedServers
* see if that file was successfully opened
* get notification if there was a mismatch between contents of file and the server fingerprint

The result looks like so:

```
[2018-12-19T20:35:49] NOTE: connecting to 'gilbert.lan': 192.168.86.148:24800
[2018-12-19T20:35:49] NOTE: server fingerprint: 53:66:BF:37:CF:ED:60:43:3C:84:86:57:2C:E3:2E:20:68:A0:0C:35
[2018-12-19T20:35:49] NOTE: trustedServersFilename: /home/pi/.local/share/barrier/SSL/Fingerprints/TrustedServers.txt
[2018-12-19T20:35:49] NOTE: Opened trustedServersFilename: /home/pi/.local/share/barrier/SSL/Fingerprints/TrustedServers.txt
[2018-12-19T20:35:49] NOTE: Fingerprint matches trusted fingerprint
[2018-12-19T20:35:49] NOTE: connected to server
```