### PR TITLE
Revert "Tidy up and fix lint errors in build scripts"

### DIFF
--- a/clean_build.sh
+++ b/clean_build.sh
@@ -1,52 +1,28 @@
-#!/bin/bash
-
-set -eu # we set this to catch errors and terminate
-
-cd "$(dirname "$0")" || exit 1
-
+#!/bin/sh
+cd "$(dirname $0)" || exit 1
 # some environments have cmake v2 as 'cmake' and v3 as 'cmake3'
 # check for cmake3 first then fallback to just cmake
-
-if type cmake3 2>/dev/null; then
-    B_CMAKE=$(command -v "$(echo "$B_CMAKE" | cut -d' ' -f3)")
+B_CMAKE=`type cmake3 2>/dev/null`
+if [ $? -eq 0 ]; then
+    B_CMAKE=`echo $B_CMAKE | cut -d' ' -f3`
 else
-    B_CMAKE=$(command -v cmake)
+    B_CMAKE=cmake
 fi
-
 # default build configuration
 B_BUILD_TYPE=${B_BUILD_TYPE:-Debug}
-
-if [ "$(uname -s)" = "Darwin" ]; then
+if [ "$(uname)" = "Darwin" ]; then
     # OSX needs a lot of extra help, poor thing
     # run the osx_environment.sh script to fix paths
-    if [ -f "./osx_environment.sh" ]; then
-       . ./osx_environment.sh
-    fi
+    . ./osx_environment.sh
     B_CMAKE_FLAGS="-DCMAKE_OSX_SYSROOT=$(xcode-select --print-path)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 $B_CMAKE_FLAGS"
 fi
-
 # allow local customizations to build environment
-if [ -f "./build_env.sh" ]; then
-    . ./build_env.sh
-fi
-
-set +eu # disable this temporarily
-if [ -n "${B_CMAKE_FLAGS}" ]; then
-    B_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=$B_BUILD_TYPE ${B_CMAKE_FLAGS}"
-else
-    B_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=$B_BUILD_TYPE"
-fi
-set -eu # enable this
-
+[ -r ./build_env.sh ] && . ./build_env.sh
+B_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=$B_BUILD_TYPE $B_CMAKE_FLAGS"
 rm -rf build
 mkdir build || exit 1
 cd build || exit 1
-
-echo "Starting Barrier build..."
-echo "Build type: ${B_BUILD_TYPE}"
-
-"$B_CMAKE" "$B_CMAKE_FLAGS" .. || exit 1
-
+echo Starting Barrier $B_BUILD_TYPE build...
+$B_CMAKE $B_CMAKE_FLAGS .. || exit 1
 make || exit 1
-
-echo "Build completed successfully."
+echo "Build completed successfully"

--- a/osx_environment.sh
+++ b/osx_environment.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set +eu
-
 # Checks if directory exists, otherwise asks to install package.
 function check_dir_exists() {
     local path=$1
@@ -13,7 +11,7 @@ function check_dir_exists() {
     fi
 }
 
-if [ ! "$BARRIER_BUILD_ENV" ]; then
+if [ ! $BARRIER_BUILD_ENV ]; then
     check_dir_exists '/Applications/Xcode.app' 'Xcode'
 
     printf "Modifying environment for Barrier build...\n"


### PR DESCRIPTION
This series of fixes seems to make Azure pipeline nolonger upload the `.dmg` file to the artifact section, as such, for now it will be reverted.