### PR TITLE
add checks to osx_environment.sh

### DIFF
--- a/osx_environment.sh
+++ b/osx_environment.sh
@@ -1,15 +1,26 @@
 #!/bin/bash
 
+# Checks if directory exists, otherwise asks to install package.
+function check_dir_exists() {
+    local path=$1
+    local package=$2
+
+    if [ ! -d "$path" ]; then
+        echo "Please install $package"
+        exit 1
+    fi
+}
+
 if [ ! $BARRIER_BUILD_ENV ]; then
+    check_dir_exists '/Applications/Xcode.app' 'Xcode'
 
     printf "Modifying environment for Barrier build...\n"
 
     if command -v port; then
         printf "Detected Macports\n"
 
-        if [ ! -d /opt/local/lib/cmake/Qt5 ]; then
-            printf "Please install qt5-qtbase port\n"
-        fi
+        check_dir_exists '/opt/local/lib/cmake/Qt5' 'qt5-qtbase port'
+
         export BARRIER_BUILD_MACPORTS=1
         export CMAKE_PREFIX_PATH="/opt/local/lib/cmake/Qt5:$CMAKE_PREFIX_PATH"
         export LD_LIBRARY_PATH="/opt/local/lib:$LD_LIBRARY_PATH"
@@ -20,6 +31,9 @@ if [ ! $BARRIER_BUILD_ENV ]; then
         printf "Detected Homebrew\n"
         QT_PATH=$(brew --prefix qt)
         OPENSSL_PATH=$(brew --prefix openssl)
+
+        check_dir_exists "$QT_PATH" 'qt'
+        check_dir_exists "$OPENSSL_PATH" 'openssl'
 
         export BARRIER_BUILD_BREW=1
         export CMAKE_PREFIX_PATH="$QT_PATH:$CMAKE_PREFIX_PATH"


### PR DESCRIPTION
Check if Xcode and required packages are installed, otherwise fail early.

I was confused on some missing qt dependency, and turned out that it needed full Xcode to be installed to be able to build qt. Hopefully this saves somebody else some head scratching.