### PR TITLE
Fix: CMake now checks for required Qt5 libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -349,6 +349,12 @@ else()
     set (OPENSSL_LIBS ${lib_ssl} ${lib_crypto})
 endif()
 
+
+# Check we have the *required* Qt5 libs.
+find_package(Qt5Core REQUIRED)
+find_package(Qt5Network REQUIRED)
+find_package(Qt5Widgets REQUIRED)
+
 #
 # Configure_file... but for directories, recursively.
 #


### PR DESCRIPTION
This won't fix #402 completely, but it *will* help mitigate similar
issues with Qt5 libraries during compilation in the future.