### PR TITLE
Fixes high cpu usage spikes on win10

### DIFF
--- a/src/lib/base/EventQueue.cpp
+++ b/src/lib/base/EventQueue.cpp
@@ -436,12 +436,6 @@ EventQueue::removeHandlers(void* target)
     }
 }
 
-bool
-EventQueue::isEmpty() const
-{
-    return (m_buffer->isEmpty() && getNextTimerTimeout() != 0.0);
-}
-
 IEventJob*
 EventQueue::getHandler(Event::Type type, void* target) const
 {

--- a/src/lib/base/EventQueue.h
+++ b/src/lib/base/EventQueue.h
@@ -58,7 +58,6 @@ public:
     virtual void        removeHandlers(void* target);
     virtual Event::Type
                         registerTypeOnce(Event::Type& type, const char* name);
-    virtual bool        isEmpty() const;
     virtual IEventJob*    getHandler(Event::Type type, void* target) const;
     virtual const char*    getTypeName(Event::Type type);
     virtual Event::Type

--- a/src/lib/base/IEventQueue.h
+++ b/src/lib/base/IEventQueue.h
@@ -189,13 +189,6 @@ public:
     //! @name accessors
     //@{
 
-    //! Test if queue is empty
-    /*!
-    Returns true iff the queue has no events in it, including timer
-    events.
-    */
-    virtual bool        isEmpty() const = 0;
-
     //! Get an event handler
     /*!
     Finds and returns the event handler for the \p type, \p target pair

--- a/src/lib/platform/MSWindowsEventQueueBuffer.h
+++ b/src/lib/platform/MSWindowsEventQueueBuffer.h
@@ -47,4 +47,5 @@ private:
     MSG                    m_event;
     UINT                m_daemonQuit;
     IEventQueue*        m_events;
+    UINT                m_os_supported_message_types;
 };


### PR DESCRIPTION
Using barrierc on windows10 I noticed that sometimes but quite often, say 1 times of 5 opens of a task manager (even when server is offline) it begins utilizing 100% of a cpu core.

Fixes high cpu usage spikes on win10.
When queue was containing messages of only non-QS_POSTMESSAGE type the
"while (m_buffer->isEmpty())" busy-looped in EventQueue::getEvent
since isEmpty was true (checked only QS_POSTMESSAGE message type),
but waitForEvent returned immediately (checked more message types).

Investigation shows that the difference was introduced in
https://github.com/debauchee/barrier/commit/dbfb04a6e
to fix a problem with bad behaviour of GetQueueStatus
Researching showed that a similar problem was fixed in Qt,
and the solution was
"pass different flags to GetQueueStatus depending on version of windows"
https://bugreports.qt.io/browse/QTBUG-29097

So this patch makes changes to a barrier non-GUI core similar to Qt fix.

Unfortunately I'm not using barrier often now, so only basic tests were performed and only windows as a client, not as a server.

However, this PR is created since the problem may be common, so more testers may appear)