### PR TITLE
Fix snapcraft yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,14 +13,19 @@ confinement: strict # use 'strict' once you have the right plugs and slots
 apps:
   barrier-kvm:
     command: desktop-launch barrier #first run might take longer
-    plugs:
-      gnome-3-26-1604:
-        interface: content
-        target: gnome-platform
-        default-provider: gnome-3-26-1604:gnome-3-26-1604
-    plugs: [gnome-3-26-1604]
-    plugs: [x11]
-parts: [qt5conf]
+    plugs: &plugs
+      - desktop
+      - desktop-legacy
+      - home
+      - joystick
+      - network
+      - opengl
+      - pulseaudio
+      - screen-inhibit-control
+      - unity7
+      - wayland
+      - x11
+
 parts:
   desktop:
     plugin: nil

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -2,11 +2,7 @@ name: barrier-kvm # the Barrier Snappy for Linux / not tested on MAC yet
 base: core18 
 version: master
 version-script: git -C parts/barrier/src/ describe --tags --long | sed "s/^v//"
-summary: Eliminate the barrier between your machines.
-description: |
-       Barrier is KVM software forked from Symless's synergy 1.9 codebase. 
-       Synergy was a commercialized reimplementation of the original 
-       CosmoSynergy written by Chris Schoeneman.
+adopt-info: appstream-flathub
 grade: stable # must be 'stable' to release into candidate/stable channels
 confinement: strict # use 'strict' once you have the right plugs and slots
 icon: res/barrier.svg
@@ -16,6 +12,7 @@ apps:
   barrier:
     command: desktop-launch barrier #first run might take longer
     desktop: usr/share/applications/barrier.desktop
+    common-id: com.github.debauchee.barrier
     plugs: &plugs
       - desktop
       - desktop-legacy
@@ -79,3 +76,8 @@ parts:
     override-build:
       sed -i 's|Icon=barrier|Icon=/usr/share/icons/hicolor/scalable/apps/barrier.svg|' $SNAPCRAFT_STAGE/usr/share/applications/barrier.desktop
     after: [barrier]
+
+  appstream-flathub:
+    plugin: dump
+    source: https://github.com/flathub/com.github.debauchee.barrier.git
+    parse-info: [com.github.debauchee.barrier.appdata.xml]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,6 +9,8 @@ description: |
        CosmoSynergy written by Chris Schoeneman.
 grade: stable # must be 'stable' to release into candidate/stable channels
 confinement: strict # use 'strict' once you have the right plugs and slots
+icon: res/barrier.svg
+license: GPL-2.0
 
 apps:
   barrier:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,32 +42,29 @@ parts:
     source: .
     plugin: cmake
     build-packages:
-      - g++
-      - gcc
-      - make
       - xorg-dev 
       - libcurl4-openssl-dev
       - libavahi-compat-libdnssd-dev
       - libssl-dev
       - libx11-dev
-      - libqt4-dev
       - qtbase5-dev
       - qt5-style-plugins
-      - qt5ct
-    stage-packages:
       - libxinerama-dev
-      - libxinerama1
       - libxrandr-dev
-      - libxrandr2
       - libxrender-dev
-      - libxrender1
       - libxtst-dev
       - qtdeclarative5-dev
-      - libavahi-compat-libdnssd-dev
-      - libqt5gui5
       - libavahi-common-dev
+      - libqt5svg5-dev
+    stage-packages:
+      - libxinerama1
+      - libxrandr2
+      - libxrender1
+      - libqt5gui5
       - libqt5x11extras5
       - libqt5svg5
-      - libqt5svg5-dev
-      - qt5ct
+      - libxtst6
+      - libavahi-client3
+      - libavahi-common3
+      - libavahi-compat-libdnssd1
     after: [desktop-qt5]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,56 +33,13 @@ apps:
     plugs: *plugs
 
 parts:
-  desktop:
-    plugin: nil
-    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
   desktop-qt5:
     source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
     source-subdir: qt
     plugin: make
-    make-parameters: ["FLAVOR=qt5"]
-    build-packages:
-      - build-essential
-      - qtbase5-dev
-      - dpkg-dev
-    stage-packages:
-      - libxkbcommon0
-      - ttf-ubuntu-font-family
-      - dmz-cursor-theme
-      - light-themes
-      - adwaita-icon-theme
-      - gnome-themes-standard
-      - shared-mime-info
-      - libqt5gui5
-      - libgdk-pixbuf2.0-0
-      - libqt5svg5 # for loading icon themes which are svg
-      - try: [appmenu-qt5] # not available on core18
-      - locales-all
-      - xdg-user-dirs
-      - fcitx-frontend-qt5  
-  qt5:
-    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git    
-    source-subdir: qt
-    plugin: make
-    make-parameters: ["FLAVOR=qt5"]
-    build-packages:
-      - qtbase5-dev
-      - dpkg-dev
-    stage-packages:
-      - libxkbcommon0
-      - ttf-ubuntu-font-family
-      - dmz-cursor-theme
-      - light-themes
-      - adwaita-icon-theme
-      - gnome-themes-standard
-      - shared-mime-info
-      - libqt5gui5
-      - libgdk-pixbuf2.0-0
-      - libqt5svg5 # for loading icon themes which are svg
-      - try: [appmenu-qt5] # not available on core18
-      - locales-all    
-  barrier-kvm:
-    source: https://github.com/payomagic/barrier.git
+
+  barrier:
+    source: .
     plugin: cmake
     build-packages:
       - g++

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,7 @@
 name: barrier-kvm # the Barrier Snappy for Linux / not tested on MAC yet
 base: core18 
-version: '2.2.0' # 03/2019 
+version: master
+version-script: git -C parts/barrier/src/ describe --tags --long | sed "s/^v//"
 summary: Eliminate the barrier between your machines.
 description: |
        Barrier is KVM software forked from Symless's synergy 1.9 codebase. 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,7 +11,7 @@ grade: stable # must be 'stable' to release into candidate/stable channels
 confinement: strict # use 'strict' once you have the right plugs and slots
 
 apps:
-  barrier-kvm:
+  barrier:
     command: desktop-launch barrier #first run might take longer
     plugs: &plugs
       - desktop
@@ -25,6 +25,12 @@ apps:
       - unity7
       - wayland
       - x11
+  barrierc:
+    command: desktop-launch barrierc
+    plugs: *plugs
+  barriers:
+    command: desktop-launch barriers
+    plugs: *plugs
 
 parts:
   desktop:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,6 +13,7 @@ confinement: strict # use 'strict' once you have the right plugs and slots
 apps:
   barrier:
     command: desktop-launch barrier #first run might take longer
+    desktop: usr/share/applications/barrier.desktop
     plugs: &plugs
       - desktop
       - desktop-legacy
@@ -41,6 +42,8 @@ parts:
   barrier:
     source: .
     plugin: cmake
+    configflags:
+      - "-DCMAKE_INSTALL_PREFIX=/usr"
     build-packages:
       - xorg-dev 
       - libcurl4-openssl-dev
@@ -68,3 +71,9 @@ parts:
       - libavahi-common3
       - libavahi-compat-libdnssd1
     after: [desktop-qt5]
+
+  fix-icon:
+    plugin: nil
+    override-build:
+      sed -i 's|Icon=barrier|Icon=/usr/share/icons/hicolor/scalable/apps/barrier.svg|' $SNAPCRAFT_STAGE/usr/share/applications/barrier.desktop
+    after: [barrier]


### PR DESCRIPTION
Hi! This should fix issue #301. Includes lots of fixes and improvements, such as:

- Fix snap permissions - including networking and OpenGL.
- Streamline build to use distro-provided Qt - saves build time (and space).
- Drop `-dev` packages from final snap - reduces snap size from 289MB to 51MB.
- Set snap icon and license, use [flathub appstream metadata](https://github.com/flathub/com.github.debauchee.barrier/blob/master/com.github.debauchee.barrier.appdata.xml) for summary and description.
- Add desktop entry with an icon.
- Expose commands: `barrier`, `barrierc`, `barriers` (with a `barrier-kvm.` prefix).
- Use version from git tag - suitable for CI.

Btw, is the [barrier-kvm](https://snapcraft.io/barrier-kvm) snap official? It's currently in very bad shape. And, it should really be named `barrier`, so that the main command will be exposed to users as `barrier` with no prefix. I've checked and the name `barrier` is already reserved at the Snap Store, although with no published snaps. Is it reserved by you? If not, you can claim it [here](https://dashboard.snapcraft.io/register-snap/?name=barrier).

Finally, are there plans for a CI pipeline to publish e.g. daily builds of snaps? If not, you could start with https://build.snapcraft.io. For example, I've already set up [my fork](https://snapcraft.io/barrier-maxiberta) to be [automatically built and published to the edge channel](https://build.snapcraft.io/user/maxiberta/barrier) (hopefully temporarily; will drop this fork once there's an official up-to-date snap).

I can happily help if needed :)
Thanks!