### PR TITLE
Add settings in the Info.plist file that enable high-DPI support on macOS

### DIFF
--- a/dist/macos/bundle/Barrier.app/Contents/Info.plist.in
+++ b/dist/macos/bundle/Barrier.app/Contents/Info.plist.in
@@ -24,6 +24,10 @@
     <string>@BARRIER_VERSION@</string>
     <key>CFBundleVersion</key>
     <string>@BARRIER_VERSION@</string>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+    <key>NSHighResolutionCapable</key>
+    <string>True</string>
     <key>NSHumanReadableCopyright</key>
     <string>© 2018 Debauchee Open Source Group</string>
     <key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
These changes follow the instructions in the official Qt docs.

https://doc.qt.io/qt-5/highdpi.html

Tested on macOS Catalina 10.15.1 running on a MacBook Air 2018 model, which has a Retina (high-DPI) display. Tested with both Qt 5.12.3 (same version used in Azure build pipeline) and with the current Qt 5.13.2.

Also tested on macOS High Sierra 10.13.6 running on a non-Retina display computer (confirmed that it is not running in high-DPI mode by inspecting outputs of `system_profiler SPDisplaysDataType | grep Resolution`). Tested with both Qt 5.12.3 and with Qt 5.13.2 on this computer as well.

This change makes it so that the application GUI looks like it should on Retina displays on macOS, instead of being blocky/pixely/blurry like it was prior to this change when macOS was upscaling it.