### PR TITLE
Add autoStart setting

### DIFF
--- a/doc/newsfragments/gui-autostart.feature
+++ b/doc/newsfragments/gui-autostart.feature
@@ -1,0 +1,1 @@
+Implemented a configuration option for Server GUI auto-start.

--- a/src/gui/src/AppConfig.cpp
+++ b/src/gui/src/AppConfig.cpp
@@ -60,6 +60,7 @@ AppConfig::AppConfig(QSettings* settings) :
     m_AutoConfigPrompted(false),
     m_CryptoEnabled(false),
     m_AutoHide(false),
+    m_AutoStart(false),
     m_MinimizeToTray(false)
 {
     Q_ASSERT(m_pSettings);
@@ -158,6 +159,7 @@ void AppConfig::loadSettings()
     m_AutoConfigPrompted = settings().value("autoConfigPrompted", false).toBool();
     m_CryptoEnabled = settings().value("cryptoEnabled", true).toBool();
     m_AutoHide = settings().value("autoHide", false).toBool();
+    m_AutoStart = settings().value("autoStart", false).toBool();
     m_MinimizeToTray = settings().value("minimizeToTray", false).toBool();
 }
 
@@ -180,6 +182,7 @@ void AppConfig::saveSettings()
     settings().setValue("autoConfigPrompted", m_AutoConfigPrompted);
     settings().setValue("cryptoEnabled", m_CryptoEnabled);
     settings().setValue("autoHide", m_AutoHide);
+    settings().setValue("autoStart", m_AutoStart);
     settings().setValue("minimizeToTray", m_MinimizeToTray);
     settings().sync();
 }
@@ -225,6 +228,10 @@ bool AppConfig::getCryptoEnabled() const { return m_CryptoEnabled; }
 void AppConfig::setAutoHide(bool b) { m_AutoHide = b; }
 
 bool AppConfig::getAutoHide() { return m_AutoHide; }
+
+void AppConfig::setAutoStart(bool b) { m_AutoStart = b; }
+
+bool AppConfig::getAutoStart() { return m_AutoStart; }
 
 void AppConfig::setMinimizeToTray(bool b) { m_MinimizeToTray = b; }
 

--- a/src/gui/src/AppConfig.h
+++ b/src/gui/src/AppConfig.h
@@ -94,6 +94,9 @@ class AppConfig: public QObject
         void setAutoHide(bool b);
         bool getAutoHide();
 
+        void setAutoStart(bool b);
+        bool getAutoStart();
+
         void setMinimizeToTray(bool b);
         bool getMinimizeToTray();
 
@@ -130,6 +133,7 @@ protected:
         bool m_AutoConfigPrompted;
         bool m_CryptoEnabled;
         bool m_AutoHide;
+        bool m_AutoStart;
         bool m_MinimizeToTray;
 
         static const char m_BarriersName[];

--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -201,7 +201,7 @@ void MainWindow::open()
     // only start if user has previously started. this stops the gui from
     // auto hiding before the user has configured barrier (which of course
     // confuses first time users, who think barrier has crashed).
-    if (appConfig().startedBefore() && appConfig().processMode() == Desktop) {
+    if (appConfig().startedBefore() && appConfig().getAutoStart()) {
         m_SuppressEmptyServerWarning = true;
         startBarrier();
         m_SuppressEmptyServerWarning = false;

--- a/src/gui/src/SettingsDialog.cpp
+++ b/src/gui/src/SettingsDialog.cpp
@@ -48,6 +48,7 @@ SettingsDialog::SettingsDialog(QWidget* parent, AppConfig& config) :
     m_pLineEditLogFilename->setText(appConfig().logFilename());
     setIndexFromItemData(m_pComboLanguage, appConfig().language());
     m_pCheckBoxAutoHide->setChecked(appConfig().getAutoHide());
+    m_pCheckBoxAutoStart->setChecked(appConfig().getAutoStart());
     m_pCheckBoxMinimizeToTray->setChecked(appConfig().getMinimizeToTray());
     m_pCheckBoxEnableCrypto->setChecked(m_appConfig.getCryptoEnabled());
 
@@ -72,6 +73,7 @@ void SettingsDialog::accept()
     m_appConfig.setLanguage(m_pComboLanguage->itemData(m_pComboLanguage->currentIndex()).toString());
     m_appConfig.setElevateMode(static_cast<ElevateMode>(m_pComboElevate->currentIndex()));
     m_appConfig.setAutoHide(m_pCheckBoxAutoHide->isChecked());
+    m_appConfig.setAutoStart(m_pCheckBoxAutoStart->isChecked());
     m_appConfig.setMinimizeToTray(m_pCheckBoxMinimizeToTray->isChecked());
     m_appConfig.saveSettings();
     QDialog::accept();

--- a/src/gui/src/SettingsDialogBase.ui
+++ b/src/gui/src/SettingsDialogBase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>368</width>
-    <height>380</height>
+    <height>428</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -123,6 +123,13 @@
        <widget class="QCheckBox" name="m_pCheckBoxAutoHide">
         <property name="text">
          <string>&amp;Hide on startup</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QCheckBox" name="m_pCheckBoxAutoStart">
+        <property name="text">
+         <string>Start &amp;Barrier on startup</string>
         </property>
        </widget>
       </item>
@@ -322,6 +329,7 @@
   <tabstop>m_pComboElevate</tabstop>
   <tabstop>m_pCheckBoxMinimizeToTray</tabstop>
   <tabstop>m_pCheckBoxAutoHide</tabstop>
+  <tabstop>m_pCheckBoxAutoStart</tabstop>
   <tabstop>m_pSpinBoxPort</tabstop>
   <tabstop>m_pLineEditInterface</tabstop>
   <tabstop>m_pCheckBoxEnableCrypto</tabstop>


### PR DESCRIPTION
Add a new auto start setting to GUI (defaults to false)

client/server only start on GUI start if this is set to true
(Previously, only client would auto start, and server wouldn't start at all)