### PR TITLE
Use explicit memory ownership in SocketMultiplexer

### DIFF
--- a/src/lib/barrier/App.cpp
+++ b/src/lib/barrier/App.cpp
@@ -200,7 +200,7 @@ App::initApp(int argc, const char** argv)
 void
 App::initIpcClient()
 {
-    m_ipcClient = new IpcClient(m_events, m_socketMultiplexer);
+    m_ipcClient = new IpcClient(m_events, m_socketMultiplexer.get());
     m_ipcClient->connect();
 
     m_events->adoptHandler(

--- a/src/lib/barrier/App.h
+++ b/src/lib/barrier/App.h
@@ -23,7 +23,9 @@
 #include "base/String.h"
 #include "base/Log.h"
 #include "base/EventQueue.h"
+#include "net/SocketMultiplexer.h"
 #include "common/common.h"
+#include <memory>
 
 #if SYSAPI_WIN32
 #include "barrier/win32/AppUtilWindows.h"
@@ -95,8 +97,8 @@ public:
     
     virtual IEventQueue* getEvents() const { return m_events; }
 
-    void                setSocketMultiplexer(SocketMultiplexer* sm) { m_socketMultiplexer = sm; }
-    SocketMultiplexer*    getSocketMultiplexer() const { return m_socketMultiplexer; }
+    void setSocketMultiplexer(std::unique_ptr<SocketMultiplexer>&& sm) { m_socketMultiplexer = std::move(sm); }
+    SocketMultiplexer*    getSocketMultiplexer() const { return m_socketMultiplexer.get(); }
 
     void                setEvents(EventQueue& events) { m_events = &events; }
 
@@ -119,7 +121,7 @@ private:
     CreateTaskBarReceiverFunc m_createTaskBarReceiver;
     ARCH_APP_UTIL m_appUtil;
     IpcClient*            m_ipcClient;
-    SocketMultiplexer*    m_socketMultiplexer;
+    std::unique_ptr<SocketMultiplexer> m_socketMultiplexer;
 };
 
 class MinimalApp : public App {

--- a/src/lib/barrier/ClientApp.cpp
+++ b/src/lib/barrier/ClientApp.cpp
@@ -443,8 +443,7 @@ ClientApp::mainLoop()
 {
     // create socket multiplexer.  this must happen after daemonization
     // on unix because threads evaporate across a fork().
-    SocketMultiplexer multiplexer;
-    setSocketMultiplexer(&multiplexer);
+    setSocketMultiplexer(std::make_unique<SocketMultiplexer>());
 
     // start client, etc
     appUtil().startNode();

--- a/src/lib/barrier/ServerApp.cpp
+++ b/src/lib/barrier/ServerApp.cpp
@@ -713,8 +713,7 @@ ServerApp::mainLoop()
 {
     // create socket multiplexer.  this must happen after daemonization
     // on unix because threads evaporate across a fork().
-    SocketMultiplexer multiplexer;
-    setSocketMultiplexer(&multiplexer);
+    setSocketMultiplexer(std::make_unique<SocketMultiplexer>());
 
     // if configuration has no screens then add this system
     // as the default

--- a/src/lib/net/ISocketMultiplexerJob.h
+++ b/src/lib/net/ISocketMultiplexerJob.h
@@ -20,6 +20,19 @@
 
 #include "arch/IArchNetwork.h"
 #include "common/IInterface.h"
+#include <memory>
+
+class ISocketMultiplexerJob;
+
+struct MultiplexerJobStatus
+{
+    MultiplexerJobStatus(bool cont, std::unique_ptr<ISocketMultiplexerJob>&& nj) :
+        continue_servicing(cont), new_job(std::move(nj))
+    {}
+
+    bool continue_servicing = false;
+    std::unique_ptr<ISocketMultiplexerJob> new_job;
+};
 
 //! Socket multiplexer job
 /*!
@@ -32,21 +45,20 @@ public:
 
     //! Handle socket event
     /*!
-    Called by a socket multiplexer when the socket becomes readable,
-    writable, or has an error.  It should return itself if the same
-    job can continue to service events, a new job if the socket must
-    be serviced differently, or NULL if the socket should no longer
-    be serviced.  The socket is readable if \p readable is true,
-    writable if \p writable is true, and in error if \p error is
-    true.
+    Called by a socket multiplexer when the socket becomes readable, writable, or has an error.
+    The socket is readable if \p readable is true, writable if \p writable is true, and in error
+    if \p error is true.
+
+    The method returns false as the continue_servicing member of the returned struct if the socket
+    should no longer be served and true otherwise. Additionally, if the new_job member of the
+    returned pair is not empty, the socket should be serviced differently with the specified job.
 
     This call must not attempt to directly change the job for this
     socket by calling \c addSocket() or \c removeSocket() on the
     multiplexer.  It must instead return the new job.  It can,
     however, add or remove jobs for other sockets.
     */
-    virtual ISocketMultiplexerJob*
-                        run(bool readable, bool writable, bool error) = 0;
+    virtual MultiplexerJobStatus run(bool readable, bool writable, bool error) = 0;
 
     //@}
     //! @name accessors
@@ -72,5 +84,6 @@ public:
     */
     virtual bool        isWritable() const = 0;
 
+    virtual bool isCursor() const { return false; }
     //@}
 };

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -83,7 +83,7 @@ SecureSocket::~SecureSocket()
     // take socket from multiplexer ASAP otherwise the race condition
     // could cause events to get called on a dead object. TCPSocket
     // will do this, too, but the double-call is harmless
-    setJob(NULL);
+    removeJob();
     freeSSLResources();
 
     // removing sleep() because I have no idea why you would want to do it
@@ -125,13 +125,12 @@ SecureSocket::connect(const NetworkAddress& addr)
     TCPSocket::connect(addr);
 }
 
-ISocketMultiplexerJob*
-SecureSocket::newJob()
+std::unique_ptr<ISocketMultiplexerJob> SecureSocket::newJob()
 {
     // after TCP connection is established, SecureSocket will pick up
     // connected event and do secureConnect
     if (m_connected && !m_secureReady) {
-        return NULL;
+        return {};
     }
     
     return TCPSocket::newJob();
@@ -140,7 +139,7 @@ SecureSocket::newJob()
 void
 SecureSocket::secureConnect()
 {
-    setJob(new TSocketMultiplexerMethodJob<SecureSocket>(
+    setJob(std::make_unique<TSocketMultiplexerMethodJob<SecureSocket>>(
                     this, &SecureSocket::serviceConnect,
                     getSocket(), isReadable(), isWritable()));
 }
@@ -148,7 +147,7 @@ SecureSocket::secureConnect()
 void
 SecureSocket::secureAccept()
 {
-    setJob(new TSocketMultiplexerMethodJob<SecureSocket>(
+    setJob(std::make_unique<TSocketMultiplexerMethodJob<SecureSocket>>(
                     this, &SecureSocket::serviceAccept,
                     getSocket(), isReadable(), isWritable()));
 }
@@ -740,10 +739,11 @@ SecureSocket::verifyCertFingerprint()
     return isValid;
 }
 
-ISocketMultiplexerJob*
-SecureSocket::serviceConnect(ISocketMultiplexerJob* job,
-                bool, bool write, bool error)
+MultiplexerJobStatus SecureSocket::serviceConnect(ISocketMultiplexerJob* job,
+                                                  bool read, bool write, bool error)
 {
+    (void) read;
+
     Lock lock(&getMutex());
 
     int status = 0;
@@ -755,25 +755,28 @@ SecureSocket::serviceConnect(ISocketMultiplexerJob* job,
 
     // If status < 0, error happened
     if (status < 0) {
-        return NULL;
+        return {false, {}};
     }
 
     // If status > 0, success
     if (status > 0) {
         sendEvent(m_events->forIDataSocket().secureConnected());
-        return newJob();
+        return {true, newJob()};
     }
 
     // Retry case
-    return new TSocketMultiplexerMethodJob<SecureSocket>(
+    return {
+        true,
+        std::make_unique<TSocketMultiplexerMethodJob<SecureSocket>>(
             this, &SecureSocket::serviceConnect,
-            getSocket(), isReadable(), isWritable());
+            getSocket(), isReadable(), isWritable())
+    };
 }
 
-ISocketMultiplexerJob*
-SecureSocket::serviceAccept(ISocketMultiplexerJob* job,
-                bool, bool write, bool error)
+MultiplexerJobStatus SecureSocket::serviceAccept(ISocketMultiplexerJob* job,
+                                                 bool read, bool write, bool error)
 {
+    (void) read;
     Lock lock(&getMutex());
 
     int status = 0;
@@ -784,19 +787,19 @@ SecureSocket::serviceAccept(ISocketMultiplexerJob* job,
 #endif
         // If status < 0, error happened
     if (status < 0) {
-        return NULL;
+        return {false, {}};
     }
 
     // If status > 0, success
     if (status > 0) {
         sendEvent(m_events->forClientListener().accepted());
-        return newJob();
+        return {true, newJob()};
     }
 
     // Retry case
-    return new TSocketMultiplexerMethodJob<SecureSocket>(
+    return {true, std::make_unique<TSocketMultiplexerMethodJob<SecureSocket>>(
             this, &SecureSocket::serviceAccept,
-            getSocket(), isReadable(), isWritable());
+            getSocket(), isReadable(), isWritable())};
 }
 
 void

--- a/src/lib/net/SecureSocket.h
+++ b/src/lib/net/SecureSocket.h
@@ -44,8 +44,7 @@ public:
     // IDataSocket overrides
     virtual void        connect(const NetworkAddress&);
     
-    ISocketMultiplexerJob*
-                        newJob();
+    std::unique_ptr<ISocketMultiplexerJob> newJob() override;
     bool                isFatal() const { return m_fatal; }
     void                isFatal(bool b) { m_fatal = b; }
     bool                isSecureReady();
@@ -74,13 +73,8 @@ private:
                                             bool separator = true);
     bool                verifyCertFingerprint();
 
-    ISocketMultiplexerJob*
-                        serviceConnect(ISocketMultiplexerJob*,
-                            bool, bool, bool);
-
-    ISocketMultiplexerJob*
-                        serviceAccept(ISocketMultiplexerJob*,
-                            bool, bool, bool);
+    MultiplexerJobStatus serviceConnect(ISocketMultiplexerJob*, bool, bool, bool);
+    MultiplexerJobStatus serviceAccept(ISocketMultiplexerJob*, bool, bool, bool);
 
     void                showSecureConnectInfo();
     void                showSecureLibInfo();

--- a/src/lib/net/SocketMultiplexer.h
+++ b/src/lib/net/SocketMultiplexer.h
@@ -21,6 +21,7 @@
 #include "arch/IArchNetwork.h"
 #include "common/stdlist.h"
 #include "common/stdmap.h"
+#include <memory>
 
 template <class T>
 class CondVar;
@@ -41,7 +42,7 @@ public:
     //! @name manipulators
     //@{
 
-    void                addSocket(ISocket*, ISocketMultiplexerJob*);
+    void                addSocket(ISocket*, std::unique_ptr<ISocketMultiplexerJob>&& job);
 
     void                removeSocket(ISocket*);
 
@@ -58,7 +59,7 @@ public:
 private:
     // list of jobs.  we use a list so we can safely iterate over it
     // while other threads modify it.
-    typedef std::list<ISocketMultiplexerJob*> SocketJobs;
+    using SocketJobs = std::list<std::unique_ptr<ISocketMultiplexerJob>>;
     typedef SocketJobs::iterator JobCursor;
     typedef std::map<ISocket*, JobCursor> SocketJobMap;
 
@@ -106,6 +107,4 @@ private:
 
     SocketJobs            m_socketJobs;
     SocketJobMap        m_socketJobMap;
-    ISocketMultiplexerJob*
-                        m_cursorMark;
 };

--- a/src/lib/net/TCPListenSocket.h
+++ b/src/lib/net/TCPListenSocket.h
@@ -19,10 +19,10 @@
 #pragma once
 
 #include "net/IListenSocket.h"
+#include "net/ISocketMultiplexerJob.h"
 #include "arch/IArchNetwork.h"
 
 class Mutex;
-class ISocketMultiplexerJob;
 class IEventQueue;
 class SocketMultiplexer;
 
@@ -48,9 +48,7 @@ protected:
     void                setListeningJob();
 
 public:
-    ISocketMultiplexerJob*
-                        serviceListening(ISocketMultiplexerJob*,
-                            bool, bool, bool);
+    MultiplexerJobStatus serviceListening(ISocketMultiplexerJob*, bool, bool, bool);
 
 protected:
     ArchSocket            m_socket;

--- a/src/lib/net/TCPSocket.h
+++ b/src/lib/net/TCPSocket.h
@@ -19,14 +19,15 @@
 #pragma once
 
 #include "net/IDataSocket.h"
+#include "net/ISocketMultiplexerJob.h"
 #include "io/StreamBuffer.h"
 #include "mt/CondVar.h"
 #include "mt/Mutex.h"
 #include "arch/IArchNetwork.h"
+#include <memory>
 
 class Mutex;
 class Thread;
-class ISocketMultiplexerJob;
 class IEventQueue;
 class SocketMultiplexer;
 
@@ -59,8 +60,7 @@ public:
     virtual void        connect(const NetworkAddress&);
 
     
-    virtual ISocketMultiplexerJob*
-                        newJob();
+    virtual std::unique_ptr<ISocketMultiplexerJob> newJob();
 
 protected:
     enum EJobResult {
@@ -74,7 +74,8 @@ protected:
     virtual EJobResult    doRead();
     virtual EJobResult    doWrite();
 
-    void                setJob(ISocketMultiplexerJob*);
+    void removeJob();
+    void setJob(std::unique_ptr<ISocketMultiplexerJob>&& job);
     
     bool                isReadable() { return m_readable; }
     bool                isWritable() { return m_writable; }
@@ -93,12 +94,8 @@ private:
     void                onOutputShutdown();
     void                onDisconnected();
 
-    ISocketMultiplexerJob*
-                        serviceConnecting(ISocketMultiplexerJob*,
-                            bool, bool, bool);
-    ISocketMultiplexerJob*
-                        serviceConnected(ISocketMultiplexerJob*,
-                            bool, bool, bool);
+    MultiplexerJobStatus serviceConnecting(ISocketMultiplexerJob*, bool, bool, bool);
+    MultiplexerJobStatus serviceConnected(ISocketMultiplexerJob*, bool, bool, bool);
 
 protected:
     bool                m_readable;

--- a/src/lib/net/TSocketMultiplexerMethodJob.h
+++ b/src/lib/net/TSocketMultiplexerMethodJob.h
@@ -28,8 +28,7 @@ A socket multiplexer job class that invokes a member function.
 template <class T>
 class TSocketMultiplexerMethodJob : public ISocketMultiplexerJob {
 public:
-    typedef ISocketMultiplexerJob*
-                (T::*Method)(ISocketMultiplexerJob*, bool, bool, bool);
+    using Method = MultiplexerJobStatus (T::*)(ISocketMultiplexerJob*, bool, bool, bool);
 
     //! run() invokes \c object->method(arg)
     TSocketMultiplexerMethodJob(T* object, Method method,
@@ -37,11 +36,10 @@ public:
     virtual ~TSocketMultiplexerMethodJob();
 
     // IJob overrides
-    virtual ISocketMultiplexerJob*
-                        run(bool readable, bool writable, bool error);
-    virtual ArchSocket    getSocket() const;
-    virtual bool        isReadable() const;
-    virtual bool        isWritable() const;
+    virtual MultiplexerJobStatus run(bool readable, bool writable, bool error) override;
+    virtual ArchSocket getSocket() const override;
+    virtual bool isReadable() const override;
+    virtual bool isWritable() const override;
 
 private:
     T*                    m_object;
@@ -74,14 +72,12 @@ TSocketMultiplexerMethodJob<T>::~TSocketMultiplexerMethodJob()
 }
 
 template <class T>
-inline
-ISocketMultiplexerJob*
-TSocketMultiplexerMethodJob<T>::run(bool read, bool write, bool error)
+inline MultiplexerJobStatus TSocketMultiplexerMethodJob<T>::run(bool read, bool write, bool error)
 {
     if (m_object != NULL) {
         return (m_object->*m_method)(this, read, write, error);
     }
-    return NULL;
+    return {false, {}};
 }
 
 template <class T>


### PR DESCRIPTION
The code of SocketMultiplexer is extremely hard to follow, as the ownership of various data is not clear. This PR fixes that by making ownership explicit by using `std::unique_ptr`. While no memory leaks have been detected or fixed, this will make this basically impossible in the future.