### PR TITLE
Check Inno Setup is installed

### DIFF
--- a/build_installer.bat
+++ b/build_installer.bat
@@ -1,5 +1,14 @@
 @echo off
-set INNO_ROOT=C:\Program Files (x86)\Inno Setup 5
+REM Use setlocal to automatically unset variables
+setlocal
+
+REM Inno Setup folders. Defined in order of preference.
+set INNO6_USER_ROOT=%LOCALAPPDATA%\Programs\Inno Setup 6
+set INNO6_ROOT=%ProgramFiles(x86)%\Inno Setup 6
+SET INNO5_ROOT=%ProgramFiles(x86)%\Inno Setup 5
+set INNO_ROOTS="%INNO6_USER_ROOT%" "%INNO6_ROOT%" "%INNO5_ROOT%"
+set INNO_EXE=ISCC.exe
+set INNO_EXE_PATH=""
 
 set savedir=%cd%
 cd /d %~dp0
@@ -8,9 +17,25 @@ if not exist build\bin\Release goto buildproject
 
 echo Building 64-bit Windows installer...
 
+REM Find where Inno Setup is installed
+for %%r in (%INNO_ROOTS%) do (
+    if exist "%%~r\%INNO_EXE%" (
+        set INNO_EXE_PATH="%%~r\%INNO_EXE%"
+        goto endcheckinnosetuploop
+    )
+)
+:endcheckinnosetuploop
+
+REM Check that Inno Setup is installed
+if %INNO_EXE_PATH%=="" (
+    echo Could not find Inno Setup.
+    echo Check if Inno Setup is installed.
+    goto failed
+)
+
 cd build\installer-inno
 if ERRORLEVEL 1 goto buildproject
-"%INNO_ROOT%\ISCC.exe" /Qp barrier.iss
+%INNO_EXE_PATH% /Qp barrier.iss
 if ERRORLEVEL 1 goto failed
 
 echo Build completed successfully
@@ -28,7 +53,4 @@ goto done
 echo Build failed
 
 :done
-set INNO_ROOT=
-
 cd /d %savedir%
-set savedir=


### PR DESCRIPTION
The build_installer.bat file uses Inno Setup to build the installer. It
does currently not check if Inno Setup is installed, and fails with the
message:
  The system cannot find the path specified.
  Build failed

That message does not explain how to fix the problem. I have added a
loop to search for Inno Setup 6 and 5. The user installed Inno Setup is
preferred over the system installed version. If Inno Setup cannot be
found then it prints an actionable error message.

I have tested it by:
1. Not having Inno Setup installed
2. Running build_installer.bat
3. Checked that the error message appears.
4. Installed Inno Setup 6 for my current user
5. Checked that the error message does not appear.
6. Checked that the installer package is generated
7. Installed build\installer-inno\bin\BarrierSetup-2.3.1-snapshot
8. Verified that Barrier started
9. Uninstalled Barrier
10. Uninstalled Inno Setup 6
11. Installed Inno Setup 6 for all users
12. Checked that the error message does not appear.
13. Checked that the installer package is generated
14. Installed build\installer-inno\bin\BarrierSetup-2.3.1-snapshot
15. Verified that Barrier started
16. Uninstalled Barrier
17. Uninstalled Inno Setup 6
18. Installed Inno Setup 5
19. Checked that the error message does not appear.
20. Checked that the installer package is generated
21. Installed build\installer-inno\bin\BarrierSetup-2.3.1-snapshot
22. Verified that Barrier started
23. Uninstalled Barrier

NOTE: There is an existing issue where you have to manually terminate barrierd.exe after Quitting Barrier. If you do not do that then the uninstaller will not be able to remove everything. It was reproduced with the latest release version (2.3.1).

Fixes #397 