### PR TITLE
make non-gui variants build without avahi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,7 +175,7 @@ if (UNIX)
             link_directories("/usr/X11R6/lib")
         endif()
 
-        if (${PKG_CONFIG_FOUND})
+        if (BARRIER_BUILD_GUI AND ${PKG_CONFIG_FOUND})
             pkg_check_modules (AVAHI_COMPAT REQUIRED avahi-compat-libdns_sd)
             include_directories (BEFORE SYSTEM ${AVAHI_COMPAT_INCLUDE_DIRS})
             set (CMAKE_REQUIRED_INCLUDES "${CMAKE_REQUIRED_INCLUDES};${AVAHI_COMPAT_INCLUDE_DIRS}")


### PR DESCRIPTION
Hi,
I adapted and extended a barrier ebuild, it provides optional support for qt. 
I tested it with and without, but a user stumbled about building it without qt and couldn't build it withotu avahi. Thankfully he made a simple patch that works so far (which is in this request).
My testing did not catch that, because I still had avahi installed.