### PR TITLE
Only require Qt5 when building the GUI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,12 +357,6 @@ else()
     set (OPENSSL_LIBS ${lib_ssl} ${lib_crypto})
 endif()
 
-
-# Check we have the *required* Qt5 libs.
-find_package(Qt5Core REQUIRED)
-find_package(Qt5Network REQUIRED)
-find_package(Qt5Widgets REQUIRED)
-
 #
 # Configure_file... but for directories, recursively.
 #

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required (VERSION 3.4)
 
-find_package (Qt5 COMPONENTS Core Widgets Network)
+find_package (Qt5 REQUIRED COMPONENTS Core Widgets Network)
 set (CMAKE_AUTOMOC ON)
 set (CMAKE_AUTORCC ON)
 set (CMAKE_AUTOUIC ON)


### PR DESCRIPTION
Commit 6c888437 made Qt5 mandatory for all builds when it is only required for the GUI. There's already a `find_package` call in src/gui, it just needed the `REQUIRED` flag to be added.