### PR TITLE
Fix infinite loop on fast TCP disconnection

### DIFF
--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -761,7 +761,7 @@ MultiplexerJobStatus SecureSocket::serviceConnect(ISocketMultiplexerJob* job,
     // If status > 0, success
     if (status > 0) {
         sendEvent(m_events->forIDataSocket().secureConnected());
-        return {true, newJob()};
+        return newJobOrStopServicing();
     }
 
     // Retry case
@@ -793,7 +793,7 @@ MultiplexerJobStatus SecureSocket::serviceAccept(ISocketMultiplexerJob* job,
     // If status > 0, success
     if (status > 0) {
         sendEvent(m_events->forClientListener().accepted());
-        return {true, newJob()};
+        return newJobOrStopServicing();
     }
 
     // Retry case

--- a/src/lib/net/TCPSocket.h
+++ b/src/lib/net/TCPSocket.h
@@ -76,7 +76,8 @@ protected:
 
     void removeJob();
     void setJob(std::unique_ptr<ISocketMultiplexerJob>&& job);
-    
+    MultiplexerJobStatus newJobOrStopServicing();
+
     bool                isReadable() { return m_readable; }
     bool                isWritable() { return m_writable; }
 


### PR DESCRIPTION
The commit a841b28 changed the condition for removing job from processing.
New flag MultiplexerJobStatus::continue_servicing become used
instead of checking pointer for NULL.
However for cases when TCPSocket::newJob() returns nullptr
the behaviour changed: earlier the job was removed, but after change
it is called again, since MultiplexerJobStatus equal to {true, nullptr}
means "run this job again".

This leads to problem with eating CPU and RAM on linux
https://github.com/debauchee/barrier/issues/470

There is similar windows problem, but not sure it is related.
https://github.com/debauchee/barrier/issues/552

Since it looks that the goal of a841b28 was only clarifying
object ownership and not changing job deletion behaviour,
this commit tries to get original behaviour and fix the bugs above
by returning {false, nullptr} instead of {true, nullptr}
when TCPSocket::newJob() returns nullptr.