### PR TITLE
XWindowsEventQueueBuffer: Fix delays when waiting for new events

### DIFF
--- a/src/lib/platform/XWindowsEventQueueBuffer.h
+++ b/src/lib/platform/XWindowsEventQueueBuffer.h
@@ -51,6 +51,8 @@ public:
 private:
     void                flush();
 
+    int getPendingCountLocked();
+
 private:
     typedef std::vector<XEvent> EventList;
      IXWindowsImpl*       m_impl;


### PR DESCRIPTION
Fixes #617, #298, #58, https://github.com/symless/synergy-core/issues/6487.

This PR fixes intermittent waits on Linux client. These were caused by the wait loop in `XWindowsEventQueueBuffer` where we wait for new events. The problem was that we use `QLength()` to check if there are new events coming from the X11 server. This is insufficient, because it checks only for messages that the XLib already knows about.

Consider the situation when we have no pending events at all and we enter the wait loop. An event arrives in the socket, we are woken up and go on to check `QLength()`. It will return 0, because the socket itself was not read by XLib. If we call XPending() instead, the socket would be read as we expect, the event would become visible to XLib, XPending() would return nonzero value and we would exit the event loop.

Tested for a couple of days, did not see problems on my local workstation. The fix need further testing, maybe there are other related issues that I have not noticed.