### PR TITLE
Fix snap version-control script for local LXD builds

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: barrier-kvm # the Barrier Snappy for Linux / not tested on MAC yet
 base: core18 
 version: master
-version-script: git -C parts/barrier/src/ describe --tags --long | sed "s/^v//"
+version-script: git describe --tags --long | sed "s/^v//"
 adopt-info: appstream-flathub
 grade: stable # must be 'stable' to release into candidate/stable channels
 confinement: strict # use 'strict' once you have the right plugs and slots


### PR DESCRIPTION
Fixes local snap builds on LXD. Automatic builds on [build.snapcraft.io](https://build.snapcraft.io/user/maxiberta/barrier) still work as well. E.g.:

```
$ snapcraft --use-lxd
Using 'snap/snapcraft.yaml': Project assets will be searched for from the 'snap' directory.
The LXD provider is offered as a technology preview for early adopters.
The command line interface, container names or lifecycle handling may change in upcoming releases.
Launching a container.
Waiting for cloud-init

status: done
snap "core" has no updates available
snap "snapcraft" has no updates available
snap "core18" has no updates available
Using 'snap/snapcraft.yaml': Project assets will be searched for from the 'snap' directory.
Skipping pull appstream-flathub (already ran)
Skipping pull desktop-qt5 (already ran)
Updating pull step for barrier (source changed)
'fix-icon' has dependencies that need to be staged: barrier
Skipping pull barrier (already ran)
Updating build step for barrier ('pull' step changed)
cmake /root/parts/barrier/src -DCMAKE_INSTALL_PREFIX= -DCMAKE_INSTALL_PREFIX=/usr
-- Full Barrier version string is '2.3.0-snapshot-snapshot.b1-f23a2ece'
-- Configuring directory /root/parts/barrier/build/rpm
-- Configuring file barrier.spec
-- Configuring done
-- Generating done
-- Build files have been written to: /root/parts/barrier/build
cmake --build . -- -j4
[  2%] Built target io
[  6%] Built target mt
[  9%] Built target common
[ 18%] Built target arch
[ 18%] Automatic MOC, UIC and RCC for target barrier
[ 25%] Built target base
[ 30%] Built target net
[ 30%] Built target barrier_autogen
[ 49%] Built target synlib
[ 58%] Built target server
[ 66%] Built target platform
[ 90%] Built target barrier
[ 94%] Built target ipc
[ 96%] Built target client
[ 98%] Built target barrierc
[100%] Built target barriers
cmake --build . --target install
[  9%] Built target arch
[ 12%] Built target common
[ 19%] Built target base
[ 23%] Built target mt
[ 25%] Built target io
[ 30%] Built target net
[ 49%] Built target synlib
[ 58%] Built target server
[ 66%] Built target platform
[ 70%] Built target ipc
[ 72%] Built target client
[ 74%] Built target barrierc
[ 76%] Built target barriers
[ 76%] Automatic MOC, UIC and RCC for target barrier
[ 76%] Built target barrier_autogen
[100%] Built target barrier
Install the project...
-- Install configuration: ""
-- Up-to-date: /root/parts/barrier/install/usr/share/icons/hicolor/scalable/apps/barrier.svg
-- Up-to-date: /root/parts/barrier/install/usr/share/applications/barrier.desktop
-- Up-to-date: /root/parts/barrier/install/usr/bin/barrierc
-- Up-to-date: /root/parts/barrier/install/usr/bin/barriers
-- Up-to-date: /root/parts/barrier/install/usr/bin/barrier
Cleaning later steps and re-staging barrier 
Cleaning later steps and re-pulling fix-icon ('barrier' changed)
Skipping build appstream-flathub (already ran)
Skipping build desktop-qt5 (already ran)
Skipping build barrier (already ran)
Building fix-icon 
Skipping stage appstream-flathub (already ran)
Skipping stage desktop-qt5 (already ran)
Skipping stage barrier (already ran)
Staging fix-icon 
Skipping prime appstream-flathub (already ran)
Skipping prime desktop-qt5 (already ran)
Priming barrier 
Priming fix-icon 
Common ID None specified in app 'barriers' is not used in any metadata file.
Common ID None specified in app 'barrierc' is not used in any metadata file.
Determining the version from the project repo (version-script).
fatal: cannot change to 'parts/barrier/src/': No such file or directory
The version-script produced no output
Run the same command again with --debug to shell into the environment if you wish to introspect this failure.
An error occurred when trying to execute 'snapcraft snap' with 'LXD': returned exit code 2.
