### PR TITLE
Add .appveyor.yml File With Ubuntu & Windows Builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -44,6 +44,7 @@ install:
 
 # Use build_script for our own build script
 build_script:
+  - cmd: ./clean_build.bat
   - sh: ./clean_build.sh
 
 ##### Test Phase #####

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,53 @@
+# An AppVeyor build configuration file for the Barrier project
+
+
+##### General Configuiration #####
+version: '0.0.{build}'
+
+environment:
+  # these variables are common to all jobs
+#  common_var1: value1
+#  common_var2: value2
+
+image:
+  - Ubuntu
+
+platform:
+  - x86
+#  - Any CPU
+
+configuration:
+  - Debug
+#  - Release
+
+##### Setup Phase #####
+
+install:
+  - echo The Install has started...
+  - sh: echo ... for Linux
+  - cmd: echo ... for Windows
+  - sh sudo apt-get update && sudo apt-get install \
+      libxtst-dev
+      qtdeclarative5-dev
+      libavahi-compat-libdnssd-dev
+
+##### Build Phase #####
+
+# Use build_script for our Linux builds and build for .NET
+build_script:
+  - sh: ./clean_build.sh
+
+##### Test Phase #####
+
+# Use test_script for our Linux tests and test for .NET
+
+##### Deploy Phase #####
+
+##### Catching & Cleanup #####
+
+# Success
+
+# Failure
+
+# Finish
+

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,10 +26,10 @@ install:
   - echo The Install has started...
   - sh: echo ... for Linux
   - cmd: echo ... for Windows
-  - sh: sudo apt-get update && sudo apt-get install \
-      libxtst-dev
-      qtdeclarative5-dev
-      libavahi-compat-libdnssd-dev
+  - sh: sudo apt-get update && sudo apt-get install
+        git cmake make xorg-dev g++ libcurl4-openssl-dev \
+        libavahi-compat-libdnssd-dev libssl-dev libx11-dev \
+        libqt4-dev qtbase5-dev
 
 ##### Build Phase #####
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,7 +26,7 @@ install:
   - echo The Install has started...
   - sh: echo ... for Linux
   - cmd: echo ... for Windows
-  - sh sudo apt-get update && sudo apt-get install \
+  - sh: sudo apt-get update && sudo apt-get install \
       libxtst-dev
       qtdeclarative5-dev
       libavahi-compat-libdnssd-dev

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,6 +10,7 @@ version: '0.0.{build}'
 #  common_var2: value2
 
 image:
+  - Visual Studio 2015
   - Ubuntu
 
 platform:
@@ -41,12 +42,9 @@ install:
 
 ##### Build Phase #####
 
-# Use build_script for our Linux builds and build for .NET
+# Use build_script for our own build script
 build_script:
   - sh: ./clean_build.sh
-
-build:
-  - cmd: ./clean_build.bat
 
 ##### Test Phase #####
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,9 +27,17 @@ install:
   - sh: echo ... for Linux
   - cmd: echo ... for Windows
   - sh: sudo apt-get update && sudo apt-get install
-        git cmake make xorg-dev g++ libcurl4-openssl-dev \
-        libavahi-compat-libdnssd-dev libssl-dev libx11-dev \
-        libqt4-dev qtbase5-dev
+        cmake
+        g++
+        git
+        libavahi-compat-libdnssd-dev
+        libcurl4-openssl-dev
+        libqt4-dev
+        libssl-dev
+        libx11-dev
+        make
+        qtbase5-dev
+        xorg-dev
 
 ##### Build Phase #####
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,7 +26,7 @@ install:
   - echo The Install has started...
   - sh: echo ... for Linux
   - cmd: echo ... for Windows
-  - sh: sudo apt-get update && sudo apt-get install
+  - sh: sudo apt-get -y update && sudo apt-get -y install
         cmake
         g++
         git

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,7 @@
 
 
 ##### General Configuiration #####
-version: '0.0.{build}'
+version: '0.0.{APPVEYOR_REPO_COMMIT}.{build}'
 
 #environment:
   # these variables are common to all jobs

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,7 @@
 
 
 ##### General Configuiration #####
-version: '0.0.{APPVEYOR_REPO_COMMIT}.{build}'
+version: '0.0.0.{APPVEYOR_REPO_COMMIT}.{build}'
 
 #environment:
   # these variables are common to all jobs

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,7 +4,7 @@
 ##### General Configuiration #####
 version: '0.0.{build}'
 
-environment:
+#environment:
   # these variables are common to all jobs
 #  common_var1: value1
 #  common_var2: value2

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -45,6 +45,9 @@ install:
 build_script:
   - sh: ./clean_build.sh
 
+build:
+  - cmd: ./clean_build.bat
+
 ##### Test Phase #####
 
 # Use test_script for our Linux tests and test for .NET

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,7 @@ version: '0.0.{build}'
 #  common_var2: value2
 
 image:
-  - Visual Studio 2015
+  - Visual Studio 2017
   - Ubuntu
 
 platform:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,8 +25,8 @@ configuration:
 
 install:
   - echo The Install has started...
+  # The Linux setup stages
   - sh: echo ... for Linux
-  - cmd: echo ... for Windows
   - sh: sudo apt-get -y update && sudo apt-get -y install
         cmake
         g++
@@ -39,6 +39,12 @@ install:
         make
         qtbase5-dev
         xorg-dev
+  # The Windows setup stages
+  - cmd: echo ... for Windows
+#  - ps: (new-object net.webclient).DownloadFile('https://mysite.com/mypackage.msi', 'mypackage.msi')
+#  - ps: msiexec /i mypackage.msi /quiet /qn /norestart /log install.log PROPERTY1=value1 PROPERTY2=value2
+  # End of Install
+  - echo The Install has finished.
 
 ##### Build Phase #####
 

--- a/clean_build.bat
+++ b/clean_build.bat
@@ -3,7 +3,7 @@
 REM defaults - override them by creating a build_env.bat file
 set B_BUILD_TYPE=Debug
 set B_QT_ROOT=C:\Qt
-set B_QT_VER=5.11.1
+set B_QT_VER=5.11.2
 set B_QT_MSVC=msvc2017_64
 set B_BONJOUR=C:\Program Files\Bonjour SDK
 


### PR DESCRIPTION
I had no idea where the AppVeyor CI was getting its settings from before.  I guess it is configured server side?  If that is the case it makes the process very hard to replicate elsewhere. 

This PR adds a .appveyor.yml file that the AppVeyor CI automatically picks up and attempts to use.  Presently this builds only for Windows using Visual Studio 2017 and for Ubuntu 18.04.  The bones of a matric build are there to allow expansion into Release builds, tests and other target platforms. 

At present, the Ubuntu build seems to work OK and the Windows build reports a pass but actually has errors in it.  Perhaps @p12tic could offer some advice on how to fix this as in #66 he may already have got AppVeyor working.  Getting it to report a failed build would be my first task, then seeing how to add the Bonjour SDK without having to automate a sign in to Apple servers and agreements.