### PR TITLE
Use macdeployqt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -400,7 +400,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
     configure_files (${BARRIER_BUNDLE_SOURCE_DIR} ${BARRIER_BUNDLE_DIR})
 
-    add_custom_target(Barrier_dmg ALL
+    add_custom_target(Barrier_MacOS ALL
                       bash build_dist.sh
                       DEPENDS barrier barriers barrierc
                       WORKING_DIRECTORY ${BARRIER_BUNDLE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -400,12 +400,10 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
     configure_files (${BARRIER_BUNDLE_SOURCE_DIR} ${BARRIER_BUNDLE_DIR})
 
-    if (CMAKE_BUILD_TYPE STREQUAL "Release")
-        add_custom_target(Barrier_dmg ALL
-                          bash build_installer.sh
-                          DEPENDS barrier barriers barrierc
-                          WORKING_DIRECTORY ${BARRIER_BUNDLE_DIR})
-    endif()
+    add_custom_target(Barrier_dmg ALL
+                      bash build_dist.sh
+                      DEPENDS barrier barriers barrierc
+                      WORKING_DIRECTORY ${BARRIER_BUNDLE_DIR})
 endif()
 
 #

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,11 +82,16 @@ jobs:
       Release:
         B_BUILD_TYPE: Release
         BARRIER_VERSION_STAGE: Release
+  variables:
+    VERBOSE: 1
+    TERM: xterm-256color
   steps:
-    - script: brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/aac86fc018c48d7b6f23a2e7535276899774567a/Formula/qt.rb
-      displayName: Installed Pinned Qt
-    - script: brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/aac86fc018c48d7b6f23a2e7535276899774567a/Formula/openssl.rb
-      displayName: Installed Pinned OpenSSL
+    - script: rm -rf /usr/local/opt/openssl
+      displayName: Remove incompatible OpenSSL 1.0.2t from macOS-10.14 vmImage
+    - script: brew reinstall openssl
+      displayName: Installed newer OpenSSL 1.1.x
+    - script: brew install pkg-config qt5
+      displayName: Install Qt5 and pkg-config prereqs
     - script: sh -x ./clean_build.sh
       displayName: Clean Build
     - task: PublishBuildArtifacts@1

--- a/dist/macos/bundle/build_dist.sh.in
+++ b/dist/macos/bundle/build_dist.sh.in
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+# Use the same verbose variable as CMake
+[ "$VERBOSE" == "1" ] && set -x
+
+# Exit on unset variables or pipe errors
+set -uo pipefail
+
+B_MACOS="Barrier.app/Contents/MacOS"
+B_VERSION="@BARRIER_VERSION@"
+B_BINDIR="@CMAKE_RUNTIME_OUTPUT_DIRECTORY@"
+B_BUILDTYPE="@CMAKE_BUILD_TYPE@"
+
+# Colorized output
+function info() { tput bold; echo "$@" ; tput sgr0 ;}
+function error() { tput bold; tput setaf 1; echo "$@"; tput sgr0 ; }
+function success() { tput bold; tput setaf 2; echo "$@"; tput sgr0 ; }
+function warn() { tput bold; tput setaf 3; echo "$@"; tput sgr0 ; }
+
+info "Checking for bundle contents"
+if [ ! -d "Barrier.app/Contents" ]; then
+    error "Please make sure that the build completed successfully"
+    error "before trying to create the installer."
+    exit 1
+fi
+
+if [ -d "$B_MACOS" ]; then
+    info "Removing old binaries from bundle"
+    rm -r "$B_MACOS"
+fi
+
+info "Copying binaries into bundle"
+# Copy the folder instead of globbing unquoted path
+cp -r "$B_BINDIR" "$B_MACOS" || exit 1
+
+# Check for macdeployqt on MacPorts
+if which -s port ; then
+    info "MacPorts found, searching for macdeployqt"
+    DEPLOYQT="$(port contents qt5-qttools | grep --only --max-count 1 '/.*macdeployqt')"
+    if [ ! -x "$DEPLOYQT" ]; then
+        error Please install package qt5-qttools
+        exit 1
+    fi
+fi
+
+# Check for macdeployqt on Homebrew
+if which -s brew ; then
+    info "Homebrew found, searching for macdeployqt"
+    DEPLOYQT="$(brew list qt | grep --only --max-count 1 '/.*macdeployqt')"
+    if [ ! -x "$DEPLOYQT" ]; then
+        error Please install package qt
+        exit 1
+    fi
+fi
+
+# Use macdeployqt to include libraries and create dmg
+if [ "$B_BUILDTYPE" == "Release" ]; then
+    info "Building Release disk image (dmg)"
+    "$DEPLOYQT" Barrier.app -dmg || exit 1
+    mv "Barrier.dmg" "Barrier-$B_VERSION.dmg" || exit 1
+    success "Created Barrier-$B_VERSION.dmg"
+else
+    warn "Disk image (dmg) only created for Release builds"
+    info "Building debug bundle"
+    "$DEPLOYQT" Barrier.app -use-debug-libs -no-strip || exit 1
+    success "Bundle created successfully"
+fi

--- a/dist/macos/bundle/build_dist.sh.in
+++ b/dist/macos/bundle/build_dist.sh.in
@@ -46,7 +46,7 @@ fi
 # Check for macdeployqt on Homebrew
 if which -s brew ; then
     info "Homebrew found, searching for macdeployqt"
-    DEPLOYQT="$(brew list qt | grep --only --max-count 1 '/.*macdeployqt')"
+    DEPLOYQT="$(brew list qt | grep --only '/.*macdeployqt' | head -1)"
     if [ ! -x "$DEPLOYQT" ]; then
         error Please install package qt
         exit 1

--- a/dist/macos/bundle/build_dist.sh.in
+++ b/dist/macos/bundle/build_dist.sh.in
@@ -10,6 +10,8 @@ B_MACOS="Barrier.app/Contents/MacOS"
 B_VERSION="@BARRIER_VERSION@"
 B_BINDIR="@CMAKE_RUNTIME_OUTPUT_DIRECTORY@"
 B_BUILDTYPE="@CMAKE_BUILD_TYPE@"
+B_BARRIERC="Barrier.app/Contents/MacOS/barrierc"
+B_BARRIERS="Barrier.app/Contents/MacOS/barriers"
 
 # Colorized output
 function info() { tput bold; echo "$@" ; tput sgr0 ;}
@@ -56,12 +58,16 @@ fi
 # Use macdeployqt to include libraries and create dmg
 if [ "$B_BUILDTYPE" == "Release" ]; then
     info "Building Release disk image (dmg)"
-    "$DEPLOYQT" Barrier.app -dmg || exit 1
+    "$DEPLOYQT" Barrier.app -dmg \
+    -executable="$B_BARRIERC" \
+    -executable="$B_BARRIERS" || exit 1
     mv "Barrier.dmg" "Barrier-$B_VERSION.dmg" || exit 1
     success "Created Barrier-$B_VERSION.dmg"
 else
     warn "Disk image (dmg) only created for Release builds"
     info "Building debug bundle"
-    "$DEPLOYQT" Barrier.app -use-debug-libs -no-strip || exit 1
+    "$DEPLOYQT" Barrier.app -no-strip \
+    -executable="$B_BARRIERC" \
+    -executable="$B_BARRIERS" || exit 1
     success "Bundle created successfully"
 fi

--- a/dist/macos/bundle/build_installer.sh.in
+++ b/dist/macos/bundle/build_installer.sh.in
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+# add warning for users running manually
+function warn() { tput bold; tput setaf 3; echo "$@"; tput sgr0 ; }
+warn "The scripts build_installer.sh and reref_dylibs.sh have been deprecated."
+warn "Please use build_dist.sh instead to deploy using macdeployqt"
+
 # change this to rename the installer package
 B_DMG="Barrier-@BARRIER_VERSION@.dmg"
 

--- a/dist/macos/bundle/reref_dylibs.sh
+++ b/dist/macos/bundle/reref_dylibs.sh
@@ -3,6 +3,12 @@
 # $1 = binary (program or dylib)
 B_TARGET=$1
 if [ "x$B_TARGET" = "x" ]; then
+
+    # add warning for users running manually
+    function warn() { tput bold; tput setaf 3; echo "$@"; tput sgr0 ; }
+    warn "The scripts build_installer.sh and reref_dylibs.sh have been deprecated."
+    warn "Please use build_dist.sh instead to deploy using macdeployqt"
+
     echo Which binary needs to be re-referenced?
     exit 1
 fi


### PR DESCRIPTION
Making a release was failing with both Homebrew and MacPorts on Mojave. The compiled binary would run successfully, but the resulting `.app` bundle from running `build_installer.sh` (which runs `reref_dylibs.sh` and builds the `.app` bundle) was giving SEGFAULT 11 when executed.

This pull request replaces `build_installer.sh` with `build_dist.sh` that runs the Qt toolkit's `macdeployqt` which is included with the Qt on both MacPorts and Homebrew. It builds the distributable bundle and creates the `dmg` if it is a Release build.

The previous scripts have been left in place with deprecation warnings in case they are still needed by older versions of MacOS.

It also removes the `if` condition in CMake that prevents building a bundle on Debug releases.