### PR TITLE
Change log level on several status messages (Fixes #652, Fixes #516)

### DIFF
--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -345,7 +345,9 @@ void MainWindow::logError()
 
 void MainWindow::appendLogInfo(const QString& text)
 {
-    m_pLogWindow->appendInfo(text);
+    if (appConfig().logLevel() >= 3) {
+        m_pLogWindow->appendInfo(text);
+    }
 }
 
 void MainWindow::appendLogDebug(const QString& text) {
@@ -536,10 +538,7 @@ void MainWindow::startBarrier()
 
     qDebug() << args;
 
-    // show command if debug log level...
-    if (appConfig().logLevel() >= 4) {
-        appendLogInfo(QString("command: %1 %2").arg(app, args.join(" ")));
-    }
+    appendLogDebug(QString("command: %1 %2").arg(app, args.join(" ")));
 
     appendLogInfo("config file: " + configFilename());
     appendLogInfo("log level: " + appConfig().logLevelText());

--- a/src/lib/barrier/ClientApp.cpp
+++ b/src/lib/barrier/ClientApp.cpp
@@ -282,7 +282,7 @@ ClientApp::scheduleClientRestart(double retryTime)
 void
 ClientApp::handleClientConnected(const Event&, void*)
 {
-    LOG((CLOG_NOTE "connected to server"));
+    LOG((CLOG_PRINT "connected to server"));
     resetRestartTimeout();
     updateStatus();
 }

--- a/src/lib/barrier/ServerApp.cpp
+++ b/src/lib/barrier/ServerApp.cpp
@@ -555,7 +555,7 @@ ServerApp::startServer()
         m_server->setListener(listener);
         m_listener = listener;
         updateStatus();
-        LOG((CLOG_NOTE "started server (%s), waiting for clients", family));
+        LOG((CLOG_PRINT "started server (%s), waiting for clients", family));
         m_serverState = kStarted;
         return true;
     }

--- a/src/lib/barrier/win32/DaemonApp.cpp
+++ b/src/lib/barrier/win32/DaemonApp.cpp
@@ -353,7 +353,7 @@ DaemonApp::handleIpcMessage(const Event& e, void*)
             LOG((CLOG_DEBUG "ipc hello, type=%s", type.c_str()));
 
             const char * serverstatus = m_watchdog->isProcessActive() ? "active" : "not active";
-            LOG((CLOG_INFO "server status: %s", serverstatus));
+            LOG((CLOG_PRINT "server status: %s", serverstatus));
 
             m_ipcLogOutputter->notifyBuffer();
             break;


### PR DESCRIPTION
This changes the log level for several statuses (started server, connected to server, server status:) from CLOG_NOTE or CLOG_INFO to CLOG_PRINT so they will be printed to stdout regardless of the log level. This allows the GUI to accurately report the status of the `barriers` or `barrierc` processes in [MainWindow.cpp#L379-L399](https://github.com/debauchee/barrier/blob/master/src/gui/src/MainWindow.cpp#L379-L399)

Until the IPC connection state messages are implemented this should fix any issues with the GUI not reporting the correct status.

Example output with this change running `barriers` (and ignoring TIS/TSM #653)
```
./build/bin/barriers -f --no-tray --debug WARNING --name <hostname> --enable-drag-drop --enable-crypto -c  <config>  --address :24800 2>&1 | egrep -v TSM
started server (IPv4/IPv6), waiting for clients
```