### PR TITLE
Elevate XSocketAddressInUse to ERROR

### DIFF
--- a/src/lib/barrier/ServerApp.cpp
+++ b/src/lib/barrier/ServerApp.cpp
@@ -560,10 +560,10 @@ ServerApp::startServer()
         return true;
     }
     catch (XSocketAddressInUse& e) {
-        LOG((CLOG_WARN "cannot listen for clients: %s", e.what()));
+        LOG((CLOG_ERR "cannot listen for clients: %s", e.what()));
         closeClientListener(listener);
         updateStatus(String("cannot listen for clients: ") + e.what());
-        retryTime = 10.0;
+        retryTime = 1.0;
     }
     catch (XBase& e) {
         LOG((CLOG_CRIT "failed to start server: %s", e.what()));


### PR DESCRIPTION
Errors where the socket address is in use will keep the server from connecting with clients. This should be reported as an ERROR instead of a warning. Also, if the retry time is shorter issues will be more obvious, since the error will cause the log to scroll visibly.

Related discussions #516, #652, #654