### PR TITLE
Fix retry timer not being unregistered properly

### DIFF
--- a/src/lib/barrier/ServerApp.cpp
+++ b/src/lib/barrier/ServerApp.cpp
@@ -302,8 +302,8 @@ void
 ServerApp::stopRetryTimer()
 {
     if (m_timer != NULL) {
+        m_events->removeHandler(Event::kTimer, m_timer);
         m_events->deleteTimer(m_timer);
-        m_events->removeHandler(Event::kTimer, NULL);
         m_timer = NULL;
     }
 }


### PR DESCRIPTION
This is cherry-pick of 70ba53caf47 from symless/synergy-core.

See https://github.com/symless/synergy-core/issues/6495.