### PR TITLE
Update Windows build script for VS2019

### DIFF
--- a/clean_build.bat
+++ b/clean_build.bat
@@ -12,7 +12,7 @@ cd /d %~dp0
 
 REM cmake generator name for the target build system
 if "%VisualStudioVersion%"=="15.0" (
-    set cmake_gen=Visual Studio 15 2017 Win64
+    set cmake_gen=Visual Studio 15 2017
 ) else if "%VisualStudioVersion%"=="16.0" (
     set cmake_gen=Visual Studio 16 2019
 ) else (
@@ -37,7 +37,7 @@ rmdir /q /s build
 mkdir build
 if ERRORLEVEL 1 goto failed
 cd build
-cmake -G "%cmake_gen%" -D CMAKE_BUILD_TYPE=%B_BUILD_TYPE% -D CMAKE_PREFIX_PATH="%B_QT_FULLPATH%" -D DNSSD_LIB="%B_BONJOUR%\Lib\x64\dnssd.lib" -D QT_VERSION=%B_QT_VER% ..
+cmake -G "%cmake_gen%" -A x64 -D CMAKE_BUILD_TYPE=%B_BUILD_TYPE% -D CMAKE_PREFIX_PATH="%B_QT_FULLPATH%" -D DNSSD_LIB="%B_BONJOUR%\Lib\x64\dnssd.lib" -D QT_VERSION=%B_QT_VER% ..
 if ERRORLEVEL 1 goto failed
 echo @msbuild barrier.sln /p:Platform="x64" /p:Configuration=%B_BUILD_TYPE% /m %B_BUILD_OPTIONS% > make.bat
 call make.bat

--- a/clean_build.bat
+++ b/clean_build.bat
@@ -10,6 +10,18 @@ set B_BONJOUR=C:\Program Files\Bonjour SDK
 set savedir=%cd%
 cd /d %~dp0
 
+REM cmake generator name for the target build system
+if "%VisualStudioVersion%"=="15.0" (
+    set cmake_gen=Visual Studio 15 2017 Win64
+) else if "%VisualStudioVersion%"=="16.0" (
+    set cmake_gen=Visual Studio 16 2019
+) else (
+    echo Visual Studio version was not detected.
+    echo Did you forget to run inside a VS developer prompt?
+    echo Using the default cmake generator.
+    set cmake_gen=Visual Studio 16 2019
+)
+
 if exist build_env.bat call build_env.bat
 
 REM needed by cmake to set bonjour include dir
@@ -17,9 +29,6 @@ set BONJOUR_SDK_HOME=%B_BONJOUR%
 
 REM full path to Qt stuff we need
 set B_QT_FULLPATH=%B_QT_ROOT%\%B_QT_VER%\%B_QT_MSVC%
-
-REM cmake generator name for the target build system
-set cmake_gen=Visual Studio 16 2019
 
 echo Bonjour: %BONJOUR_SDK_HOME%
 echo Qt: %B_QT_FULLPATH%

--- a/clean_build.bat
+++ b/clean_build.bat
@@ -18,6 +18,9 @@ set BONJOUR_SDK_HOME=%B_BONJOUR%
 REM full path to Qt stuff we need
 set B_QT_FULLPATH=%B_QT_ROOT%\%B_QT_VER%\%B_QT_MSVC%
 
+REM cmake generator name for the target build system
+set cmake_gen=Visual Studio 16 2019
+
 echo Bonjour: %BONJOUR_SDK_HOME%
 echo Qt: %B_QT_FULLPATH%
 
@@ -25,7 +28,7 @@ rmdir /q /s build
 mkdir build
 if ERRORLEVEL 1 goto failed
 cd build
-cmake -G "Visual Studio 15 2017 Win64" -D CMAKE_BUILD_TYPE=%B_BUILD_TYPE% -D CMAKE_PREFIX_PATH="%B_QT_FULLPATH%" -D DNSSD_LIB="%B_BONJOUR%\Lib\x64\dnssd.lib" -D QT_VERSION=%B_QT_VER% ..
+cmake -G "%cmake_gen%" -D CMAKE_BUILD_TYPE=%B_BUILD_TYPE% -D CMAKE_PREFIX_PATH="%B_QT_FULLPATH%" -D DNSSD_LIB="%B_BONJOUR%\Lib\x64\dnssd.lib" -D QT_VERSION=%B_QT_VER% ..
 if ERRORLEVEL 1 goto failed
 echo @msbuild barrier.sln /p:Platform="x64" /p:Configuration=%B_BUILD_TYPE% /m %B_BUILD_OPTIONS% > make.bat
 call make.bat
@@ -69,3 +72,4 @@ set B_BONJOUR=
 set BONJOUR_SDK_HOME=
 set B_QT_FULLPATH=
 set savedir=
+set cmake_gen=


### PR DESCRIPTION
I updated clean_build.bat with the cmake generator argument for Visual Studio 2019. VS2019 is what Microsoft is pushing now and what people will download if you tell them to download Visual Studio.

I also took the opportunity to move the generator string into its own variable.