### PR TITLE
Use standard mutex APIs instead of the home-grown wrapper

### DIFF
--- a/src/lib/arch/unix/ArchMultithreadPosix.h
+++ b/src/lib/arch/unix/ArchMultithreadPosix.h
@@ -22,6 +22,7 @@
 #include "common/stdlist.h"
 
 #include <pthread.h>
+#include <mutex>
 
 #define ARCH_MULTITHREAD ArchMultithreadPosix
 
@@ -104,7 +105,7 @@ private:
 
     bool                m_newThreadCalled;
 
-    ArchMutex            m_threadMutex;
+    std::mutex m_threadMutex;
     ArchThread            m_mainThread;
     ThreadList            m_threadList;
     ThreadID            m_nextID;

--- a/src/lib/base/EventQueue.h
+++ b/src/lib/base/EventQueue.h
@@ -28,9 +28,8 @@
 #include "common/stdset.h"
 #include "base/NonBlockingStream.h"
 
+#include <mutex>
 #include <queue>
-
-class Mutex;
 
 //! Event queue
 /*!
@@ -114,7 +113,7 @@ private:
     typedef std::map<void*, TypeHandlerTable> HandlerTable;
 
     int                    m_systemTarget;
-    ArchMutex            m_mutex;
+    mutable std::mutex m_mutex;
 
     // registered events
     Event::Type        m_nextType;

--- a/src/lib/base/Log.cpp
+++ b/src/lib/base/Log.cpp
@@ -63,9 +63,6 @@ Log::Log()
 {
     assert(s_log == NULL);
 
-    // create mutex for multithread safe operation
-    m_mutex = ARCH->newMutex();
-
     // other initalization
     m_maxPriority = g_defaultMaxPriority;
     m_maxNewlineLength = 0;
@@ -90,7 +87,6 @@ Log::~Log()
                                     index != m_alwaysOutputters.end(); ++index) {
         delete *index;
     }
-    ARCH->closeMutex(m_mutex);
 }
 
 Log*
@@ -214,7 +210,7 @@ Log::insert(ILogOutputter* outputter, bool alwaysAtHead)
 {
     assert(outputter != NULL);
 
-    ArchMutexLock lock(m_mutex);
+    std::lock_guard<std::mutex> lock(m_mutex);
     if (alwaysAtHead) {
         m_alwaysOutputters.push_front(outputter);
     }
@@ -237,7 +233,7 @@ Log::insert(ILogOutputter* outputter, bool alwaysAtHead)
 void
 Log::remove(ILogOutputter* outputter)
 {
-    ArchMutexLock lock(m_mutex);
+    std::lock_guard<std::mutex> lock(m_mutex);
     m_outputters.remove(outputter);
     m_alwaysOutputters.remove(outputter);
 }
@@ -245,7 +241,7 @@ Log::remove(ILogOutputter* outputter)
 void
 Log::pop_front(bool alwaysAtHead)
 {
-    ArchMutexLock lock(m_mutex);
+    std::lock_guard<std::mutex> lock(m_mutex);
     OutputterList* list = alwaysAtHead ? &m_alwaysOutputters : &m_outputters;
     if (!list->empty()) {
         delete list->front();
@@ -271,14 +267,14 @@ Log::setFilter(const char* maxPriority)
 void
 Log::setFilter(int maxPriority)
 {
-    ArchMutexLock lock(m_mutex);
+    std::lock_guard<std::mutex> lock(m_mutex);
     m_maxPriority = maxPriority;
 }
 
 int
 Log::getFilter() const
 {
-    ArchMutexLock lock(m_mutex);
+    std::lock_guard<std::mutex> lock(m_mutex);
     return m_maxPriority;
 }
 
@@ -289,7 +285,7 @@ Log::output(ELevel priority, char* msg)
     assert(msg != NULL);
     if (!msg) return;
 
-    ArchMutexLock lock(m_mutex);
+    std::lock_guard<std::mutex> lock(m_mutex);
 
     OutputterList::const_iterator i;
 

--- a/src/lib/base/Log.h
+++ b/src/lib/base/Log.h
@@ -24,6 +24,7 @@
 #include "common/stdlist.h"
 
 #include <stdarg.h>
+#include <mutex>
 
 #define CLOG (Log::getInstance())
 #define BYE "\nTry `%s --help' for more information."
@@ -132,7 +133,7 @@ private:
 
     static Log*        s_log;
 
-    ArchMutex            m_mutex;
+    mutable std::mutex m_mutex;
     OutputterList        m_outputters;
     OutputterList        m_alwaysOutputters;
     int                    m_maxNewlineLength;

--- a/src/lib/ipc/IpcClientProxy.h
+++ b/src/lib/ipc/IpcClientProxy.h
@@ -23,6 +23,8 @@
 #include "base/EventTypes.h"
 #include "base/Event.h"
 
+#include <mutex>
+
 namespace barrier { class IStream; }
 class IpcMessage;
 class IpcCommandMessage;
@@ -49,7 +51,7 @@ private:
     barrier::IStream&    m_stream;
     EIpcClientType        m_clientType;
     bool                m_disconnecting;
-    ArchMutex            m_readMutex;
-    ArchMutex            m_writeMutex;
+    std::mutex m_readMutex;
+    std::mutex m_writeMutex;
     IEventQueue*        m_events;
 };

--- a/src/lib/ipc/IpcLogOutputter.h
+++ b/src/lib/ipc/IpcLogOutputter.h
@@ -24,6 +24,7 @@
 #include "ipc/Ipc.h"
 
 #include <deque>
+#include <mutex>
 
 class IpcServer;
 class Event;
@@ -100,7 +101,7 @@ private:
 
     IpcServer&            m_ipcServer;
     Buffer                m_buffer;
-    ArchMutex            m_bufferMutex;
+    std::mutex m_bufferMutex;
     bool                m_sending;
     Thread*                m_bufferThread;
     bool                m_running;
@@ -115,5 +116,5 @@ private:
     UInt16                m_bufferWriteCount;
     double                m_bufferRateStart;
     EIpcClientType        m_clientType;
-    ArchMutex            m_runningMutex;
+    std::mutex m_runningMutex;
 };

--- a/src/lib/ipc/IpcServer.cpp
+++ b/src/lib/ipc/IpcServer.cpp
@@ -56,7 +56,6 @@ IpcServer::init()
 {
     m_socket = new TCPListenSocket(m_events, m_socketMultiplexer, IArchNetwork::kINET);
 
-    m_clientsMutex = ARCH->newMutex();
     m_address.resolve();
 
     m_events->adoptHandler(
@@ -75,15 +74,15 @@ IpcServer::~IpcServer()
         delete m_socket;
     }
 
-    ARCH->lockMutex(m_clientsMutex);
-    ClientList::iterator it;
-    for (it = m_clients.begin(); it != m_clients.end(); it++) {
-        deleteClient(*it);
+    {
+        std::lock_guard<std::mutex> lock(m_clientsMutex);
+        ClientList::iterator it;
+        for (it = m_clients.begin(); it != m_clients.end(); it++) {
+            deleteClient(*it);
+        }
+        m_clients.clear();
     }
-    m_clients.clear();
-    ARCH->unlockMutex(m_clientsMutex);
-    ARCH->closeMutex(m_clientsMutex);
-    
+
     m_events->removeHandler(m_events->forIListenSocket().connecting(), m_socket);
 }
 
@@ -103,10 +102,12 @@ IpcServer::handleClientConnecting(const Event&, void*)
 
     LOG((CLOG_DEBUG "accepted ipc client connection"));
 
-    ARCH->lockMutex(m_clientsMutex);
-    IpcClientProxy* proxy = new IpcClientProxy(*stream, m_events);
-    m_clients.push_back(proxy);
-    ARCH->unlockMutex(m_clientsMutex);
+    IpcClientProxy* proxy = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(m_clientsMutex);
+        proxy = new IpcClientProxy(*stream, m_events);
+        m_clients.push_back(proxy);
+    }
 
     m_events->adoptHandler(
         m_events->forIpcClientProxy().disconnected(), proxy,
@@ -127,7 +128,7 @@ IpcServer::handleClientDisconnected(const Event& e, void*)
 {
     IpcClientProxy* proxy = static_cast<IpcClientProxy*>(e.getTarget());
 
-    ArchMutexLock lock(m_clientsMutex);
+    std::lock_guard<std::mutex> lock(m_clientsMutex);
     m_clients.remove(proxy);
     deleteClient(proxy);
 
@@ -153,7 +154,7 @@ IpcServer::deleteClient(IpcClientProxy* proxy)
 bool
 IpcServer::hasClients(EIpcClientType clientType) const
 {
-    ArchMutexLock lock(m_clientsMutex);
+    std::lock_guard<std::mutex> lock(m_clientsMutex);
 
     if (m_clients.empty()) {
         return false;
@@ -175,7 +176,7 @@ IpcServer::hasClients(EIpcClientType clientType) const
 void
 IpcServer::send(const IpcMessage& message, EIpcClientType filterType)
 {
-    ArchMutexLock lock(m_clientsMutex);
+    std::lock_guard<std::mutex> lock(m_clientsMutex);
 
     ClientList::iterator it;
     for (it = m_clients.begin(); it != m_clients.end(); it++) {

--- a/src/lib/ipc/IpcServer.h
+++ b/src/lib/ipc/IpcServer.h
@@ -25,6 +25,7 @@
 #include "base/EventTypes.h"
 
 #include <list>
+#include <mutex>
 
 class Event;
 class IpcClientProxy;
@@ -79,7 +80,7 @@ private:
     TCPListenSocket*    m_socket;
     NetworkAddress        m_address;
     ClientList            m_clients;
-    ArchMutex            m_clientsMutex;
+    mutable std::mutex m_clientsMutex;
 
 #ifdef TEST_ENV
 public:


### PR DESCRIPTION
This PR replaces some usages of the `ArchMutex` class with the standard `std::mutex`. This is the first part of an attempt to replace the internal threading library with the standard alternatives. Some of the APIs are strange and error-prone, it is a kind of tech-debt that is best fixed. The bonus point is that we won't need to maintain all the extra code.