### PR TITLE
Remove shell script that changes directory and then executes barrier on macOS, and execute barrier directly instead

### DIFF
--- a/dist/macos/bundle/Barrier.app/Contents/Info.plist.in
+++ b/dist/macos/bundle/Barrier.app/Contents/Info.plist.in
@@ -6,7 +6,7 @@
     <key>CFBundleDisplayName</key>
     <string>Barrier</string>
     <key>CFBundleExecutable</key>
-    <string>barrier.sh</string>
+    <string>barrier</string>
     <key>CFBundleIconFile</key>
     <string>Barrier.icns</string>
     <key>CFBundleIdentifier</key>

--- a/dist/macos/bundle/build_installer.sh.in
+++ b/dist/macos/bundle/build_installer.sh.in
@@ -57,11 +57,6 @@ $B_REREF_SCRIPT barrier || exit 1
 # libraries in its metadata
 $B_REREF_SCRIPT platforms/libqcocoa.dylib ../ || exit 1
 
-# create a startup script that will change to the binary directory
-# before starting barrier
-printf "%s\n" "#!/bin/sh" "cd \$(dirname \$0)" "exec ./barrier" > barrier.sh
-chmod +x barrier.sh
-
 echo "Barrier.app created successfully"
 
 # sanity check so we don't distribute a dmg with debug symbols


### PR DESCRIPTION
This PR solves issue #475. See the issue and the comments on it for details.

Tested on macOS High Sierra 10.13.6 and on macOS Catalina 10.15.1.