### PR TITLE
Fix Auto config missing hostname prompt #704

### DIFF
--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -595,9 +595,7 @@ bool MainWindow::clientArgs(QStringList& args, QString& app)
             args << "[" + serverIp + "]:" + QString::number(appConfig().port());
             return true;
         }
-    }
-
-    if (m_pLineEditHostname->text().isEmpty()) {
+    } else if (m_pLineEditHostname->text().isEmpty()) {
         show();
         if (!m_SuppressEmptyServerWarning) {
             QMessageBox::warning(this, tr("Hostname is empty"),


### PR DESCRIPTION
I think this might fix the prompt for a missing hostname when auto config is checked