### PR TITLE
Disable wayland support in the snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -45,6 +45,7 @@ parts:
       - "-DCMAKE_INSTALL_PREFIX=/usr"
       - "-DCMAKE_BUILD_TYPE=Release"
     build-packages:
+      - build-essential
       - xorg-dev
       - libcurl4-openssl-dev
       - libavahi-compat-libdnssd-dev

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,6 +11,8 @@ license: GPL-2.0
 apps:
   barrier:
     command: desktop-launch barrier #first run might take longer
+    environment:
+      DISABLE_WAYLAND: 1
     desktop: usr/share/applications/barrier.desktop
     common-id: com.github.debauchee.barrier
     plugs: &plugs

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,6 +12,7 @@ apps:
   barrier:
     command: desktop-launch barrier #first run might take longer
     environment:
+      # Fallback to XWayland if running in a Wayland session.
       DISABLE_WAYLAND: 1
     desktop: usr/share/applications/barrier.desktop
     common-id: com.github.debauchee.barrier


### PR DESCRIPTION
Installed `plasma-workspace-wayland`, now the `barrier` snap crashes on start on X11 (!) with:

```
This application failed to start because it could not find or load the Qt platform plugin "wayland-egl"
in "".

Available platform plugins are: eglfs, linuxfb, minimal, minimalegl, offscreen, vnc, xcb.

Reinstalling the application may fix this problem.
```

Reproduced on Ubuntu 18.04 and Ubuntu 20.04.

This just completely disables any native wayland support and allows the app to start on X11. Afaik, [this is a known issue with snaps, and this is the "common" workaround](https://forum.snapcraft.io/t/problem-launching-qt-snaps-in-wayland/7055/2).

I think enabling proper wayland support should start by adding `qtwayland5` to `stage-packages`.

Additionally, make sure the minimum basic tools for building are installed (not an issue in Launchpad build farm, but helps on any desktop pc with no `g++`).