### PR TITLE
Fixed quote key on US International keyboard

### DIFF
--- a/src/lib/barrier/KeyMap.cpp
+++ b/src/lib/barrier/KeyMap.cpp
@@ -1104,6 +1104,7 @@ KeyMap::getDeadKey(KeyID key)
     case '`':
         return kKeyDeadGrave;
 
+    case '\'':
     case 0xb4u:
         return kKeyDeadAcute;
 


### PR DESCRIPTION
Fixes single quote key on US international keyboard, backported from symless/synergy-core#6448