### PR TITLE
Replace hard-coded names of build directory in build_installer.sh scr…

### DIFF
--- a/dist/macos/bundle/build_installer.sh.in
+++ b/dist/macos/bundle/build_installer.sh.in
@@ -3,9 +3,10 @@
 # change this to rename the installer package
 B_DMG="Barrier-@BARRIER_VERSION@.dmg"
 
-cd @CMAKE_CURRENT_SOURCE_DIR@/build/bundle || exit 1
+cd "$( dirname '$0' )"
+OWNDIR="$( pwd )"
 
-B_REREF_SCRIPT=@CMAKE_CURRENT_SOURCE_DIR@/build/bundle/reref_dylibs.sh
+B_REREF_SCRIPT="$OWNDIR/reref_dylibs.sh"
 if [ ! -x $B_REREF_SCRIPT ]; then
     echo Missing script: $B_REREF_SCRIPT
     exit 1


### PR DESCRIPTION
…ipt for macOS with looking at the location of the script by the script itself when it is run. This makes it possible to have differently named build dirs for debug and release builds, and without restricting what each of those directories must be named.