### PR TITLE
Upgrade QLI Installer and use Cal's Qt Mirror for more stable Windows builds

### DIFF
--- a/azure-pipelines/download_install_qt.ps1
+++ b/azure-pipelines/download_install_qt.ps1
@@ -1,6 +1,6 @@
 $ErrorActionPreference = "Stop"
 
-$qli_install_version = '2019.05.12.4'
+$qli_install_version = '2019.05.26.1'
 $qt_version = '5.12.3'
 
 New-Item -Force -ItemType Directory -Path ".\deps\"
@@ -21,5 +21,6 @@ Write-Output 'Installed QLI Installer Dependencies'
 
 Write-Output 'Starting QT Installer'
 $Env:QLI_OUT_DIR = ".\deps\Qt\Qt$qt_version"
+$Env:QLI_BASE_URL = "http://mirrors.ocf.berkeley.edu/qt/online/qtsdkrepository/"
 python .\deps\qli-installer\qli-installer.py $qt_version windows desktop win64_msvc2017_64
 Write-Output 'Installed QT Installer'


### PR DESCRIPTION
The default Qt Mirror has been having strange connectivity issues and timeouts.  This is causing timeouts and brownouts of Windows builds.

As an alternative, perhaps we should try using a mirror of the Qt repository instead of just Qt's. I've added support to use alternate mirrors to my fork of QLI Installer. ([I've opened an issue on that nicer fork to add this feature as well](https://github.com/miurahr/aqtinstall/issues/24))

From a [mirror list](https://download.qt.io/static/mirrorlist/), I've picked UC Berkeley's mirror as an alternative since I believe it to be the biggest and most stable alternative mirror to the other commercial or enthusiast mirrors in North America. It's almost government. 