### PR TITLE
WIP: Disable plain text converters to support Unicode with XWindowsClipboard

### DIFF
--- a/src/lib/platform/XWindowsClipboard.cpp
+++ b/src/lib/platform/XWindowsClipboard.cpp
@@ -93,10 +93,12 @@ XWindowsClipboard::XWindowsClipboard(IXWindowsImpl* impl, Display* display,
                                 "text/plain;charset=ISO-10646-UCS-2"));
     m_converters.push_back(new XWindowsClipboardUCS2Converter(m_display,
                                 "text/unicode"));
-    m_converters.push_back(new XWindowsClipboardTextConverter(m_display,
-                                "text/plain"));
-    m_converters.push_back(new XWindowsClipboardTextConverter(m_display,
-                                "STRING"));
+
+    // Commenting these plain text converters resolves encoding issues with Unicode characters being replaced by question marks (#344)
+    // m_converters.push_back(new XWindowsClipboardTextConverter(m_display,
+    //                             "text/plain"));
+    // m_converters.push_back(new XWindowsClipboardTextConverter(m_display,
+    //                             "STRING"));
 
     // we have no data
     clearCache();


### PR DESCRIPTION
This PRs aims to resolve issue #344, where Unicode characters pasted to linux client or server are replaced by question marks.

This is marked as WIP as I'm still investigating why the `text/plain` converter is selected instead of the Unicode one.

The current change is more like a work-around that disables plain text converters for 
 XWindowsClipboard. Did not notice side effects yet.