### PR TITLE
Windows installer fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -403,6 +403,7 @@ endif()
 # Windows installer
 #
 if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+        set (BARRIER_WIX_VERSION "${BARRIER_VERSION_MAJOR}.${BARRIER_VERSION_MINOR}.${BARRIER_VERSION_PATCH}")
         message (STATUS "Configuring the wix installer")
         configure_files (${CMAKE_CURRENT_SOURCE_DIR}/dist/wix ${CMAKE_BINARY_DIR}/installer-wix)
         message (STATUS "Configuring the inno installer")

--- a/build_installer.bat
+++ b/build_installer.bat
@@ -6,7 +6,7 @@ cd /d %~dp0
 
 if not exist build\bin\Release goto buildproject
 
-cd build\installer
+cd build\installer-wix
 if ERRORLEVEL 1 goto buildproject
 
 echo Building 64-bit Windows installer...
@@ -19,7 +19,7 @@ goto done
 
 :buildproject
 echo To build a 64-bit Windows installer:
-echo  - set Q_BUILD_TYPE=Release in build_env.bat
+echo  - set B_BUILD_TYPE=Release in build_env.bat
 echo  - also set other environmental overrides necessary for your build environment
 echo  - run clean_build.bat to build Barrier and verify that it succeeds
 echo  - re-run this script to create the installation package

--- a/build_installer.bat
+++ b/build_installer.bat
@@ -1,19 +1,18 @@
 @echo off
-set WIX_ROOT=C:\Program Files (x86)\WiX Toolset v3.11
+set INNO_ROOT=C:\Program Files (x86)\Inno Setup 5
 
 set savedir=%cd%
 cd /d %~dp0
 
 if not exist build\bin\Release goto buildproject
 
-cd build\installer-wix
-if ERRORLEVEL 1 goto buildproject
-
 echo Building 64-bit Windows installer...
-"%WIX_ROOT%\bin\candle.exe" -nologo -arch x64 -dConfiguration=Release -dPlatform=x64 -ext WixUtilExtension -ext WixFirewallExtension Product.wxs -o Barrier.wixobj
+
+cd build\installer-inno
+if ERRORLEVEL 1 goto buildproject
+"%INNO_ROOT%\ISCC.exe" /Qp barrier.iss
 if ERRORLEVEL 1 goto failed
-"%WIX_ROOT%\bin\light.exe" -nologo -ext WixUtilExtension -ext WixFirewallExtension -ext WixUIExtension Barrier.wixobj -o bin\Barrier.msi
-if ERRORLEVEL 1 goto failed
+
 echo Build completed successfully
 goto done
 
@@ -29,7 +28,7 @@ goto done
 echo Build failed
 
 :done
-set WIX_ROOT=
+set INNO_ROOT=
 
 cd /d %savedir%
 set savedir=

--- a/dist/wix/Include.wxi.in
+++ b/dist/wix/Include.wxi.in
@@ -11,12 +11,12 @@
         <?define ProgramFilesFolder="ProgramFiles64Folder" ?>
         <?define PlatformSimpleName="64-bit" ?>
         <?define UpgradeGuid="E8A4FA54-14B9-4FD1-8E00-7BC46555FDA0" ?>
-        <?define QtPath="E:\Qt\$(var.QtVersion)\msvc2015_64" ?>
+        <?define QtPath="@CMAKE_PREFIX_PATH@" ?>
     <?else ?>
         <?define ProgramFilesFolder="ProgramFilesFolder" ?>
         <?define PlatformSimpleName="32-bit" ?>
         <?define UpgradeGuid="BE0B9FD8-45E2-4A8E-A0D8-1F774D074A78" ?>
-        <?define QtPath="E:\Qt\$(var.QtVersion)\msvc2015" ?>
+        <?define QtPath="@CMAKE_PREFIX_PATH@" ?>
     <?endif ?>
     <?define QtBinPath="$(var.QtPath)\bin" ?>
     <?define QtPlatformPath="$(var.QtPath)\plugins\platforms" ?>

--- a/dist/wix/Include.wxi.in
+++ b/dist/wix/Include.wxi.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Include>
     <?define Name="Barrier" ?>
-    <?define Version="@BARRIER_VERSION@" ?>
+    <?define Version="@BARRIER_WIX_VERSION@" ?>
     <?define QtVersion="@QT_VERSION@" ?>
     <?define Author="Debauchee Open Source Group" ?>
     <?define BinPath="@CMAKE_RUNTIME_OUTPUT_DIRECTORY@/$(var.Configuration)" ?>

--- a/dist/wix/Product.wxs
+++ b/dist/wix/Product.wxs
@@ -31,7 +31,6 @@
 		<Property Id="ARPPRODUCTICON" Value="barrier.ico"/>
 		<Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER"/>
 		<Property Id="MSIRESTARTMANAGERCONTROL" Value="Disable"/>
-    </Condition>
 		<CustomAction ExeCommand="" FileKey="GuiProgram" Id="StartGui" Return="asyncNoWait"/>
 		<UI>
 			<Publish Control="Finish" Dialog="ExitDialog" Event="DoAction" Value="StartGui">NOT Installed</Publish>


### PR DESCRIPTION
Fix for #286. build_installer.bat now works. Steps for building the installer:

1. Install Wix Toolset 3.11
2. Create a Release build with clean_build.bat
3. Run build_installer.bat

You should then have an MSI installer in build/installer-wix/bin/. It does not detect or uninstall the 2.1.0 release. It needs to be tested for other issues.