### PR TITLE
Fire screen switch event on client disconnect

### DIFF
--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -2262,6 +2262,10 @@ Server::forceLeaveClient(BaseClientProxy* client)
 			m_primaryClient->enter(m_x, m_y, m_seqNum,
 								m_primaryClient->getToggleMask(), false);
 		}
+
+		Server::SwitchToScreenInfo* info =
+			Server::SwitchToScreenInfo::alloc(m_active->getName());
+		m_events->addEvent(Event(m_events->forServer().screenSwitched(), this, info));
 	}
 
 	// if this screen had the cursor when the screen saver activated


### PR DESCRIPTION
I missed this with the last PR, screen switch event was not firing when the client disconnected.