### PR TITLE
Fix TIS/TSM in logs

### DIFF
--- a/src/cmd/barriers/barriers.cpp
+++ b/src/cmd/barriers/barriers.cpp
@@ -38,6 +38,13 @@ main(int argc, char** argv)
     // record window instance for tray icon, etc
     ArchMiscWindows::setInstanceWin32(GetModuleHandle(NULL));
 #endif
+
+#ifdef __APPLE__
+	/* Silence "is calling TIS/TSM in non-main thread environment" as it is a red
+	herring that causes a lot of issues to be filed for the MacOS client/server.
+	*/
+	setenv("OS_ACTIVITY_DT_MODE", "NO", true);
+#endif
     
     Arch arch;
     arch.init();

--- a/src/cmd/barriers/barriers.cpp
+++ b/src/cmd/barriers/barriers.cpp
@@ -40,10 +40,10 @@ main(int argc, char** argv)
 #endif
 
 #ifdef __APPLE__
-	/* Silence "is calling TIS/TSM in non-main thread environment" as it is a red
-	herring that causes a lot of issues to be filed for the MacOS client/server.
-	*/
-	setenv("OS_ACTIVITY_DT_MODE", "NO", true);
+    /* Silence "is calling TIS/TSM in non-main thread environment" as it is a red
+    herring that causes a lot of issues to be filed for the MacOS client/server.
+    */
+    setenv("OS_ACTIVITY_DT_MODE", "NO", true);
 #endif
     
     Arch arch;


### PR DESCRIPTION
Silences the "is calling TIS/TSM in non-main thread environment" messages in the log when running a MacOS server as it is a red herring that causes a lot of issues to be filed. The messages are silenced by setting the `OS_ACTIVITY_DT_MODE` environment variable to `NO`.

Image of logs before:
<img width="1553" alt="before-setenv-OS_ACTIVITY_DT_MODE" src="https://user-images.githubusercontent.com/35010457/81039650-7e953880-8e5e-11ea-96e6-c5eacbf43d4a.png">

Image of logs after:
<img width="992" alt="after-setenv-OS_ACTIVITY_DT_MODE" src="https://user-images.githubusercontent.com/35010457/81039657-8228bf80-8e5e-11ea-888d-75c7de22a66c.png">

Example issues that include mentions of TIS/TSM where it was not an issue:
#643, #599, #563, #532, #393, #232, #212, #112

This error comes from text input being handled by `barriers` which is another thread from the main `barrier` application. More info about [Text Input Manager (TIS) & Text Services Manager TSM can be found here](https://developer.apple.com/library/archive/documentation/Carbon/Conceptual/UnderstandTextInput_TSM/tinptsm_intro/tinptsm_intro.html#//apple_ref/doc/uid/TP40000957)