### PR TITLE
Fix #278 "Enable Clipboard Sharing" always reset after restart

### DIFF
--- a/src/gui/src/ServerConfig.cpp
+++ b/src/gui/src/ServerConfig.cpp
@@ -117,6 +117,7 @@ void ServerConfig::saveSettings()
     settings().setValue("switchCornerSize", switchCornerSize());
     settings().setValue("ignoreAutoConfigClient", ignoreAutoConfigClient());
     settings().setValue("enableDragAndDrop", enableDragAndDrop());
+    settings().setValue("clipboardSharing", clipboardSharing());
 
     writeSettings(settings(), switchCorners(), "switchCorner");
 
@@ -161,6 +162,7 @@ void ServerConfig::loadSettings()
     setSwitchCornerSize(settings().value("switchCornerSize").toInt());
     setIgnoreAutoConfigClient(settings().value("ignoreAutoConfigClient").toBool());
     setEnableDragAndDrop(settings().value("enableDragAndDrop", true).toBool());
+    setClipboardSharing(settings().value("clipboardSharing", true).toBool());
 
     readSettings(settings(), switchCorners(), "switchCorner", false, NumSwitchCorners);
 


### PR DESCRIPTION
Unlike other settings, the "Enable Clipboard Sharing" setting of the
ServerConfigDialog does not persist when the barrier application (GUI)
is stopped completely and restarted. Add the necessary code to the
saveSettings() and loadSettings() functions.