### PR TITLE
macos: Allow WARN/ERROR to report running status

### DIFF
--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -381,7 +381,8 @@ void MainWindow::checkConnected(const QString& line)
     // TODO: implement ipc connection state messages to replace this hack.
     if (line.contains("started server") ||
         line.contains("connected to server") ||
-        line.contains("server status: active"))
+        line.contains("server status: active") ||
+        line.contains("starting cocoa loop"))
     {
         setBarrierState(barrierConnected);
 


### PR DESCRIPTION
update the hack of reading the log to detect running on macOS when using loglevel or warning or error

Resolves #652 and possibly #516