### PR TITLE
Rename the snap as `barrier`.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,4 @@
-name: barrier-kvm # the Barrier Snappy for Linux / not tested on MAC yet
+name: barrier
 base: core18
 version: master
 version-script: git describe --tags --long | sed "s/^v//"


### PR DESCRIPTION
Rename the snap, now that [the `barrier` snap name is owned by @AdrianKoshka](https://github.com/debauchee/barrier/pull/360#issuecomment-522561741) at the [snap store](https://snapcraft.io/store).

Then, a simple CI pipeline can be setup at https://snapcraft.io/build to build and release the snap on each commit to master :).