### PR TITLE
X: Only consider mouse movement on the X screen we were started on

### DIFF
--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -1548,6 +1548,11 @@ XWindowsScreen::onMouseMove(const XMotionEvent& xmotion)
 {
 	LOG((CLOG_DEBUG2 "event: MotionNotify %d,%d", xmotion.x_root, xmotion.y_root));
 
+
+	// only consider motion on the same X screen as we were started on
+	if (!xmotion.same_screen)
+		return;
+
 	// compute motion delta (relative to the last known
 	// mouse position)
 	SInt32 x = xmotion.x_root - m_xCursor;


### PR DESCRIPTION
X windows supports running multple X screens per instance of X (ie
:0.0, :0.1, etc)  Each of these X screens has its own mouse coordinate
space from 0,0 to resX,resY.  This causes issues because barrier isn't
taking into account what X screen its on when determining if it needs to
move to a remote client.  Thus just moving your mouse between your X
screens can trigger a jump to a remote client.

This patch makes it so barrier will only consider mouse movements on the
X screen it was started on.