### PR TITLE
Re-implement patch for horizontal scrolling and extra mouse buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ CMakeCache.txt
 .vscode/
 # Transient in-project-directory dependencies
 /deps/
+/out/build/x64-Debug

--- a/src/lib/barrier/mouse_types.h
+++ b/src/lib/barrier/mouse_types.h
@@ -32,10 +32,13 @@ static const ButtonID    kButtonNone   = 0;
 static const ButtonID    kButtonLeft   = 1;
 static const ButtonID    kButtonMiddle = 2;
 static const ButtonID    kButtonRight  = 3;
+// mouse button 4
 static const ButtonID    kButtonExtra0 = 4;
+// mouse button 5
+static const ButtonID    kButtonExtra1 = 5;
 
 static const ButtonID   kMacButtonRight = 2;
 static const ButtonID   kMacButtonMiddle = 3;
 //@}
 
-static const UInt8      NumButtonIDs  = 5;
+static const UInt8      NumButtonIDs  = 6;

--- a/src/lib/platform/MSWindowsDesks.cpp
+++ b/src/lib/platform/MSWindowsDesks.cpp
@@ -33,6 +33,7 @@
 #include "base/IEventQueue.h"
 
 #include <malloc.h>
+#include <VersionHelpers.h>
 
 // these are only defined when WINVER >= 0x0500
 #if !defined(SPI_GETMOUSESPEED)
@@ -606,16 +607,6 @@ MSWindowsDesks::deskThread(void* vdesk)
 {
     MSG msg;
 
-	BOOL vistaOrGreater = FALSE;
-
-	{
-        OSVERSIONINFOW osvi;
-        osvi.dwOSVersionInfoSize = sizeof(osvi);
-        if (GetVersionExW(&osvi)) {
-            vistaOrGreater = osvi.dwMajorVersion >= 6;
-        }
-    }
-
     // use given desktop for this thread
     Desk* desk              = static_cast<Desk*>(vdesk);
     desk->m_threadID         = GetCurrentThreadId();
@@ -703,7 +694,7 @@ MSWindowsDesks::deskThread(void* vdesk)
             if (msg.lParam != 0) {
                 mouse_event(MOUSEEVENTF_WHEEL, 0, 0, (DWORD)msg.lParam, 0);
             }
-            else if (vistaOrGreater && msg.wParam != 0) {
+            else if (IsWindowsVistaOrGreater() && msg.wParam != 0) {
                 mouse_event(MOUSEEVENTF_HWHEEL, 0, 0, (DWORD)msg.wParam, 0);
             }
             break;

--- a/src/lib/platform/MSWindowsHook.cpp
+++ b/src/lib/platform/MSWindowsHook.cpp
@@ -25,6 +25,10 @@
 #include "common/DataDirectories.h"
 #include "base/Log.h"
 
+#ifndef WM_MOUSEHWHEEL
+#define WM_MOUSEHWHEEL 0x020E
+#endif
+
  //
  // debugging compile flag.  when not zero the server doesn't grab
  // the keyboard when the mouse leaves the server screen.  this
@@ -470,6 +474,13 @@ mouseHookHandler(WPARAM wParam, SInt32 x, SInt32 y, SInt32 data)
         if (g_mode == kHOOK_RELAY_EVENTS) {
             // relay event
             PostThreadMessage(g_threadID, BARRIER_MSG_MOUSE_WHEEL, data, 0);
+        }
+        return (g_mode == kHOOK_RELAY_EVENTS);
+
+    case WM_MOUSEHWHEEL:
+        if (g_mode == kHOOK_RELAY_EVENTS) {
+            // relay event
+            PostThreadMessage(g_threadID, BARRIER_MSG_MOUSE_WHEEL, 0, data);
         }
         return (g_mode == kHOOK_RELAY_EVENTS);
 

--- a/src/lib/platform/MSWindowsScreen.cpp
+++ b/src/lib/platform/MSWindowsScreen.cpp
@@ -952,9 +952,9 @@ MSWindowsScreen::updateButtons()
     m_buttons[kButtonLeft]       = (GetKeyState(VK_LBUTTON)  < 0);
     m_buttons[kButtonRight]      = (GetKeyState(VK_RBUTTON)  < 0);
     m_buttons[kButtonMiddle]     = (GetKeyState(VK_MBUTTON)  < 0);
-    m_buttons[kButtonExtra0 + 0] = (numButtons >= 4) &&
+    m_buttons[kButtonExtra0]     = (numButtons >= 4) &&
                                    (GetKeyState(VK_XBUTTON1) < 0);
-    m_buttons[kButtonExtra0 + 1] = (numButtons >= 5) &&
+    m_buttons[kButtonExtra1]     = (numButtons >= 5) &&
                                    (GetKeyState(VK_XBUTTON2) < 0);
 }
 
@@ -1007,8 +1007,7 @@ MSWindowsScreen::onPreDispatchPrimary(HWND,
                             static_cast<SInt32>(lParam));
 
     case BARRIER_MSG_MOUSE_WHEEL:
-        // XXX -- support x-axis scrolling
-        return onMouseWheel(0, static_cast<SInt32>(wParam));
+        return onMouseWheel(static_cast<SInt32>(lParam), static_cast<SInt32>(wParam));
 
     case BARRIER_MSG_PRE_WARP:
         {
@@ -1670,13 +1669,13 @@ MSWindowsScreen::mapButtonFromEvent(WPARAM msg, LPARAM button) const
         switch (button) {
         case XBUTTON1:
             if (GetSystemMetrics(SM_CMOUSEBUTTONS) >= 4) {
-                return kButtonExtra0 + 0;
+                return kButtonExtra0;
             }
             break;
 
         case XBUTTON2:
             if (GetSystemMetrics(SM_CMOUSEBUTTONS) >= 5) {
-                return kButtonExtra0 + 1;
+                return kButtonExtra1;
             }
             break;
         }

--- a/src/lib/platform/MSWindowsScreen.h
+++ b/src/lib/platform/MSWindowsScreen.h
@@ -307,7 +307,7 @@ private:
     HotKeyToIDMap        m_hotKeyToIDMap;
 
     // map of button state
-    bool                m_buttons[1 + kButtonExtra0 + 1];
+    bool                m_buttons[NumButtonIDs];
 
     // the system shows the mouse cursor when an internal display count
     // is >= 0.  this count is maintained per application but there's

--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -422,6 +422,7 @@ OSXScreen::constructMouseButtonEventMap()
 		{kCGEventRightMouseUp, kCGEventRightMouseDragged, kCGEventRightMouseDown},
 		{kCGEventOtherMouseUp, kCGEventOtherMouseDragged, kCGEventOtherMouseDown},
 		{kCGEventOtherMouseUp, kCGEventOtherMouseDragged, kCGEventOtherMouseDown},
+		{kCGEventOtherMouseUp, kCGEventOtherMouseDragged, kCGEventOtherMouseDown},
 		{kCGEventOtherMouseUp, kCGEventOtherMouseDragged, kCGEventOtherMouseDown}
 	};
 

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -1870,7 +1870,7 @@ XWindowsScreen::mapButtonFromX(const XButtonEvent* event) const
 	case 8: // mouse button 4
 		return kButtonExtra0;
 	case 9: // mouse button 5
-		return kButtonExtra0;
+		return kButtonExtra1;
 	default: // unknown button
 		return kButtonNone;
 	}

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -66,7 +66,8 @@ XWindowsScreen::XWindowsScreen(
 		IEventQueue* events) :
 	m_isPrimary(isPrimary),
 	m_mouseScrollDelta(mouseScrollDelta),
-    m_accumulatedScroll(0),
+    m_x_accumulatedScroll(0),
+    m_y_accumulatedScroll(0),
 	m_display(NULL),
 	m_root(None),
 	m_window(None),
@@ -829,35 +830,37 @@ XWindowsScreen::fakeMouseRelativeMove(SInt32 dx, SInt32 dy) const
 }
 
 void
-XWindowsScreen::fakeMouseWheel(SInt32, SInt32 yDelta) const
+XWindowsScreen::fakeMouseWheel(SInt32 xDelta, SInt32 yDelta) const
 {
-	// XXX -- support x-axis scrolling
-	if (yDelta == 0) {
-		return;
-	}
+    int numEvents;
 
-    int numEvents = accumulateMouseScroll(yDelta);
+    if ((!xDelta && !yDelta) || (xDelta && yDelta)) {
+        // Invalid scrolling inputs
+        return;
+    }
 
-    // choose button depending on rotation direction
-    const unsigned int xButton = mapButtonToX(static_cast<ButtonID>(
-												(numEvents >= 0) ? -1 : -2));
-	if (xButton == 0) {
-		// If we get here, then the XServer does not support the scroll
-		// wheel buttons, so send PageUp/PageDown keystrokes instead.
-		// Patch by Tom Chadwick.
-		KeyCode keycode = 0;
-		if (yDelta >= 0) {
-            keycode = m_impl->XKeysymToKeycode(m_display, XK_Page_Up);
-		}
-		else {
-            keycode = m_impl->XKeysymToKeycode(m_display, XK_Page_Down);
-		}
-		if (keycode != 0) {
-            m_impl->XTestFakeKeyEvent(m_display, keycode, True,  CurrentTime);
-            m_impl->XTestFakeKeyEvent(m_display, keycode, False, CurrentTime);
-		}
-		return;
-	}
+    // 4,  5,    6,    7
+    // up, down, left, right
+    unsigned int xButton;
+
+    if (yDelta) { // vertical scroll
+        numEvents = y_accumulateMouseScroll(yDelta);
+        if (numEvents >= 0) {
+            xButton = 4; // up
+        }
+        else {
+            xButton = 5; // down
+        }
+    }
+    else { // horizontal scroll
+        numEvents = x_accumulateMouseScroll(xDelta);
+        if (numEvents >= 0) {
+            xButton = 7; // right
+        }
+        else {
+            xButton = 6; // left
+        }
+    }
 
     numEvents = std::abs(numEvents);
 
@@ -1540,7 +1543,14 @@ XWindowsScreen::onMouseRelease(const XButtonEvent& xbutton)
 		// wheel backward (toward user)
 		sendEvent(m_events->forIPrimaryScreen().wheel(), WheelInfo::alloc(0, -120));
 	}
-	// XXX -- support x-axis scrolling
+	else if (xbutton.button == 6) {
+		// wheel left
+		sendEvent(m_events->forIPrimaryScreen().wheel(), WheelInfo::alloc(-120, 0));
+	}
+	else if (xbutton.button == 7) {
+		// wheel right
+		sendEvent(m_events->forIPrimaryScreen().wheel(), WheelInfo::alloc(120, 0));
+	}
 }
 
 void
@@ -1613,11 +1623,20 @@ XWindowsScreen::onMouseMove(const XMotionEvent& xmotion)
 }
 
 int
-XWindowsScreen::accumulateMouseScroll(SInt32 yDelta) const
+XWindowsScreen::x_accumulateMouseScroll(SInt32 xDelta) const
 {
-    m_accumulatedScroll += yDelta;
-    int numEvents = m_accumulatedScroll / m_mouseScrollDelta;
-    m_accumulatedScroll -= numEvents * m_mouseScrollDelta;
+    m_x_accumulatedScroll += xDelta;
+    int numEvents = m_x_accumulatedScroll / m_mouseScrollDelta;
+    m_x_accumulatedScroll -= numEvents * m_mouseScrollDelta;
+    return numEvents;
+}
+
+int
+XWindowsScreen::y_accumulateMouseScroll(SInt32 yDelta) const
+{
+    m_y_accumulatedScroll += yDelta;
+    int numEvents = m_y_accumulatedScroll / m_mouseScrollDelta;
+    m_y_accumulatedScroll -= numEvents * m_mouseScrollDelta;
     return numEvents;
 }
 
@@ -1840,19 +1859,19 @@ XWindowsScreen::mapButtonFromX(const XButtonEvent* event) const
 {
 	unsigned int button = event->button;
 
-	// first three buttons map to 1, 2, 3 (kButtonLeft, Middle, Right)
-	if (button >= 1 && button <= 3) {
+	// http://xahlee.info/linux/linux_x11_mouse_button_number.html
+	// and the program `xev`
+	switch (button)
+	{
+	case 1: case 2: case 3: // kButtonLeft, Middle, Right
 		return static_cast<ButtonID>(button);
-	}
-
-	// buttons 4 and 5 are ignored here.  they're used for the wheel.
-	// buttons 6, 7, etc and up map to 4, 5, etc.
-	else if (button >= 6) {
-		return static_cast<ButtonID>(button - 2);
-	}
-
-	// unknown button
-	else {
+	case 4: case 5: case 6: case 7: // scroll up, down, left, right -- ignored here
+		return kButtonNone;
+	case 8: // mouse button 4
+		return kButtonExtra0;
+	case 9: // mouse button 5
+		return kButtonExtra0;
+	default: // unknown button
 		return kButtonNone;
 	}
 }
@@ -1860,30 +1879,17 @@ XWindowsScreen::mapButtonFromX(const XButtonEvent* event) const
 unsigned int
 XWindowsScreen::mapButtonToX(ButtonID id) const
 {
-	// map button -1 to button 4 (+wheel)
-	if (id == static_cast<ButtonID>(-1)) {
-		id = 4;
-	}
-
-	// map button -2 to button 5 (-wheel)
-	else if (id == static_cast<ButtonID>(-2)) {
-		id = 5;
-	}
-
-	// map buttons 4, 5, etc. to 6, 7, etc. to make room for buttons
-	// 4 and 5 used to simulate the mouse wheel.
-	else if (id >= 4) {
-		id += 2;
-	}
-
-	// check button is in legal range
-	if (id < 1 || id > m_buttons.size()) {
-		// out of range
+	switch (id)
+	{
+	case kButtonLeft: case kButtonMiddle: case kButtonRight:
+		return id;
+	case kButtonExtra0:
+		return 8;
+	case kButtonExtra1:
+		return 9;
+	default:
 		return 0;
 	}
-
-	// map button
-	return static_cast<unsigned int>(id);
 }
 
 void

--- a/src/lib/platform/XWindowsScreen.h
+++ b/src/lib/platform/XWindowsScreen.h
@@ -139,7 +139,8 @@ private:
 
     // Returns the number of scroll events needed after the current delta has
     // been taken into account
-    int                 accumulateMouseScroll(SInt32 yDelta) const;
+    int                 x_accumulateMouseScroll(SInt32 xDelta) const;
+    int                 y_accumulateMouseScroll(SInt32 yDelta) const;
 
     bool                detectXI2();
 #ifdef HAVE_XI2
@@ -183,10 +184,11 @@ private:
     // The size of a smallest supported scroll event, in points
     int                 m_mouseScrollDelta;
 
-    // Accumulates scrolls of less than m_mouseScrollDelta across multiple
+    // Accumulates scrolls of less than m_?_mouseScrollDelta across multiple
     // scroll events. We dispatch a scroll event whenever the accumulated scroll
-    // becomes larger than m_mouseScrollDelta
-    mutable int         m_accumulatedScroll;
+    // becomes larger than m_?_mouseScrollDelta
+    mutable int         m_x_accumulatedScroll;
+    mutable int         m_y_accumulatedScroll;
 
     Display*            m_display;
     Window                m_root;


### PR DESCRIPTION
Re-implementation of #242 for the newer CI's and an up to date codebase. Both horizontal scrolling and extra mouse buttons (buttons 4 and 5, sometimes also referred to as forward and back) have been tested between Windows 10 and Linux (Solus OS). I don't have any macOS devices, so if someone wants to build this to test that platform, that might be a good idea.

Aside from some formatting and a couple of additional comments, there are no significant changes from the original work done in the previous PR.

Fixes #51 