### PR TITLE
Run Without System Tray Support

### DIFF
--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define TRAY_RETRY_COUNT 10
+#define TRAY_RETRY_COUNT 5
 #define TRAY_RETRY_WAIT 2000
 
 #include "QBarrierApplication.h"

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -138,8 +138,7 @@ int waitForTray()
 
 		if (++trayAttempts > TRAY_RETRY_COUNT)
 		{
-			QMessageBox::critical(NULL, "Barrier",
-				QObject::tr("System tray is unavailable, don't close your window."));
+			fprintf(stdout, "System tray is unavailable.\n");
 			return false;
 		}
 


### PR DESCRIPTION
When the system tray feature is not present, quietly continue to operate.  As this is no longer considered a critical feature we spend less time waiting for it to become available.  We know it will not be available on a number of GNU Linux desktop setups going forward.

This is a response to #155 and maybe sufficient to conclude the required work there.