### PR TITLE
Reference Only Microsoft Azue Pipelines In Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,15 @@ Find [releases here](https://github.com/debauchee/barrier/releases).
 
 - `#barrier` on freenode
 
-Master branch build status: &nbsp; [![Build Status](https://travis-ci.org/debauchee/barrier.svg?branch=master)](https://travis-ci.org/debauchee/barrier)
+#### CI Build Status
 
-Azure Pipelines build status: [![Build Status](https://dev.azure.com/debauchee/Barrier/_apis/build/status/debauchee.barrier?branchName=master)](https://dev.azure.com/debauchee/Barrier/_build/latest?definitionId=1&branchName=master)
+Master branch overall build status: [![Build Status](https://dev.azure.com/debauchee/Barrier/_apis/build/status/debauchee.barrier?branchName=master)](https://dev.azure.com/debauchee/Barrier/_build/latest?definitionId=1&branchName=master)
+* Linux Build Status: [![Build Status](https://dev.azure.com/debauchee/Barrier/_apis/build/status/debauchee.barrier?branchName=master&jobName=Linux%20Build)](https://dev.azure.com/debauchee/Barrier/_build/latest?definitionId=1&branchName=master)
+* Mac Build Status: [![Build Status](https://dev.azure.com/debauchee/Barrier/_apis/build/status/debauchee.barrier?branchName=master&jobName=Mac%20Build)](https://dev.azure.com/debauchee/Barrier/_build/latest?definitionId=1&branchName=master)
+* Windows Debug Build Status: [![Build Status](https://dev.azure.com/debauchee/Barrier/_apis/build/status/debauchee.barrier?branchName=master&jobName=Windows%20Build&configuration=Windows%20Build%20Debug)](https://dev.azure.com/debauchee/Barrier/_build/latest?definitionId=1&branchName=master)
+* Windows Release Build Status: [![Build Status](https://dev.azure.com/debauchee/Barrier/_apis/build/status/debauchee.barrier?branchName=master&jobName=Windows%20Build&configuration=Windows%20Build%20Release%20with%20Release%20Installer)](https://dev.azure.com/debauchee/Barrier/_build/latest?definitionId=1&branchName=master)
+
+Our CI Builds are provided by Microsoft Azure Pipelines.
 
 ### What is it?
 


### PR DESCRIPTION
We plan to remove all the CI pipeline apart from Microsoft Azue Pipelines.  This was documented under #308 after the Azure Pipeline system was successfully integrated under #303 and shown to provide all the build targetes we needed.

As there are presently have 4 seperate main build targes.  As well as giving the overall master branch status in the Readme (which forms part of the main page on github.com) also show the seperate build status.  This makes it clear if a single part fails and gives an obvious indicator that this project works for Linux, Mac and Windows.