### PR TITLE
Allow selecting Fingerprint Qlabel

### DIFF
--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -956,6 +956,7 @@ void MainWindow::updateSSLFingerprint()
     }
     if (m_AppConfig->getCryptoEnabled() && Fingerprint::local().fileExists()) {
         m_pLabelLocalFingerprint->setText(Fingerprint::local().readFirst());
+        m_pLabelLocalFingerprint->setTextInteractionFlags(Qt::TextSelectableByMouse);
     } else {
         m_pLabelLocalFingerprint->setText("Disabled");
     }


### PR DESCRIPTION
Setting the Fingerprint label to TextSelectableByMouse allows users to copy/paste the fingerprint so it can be easily added to "TrustedServers.txt" on a client machine (i.e. via SSH).

Every time I setup a barrier server or client I try to copy and paste the fingerprint and remember that it's not selectable. I'm sure there are probably other people that would like it to be selectable as well.