### PR TITLE
gui: Use enum class to scope enum values

### DIFF
--- a/src/gui/src/BaseConfig.h
+++ b/src/gui/src/BaseConfig.h
@@ -26,61 +26,97 @@
 
 class BaseConfig
 {
-    public:
-        enum Modifier { DefaultMod = -1, Shift, Ctrl, Alt, Meta, Super, None, NumModifiers };
-        enum SwitchCorner { TopLeft, TopRight, BottomLeft, BottomRight, NumSwitchCorners };
-        enum Fix { CapsLock, NumLock, ScrollLock, XTest, PreserveFocus, NumFixes };
+public:
+    enum class Modifier {
+        DefaultMod = -1,
+        Shift,
+        Ctrl,
+        Alt,
+        Meta,
+        Super,
+        None,
+        Count
+    };
+
+    enum class SwitchCorner {
+        TopLeft,
+        TopRight,
+        BottomLeft,
+        BottomRight,
+        Count
+    };
+
+    enum class Fix {
+        CapsLock,
+        NumLock,
+        ScrollLock,
+        XTest,
+        PreserveFocus,
+        Count
+    };
 
     protected:
         BaseConfig() {}
         virtual ~BaseConfig() {}
 
     protected:
-        template<typename T1, typename T2>
-        void readSettings(QSettings& settings, T1& array, const QString& arrayName, const T2& deflt)
+        template<class SettingType, class T>
+        void readSettings(QSettings& settings, QList<T>& array, const QString& arrayName,
+                          const T& deflt)
         {
             int entries = settings.beginReadArray(arrayName + "Array");
             array.clear();
             for (int i = 0; i < entries; i++)
             {
                 settings.setArrayIndex(i);
-                QVariant v = settings.value(arrayName, deflt);
-                array.append(v.value<T2>());
+                QVariant v = settings.value(arrayName, static_cast<SettingType>(deflt));
+                array.append(static_cast<T>(v.value<SettingType>()));
             }
             settings.endArray();
         }
 
-        template<typename T1, typename T2>
-        void readSettings(QSettings& settings, T1& array, const QString& arrayName, const T2& deflt, int entries)
+        template<class SettingType, class T>
+        void readSettings(QSettings& settings, QList<T>& array, const QString& arrayName,
+                          const T& deflt, int entries)
         {
             Q_ASSERT(array.size() >= entries);
             settings.beginReadArray(arrayName + "Array");
             for (int i = 0; i < entries; i++)
             {
                 settings.setArrayIndex(i);
-                QVariant v = settings.value(arrayName, deflt);
-                array[i] = v.value<T2>();
+                QVariant v = settings.value(arrayName, static_cast<SettingType>(deflt));
+                array[i] = static_cast<T>(v.value<SettingType>());
             }
             settings.endArray();
         }
 
-        template<typename T>
-        void writeSettings(QSettings& settings, const T& array, const QString& arrayName) const
+        template<class SettingType, class T>
+        void writeSettings(QSettings& settings, const QList<T>& array,
+                           const QString& arrayName) const
         {
             settings.beginWriteArray(arrayName + "Array");
             for (int i = 0; i < array.size(); i++)
             {
                 settings.setArrayIndex(i);
-                settings.setValue(arrayName, array[i]);
+                settings.setValue(arrayName, static_cast<SettingType>(array[i]));
             }
             settings.endArray();
         }
 
 
     public:
-        static const char* modifierName(int idx) { return m_ModifierNames[idx]; }
-        static const char* fixName(int idx) { return m_FixNames[idx]; }
-        static const char* switchCornerName(int idx) { return m_SwitchCornerNames[idx]; }
+        static const char* modifierName(Modifier idx)
+        {
+            return m_ModifierNames[static_cast<int>(idx)];
+        }
+        static const char* fixName(Fix idx)
+        {
+            return m_FixNames[static_cast<int>(idx)];
+        }
+        static const char* switchCornerName(SwitchCorner idx)
+        {
+            return m_SwitchCornerNames[static_cast<int>(idx)];
+        }
 
     private:
         static const char* m_ModifierNames[];

--- a/src/gui/src/Screen.h
+++ b/src/gui/src/Screen.h
@@ -50,12 +50,17 @@ class Screen : public BaseConfig
         const QStringList& aliases() const { return m_Aliases; }
 
         bool isNull() const { return m_Name.isEmpty(); }
-        int modifier(int m) const { return m_Modifiers[m] == DefaultMod ? m : m_Modifiers[m]; }
-        const QList<int>& modifiers() const { return m_Modifiers; }
-        bool switchCorner(int c) const { return m_SwitchCorners[c]; }
+        Modifier modifier(Modifier m) const
+        {
+            Modifier overriddenModifier = m_Modifiers[static_cast<int>(m)];
+            return overriddenModifier == Modifier::DefaultMod ? m : overriddenModifier;
+        }
+
+        const QList<Modifier>& modifiers() const { return m_Modifiers; }
+        bool switchCorner(SwitchCorner c) const { return m_SwitchCorners[static_cast<int>(c)]; }
         const QList<bool>& switchCorners() const { return m_SwitchCorners; }
         int switchCornerSize() const { return m_SwitchCornerSize; }
-        bool fix(Fix f) const { return m_Fixes[f]; }
+        bool fix(Fix f) const { return m_Fixes[static_cast<int>(f)]; }
         const QList<bool>& fixes() const { return m_Fixes; }
 
         void loadSettings(QSettings& settings);
@@ -73,13 +78,13 @@ class Screen : public BaseConfig
 
         void setPixmap(const QPixmap& pixmap) { m_Pixmap = pixmap; }
         QStringList& aliases() { return m_Aliases; }
-        void setModifier(int m, int n) { m_Modifiers[m] = n; }
-        QList<int>& modifiers() { return m_Modifiers; }
+        void setModifier(Modifier m, Modifier n) { m_Modifiers[static_cast<int>(m)] = n; }
+        QList<Modifier>& modifiers() { return m_Modifiers; }
         void addAlias(const QString& alias) { m_Aliases.append(alias); }
-        void setSwitchCorner(int c, bool on) { m_SwitchCorners[c] = on; }
+        void setSwitchCorner(SwitchCorner c, bool on) { m_SwitchCorners[static_cast<int>(c)] = on; }
         QList<bool>& switchCorners() { return m_SwitchCorners; }
         void setSwitchCornerSize(int val) { m_SwitchCornerSize = val; }
-        void setFix(int f, bool on) { m_Fixes[f] = on; }
+        void setFix(Fix f, bool on) { m_Fixes[static_cast<int>(f)] = on; }
         QList<bool>& fixes() { return m_Fixes; }
         void setSwapped(bool on) { m_Swapped = on; }
 
@@ -88,7 +93,7 @@ class Screen : public BaseConfig
         QString m_Name;
 
         QStringList m_Aliases;
-        QList<int> m_Modifiers;
+        QList<Modifier> m_Modifiers;
         QList<bool> m_SwitchCorners;
         int m_SwitchCornerSize;
         QList<bool> m_Fixes;

--- a/src/gui/src/ScreenSettingsDialog.cpp
+++ b/src/gui/src/ScreenSettingsDialog.cpp
@@ -52,23 +52,23 @@ ScreenSettingsDialog::ScreenSettingsDialog(QWidget* parent, Screen* pScreen) :
     for (int i = 0; i < m_pScreen->aliases().count(); i++)
         new QListWidgetItem(m_pScreen->aliases()[i], m_pListAliases);
 
-    m_pComboBoxShift->setCurrentIndex(m_pScreen->modifier(Screen::Shift));
-    m_pComboBoxCtrl->setCurrentIndex(m_pScreen->modifier(Screen::Ctrl));
-    m_pComboBoxAlt->setCurrentIndex(m_pScreen->modifier(Screen::Alt));
-    m_pComboBoxMeta->setCurrentIndex(m_pScreen->modifier(Screen::Meta));
-    m_pComboBoxSuper->setCurrentIndex(m_pScreen->modifier(Screen::Super));
+    m_pComboBoxShift->setCurrentIndex(static_cast<int>(m_pScreen->modifier(Screen::Modifier::Shift)));
+    m_pComboBoxCtrl->setCurrentIndex(static_cast<int>(m_pScreen->modifier(Screen::Modifier::Ctrl)));
+    m_pComboBoxAlt->setCurrentIndex(static_cast<int>(m_pScreen->modifier(Screen::Modifier::Alt)));
+    m_pComboBoxMeta->setCurrentIndex(static_cast<int>(m_pScreen->modifier(Screen::Modifier::Meta)));
+    m_pComboBoxSuper->setCurrentIndex(static_cast<int>(m_pScreen->modifier(Screen::Modifier::Super)));
 
-    m_pCheckBoxCornerTopLeft->setChecked(m_pScreen->switchCorner(Screen::TopLeft));
-    m_pCheckBoxCornerTopRight->setChecked(m_pScreen->switchCorner(Screen::TopRight));
-    m_pCheckBoxCornerBottomLeft->setChecked(m_pScreen->switchCorner(Screen::BottomLeft));
-    m_pCheckBoxCornerBottomRight->setChecked(m_pScreen->switchCorner(Screen::BottomRight));
+    m_pCheckBoxCornerTopLeft->setChecked(m_pScreen->switchCorner(Screen::SwitchCorner::TopLeft));
+    m_pCheckBoxCornerTopRight->setChecked(m_pScreen->switchCorner(Screen::SwitchCorner::TopRight));
+    m_pCheckBoxCornerBottomLeft->setChecked(m_pScreen->switchCorner(Screen::SwitchCorner::BottomLeft));
+    m_pCheckBoxCornerBottomRight->setChecked(m_pScreen->switchCorner(Screen::SwitchCorner::BottomRight));
     m_pSpinBoxSwitchCornerSize->setValue(m_pScreen->switchCornerSize());
 
-    m_pCheckBoxCapsLock->setChecked(m_pScreen->fix(Screen::CapsLock));
-    m_pCheckBoxNumLock->setChecked(m_pScreen->fix(Screen::NumLock));
-    m_pCheckBoxScrollLock->setChecked(m_pScreen->fix(Screen::ScrollLock));
-    m_pCheckBoxXTest->setChecked(m_pScreen->fix(Screen::XTest));
-    m_pCheckBoxPreserveFocus->setChecked(m_pScreen->fix(Screen::PreserveFocus));
+    m_pCheckBoxCapsLock->setChecked(m_pScreen->fix(Screen::Fix::CapsLock));
+    m_pCheckBoxNumLock->setChecked(m_pScreen->fix(Screen::Fix::NumLock));
+    m_pCheckBoxScrollLock->setChecked(m_pScreen->fix(Screen::Fix::ScrollLock));
+    m_pCheckBoxXTest->setChecked(m_pScreen->fix(Screen::Fix::XTest));
+    m_pCheckBoxPreserveFocus->setChecked(m_pScreen->fix(Screen::Fix::PreserveFocus));
 }
 
 void ScreenSettingsDialog::accept()
@@ -100,23 +100,28 @@ void ScreenSettingsDialog::accept()
         m_pScreen->addAlias(alias);
     }
 
-    m_pScreen->setModifier(Screen::Shift, m_pComboBoxShift->currentIndex());
-    m_pScreen->setModifier(Screen::Ctrl, m_pComboBoxCtrl->currentIndex());
-    m_pScreen->setModifier(Screen::Alt, m_pComboBoxAlt->currentIndex());
-    m_pScreen->setModifier(Screen::Meta, m_pComboBoxMeta->currentIndex());
-    m_pScreen->setModifier(Screen::Super, m_pComboBoxSuper->currentIndex());
+    m_pScreen->setModifier(Screen::Modifier::Shift,
+                           static_cast<Screen::Modifier>(m_pComboBoxShift->currentIndex()));
+    m_pScreen->setModifier(Screen::Modifier::Ctrl,
+                           static_cast<Screen::Modifier>(m_pComboBoxCtrl->currentIndex()));
+    m_pScreen->setModifier(Screen::Modifier::Alt,
+                           static_cast<Screen::Modifier>(m_pComboBoxAlt->currentIndex()));
+    m_pScreen->setModifier(Screen::Modifier::Meta,
+                           static_cast<Screen::Modifier>(m_pComboBoxMeta->currentIndex()));
+    m_pScreen->setModifier(Screen::Modifier::Super,
+                           static_cast<Screen::Modifier>(m_pComboBoxSuper->currentIndex()));
 
-    m_pScreen->setSwitchCorner(Screen::TopLeft, m_pCheckBoxCornerTopLeft->isChecked());
-    m_pScreen->setSwitchCorner(Screen::TopRight, m_pCheckBoxCornerTopRight->isChecked());
-    m_pScreen->setSwitchCorner(Screen::BottomLeft, m_pCheckBoxCornerBottomLeft->isChecked());
-    m_pScreen->setSwitchCorner(Screen::BottomRight, m_pCheckBoxCornerBottomRight->isChecked());
+    m_pScreen->setSwitchCorner(Screen::SwitchCorner::TopLeft, m_pCheckBoxCornerTopLeft->isChecked());
+    m_pScreen->setSwitchCorner(Screen::SwitchCorner::TopRight, m_pCheckBoxCornerTopRight->isChecked());
+    m_pScreen->setSwitchCorner(Screen::SwitchCorner::BottomLeft, m_pCheckBoxCornerBottomLeft->isChecked());
+    m_pScreen->setSwitchCorner(Screen::SwitchCorner::BottomRight, m_pCheckBoxCornerBottomRight->isChecked());
     m_pScreen->setSwitchCornerSize(m_pSpinBoxSwitchCornerSize->value());
 
-    m_pScreen->setFix(Screen::CapsLock, m_pCheckBoxCapsLock->isChecked());
-    m_pScreen->setFix(Screen::NumLock, m_pCheckBoxNumLock->isChecked());
-    m_pScreen->setFix(Screen::ScrollLock, m_pCheckBoxScrollLock->isChecked());
-    m_pScreen->setFix(Screen::XTest, m_pCheckBoxXTest->isChecked());
-    m_pScreen->setFix(Screen::PreserveFocus, m_pCheckBoxPreserveFocus->isChecked());
+    m_pScreen->setFix(Screen::Fix::CapsLock, m_pCheckBoxCapsLock->isChecked());
+    m_pScreen->setFix(Screen::Fix::NumLock, m_pCheckBoxNumLock->isChecked());
+    m_pScreen->setFix(Screen::Fix::ScrollLock, m_pCheckBoxScrollLock->isChecked());
+    m_pScreen->setFix(Screen::Fix::XTest, m_pCheckBoxXTest->isChecked());
+    m_pScreen->setFix(Screen::Fix::PreserveFocus, m_pCheckBoxPreserveFocus->isChecked());
 
     QDialog::accept();
 }

--- a/src/gui/src/ServerConfig.cpp
+++ b/src/gui/src/ServerConfig.cpp
@@ -88,8 +88,9 @@ void ServerConfig::init()
     screens().clear();
 
     // m_NumSwitchCorners is used as a fixed size array. See Screen::init()
-    for (int i = 0; i < NumSwitchCorners; i++)
+    for (int i = 0; i < static_cast<int>(SwitchCorner::Count); i++) {
         switchCorners() << false;
+    }
 
     // There must always be screen objects for each cell in the screens QList. Unused screens
     // are identified by having an empty name.
@@ -119,7 +120,7 @@ void ServerConfig::saveSettings()
     settings().setValue("enableDragAndDrop", enableDragAndDrop());
     settings().setValue("clipboardSharing", clipboardSharing());
 
-    writeSettings(settings(), switchCorners(), "switchCorner");
+    writeSettings<bool>(settings(), switchCorners(), "switchCorner");
 
     settings().beginWriteArray("screens");
     for (int i = 0; i < screens().size(); i++)
@@ -164,7 +165,8 @@ void ServerConfig::loadSettings()
     setEnableDragAndDrop(settings().value("enableDragAndDrop", true).toBool());
     setClipboardSharing(settings().value("clipboardSharing", true).toBool());
 
-    readSettings(settings(), switchCorners(), "switchCorner", false, NumSwitchCorners);
+    readSettings<bool>(settings(), switchCorners(), "switchCorner", false,
+                       static_cast<int>(SwitchCorner::Count));
 
     int numScreens = settings().beginReadArray("screens");
     Q_ASSERT(numScreens <= screens().size());
@@ -258,9 +260,12 @@ QTextStream& operator<<(QTextStream& outStream, const ServerConfig& config)
         outStream << "\t" << "switchDoubleTap = " << config.switchDoubleTap() << endl;
 
     outStream << "\t" << "switchCorners = none ";
-    for (int i = 0; i < config.switchCorners().size(); i++)
-        if (config.switchCorners()[i])
-            outStream << "+" << config.switchCornerName(i) << " ";
+    for (int i = 0; i < config.switchCorners().size(); i++) {
+        auto corner = static_cast<Screen::SwitchCorner>(i);
+        if (config.switchCorners()[i]) {
+            outStream << "+" << config.switchCornerName(corner) << " ";
+        }
+    }
     outStream << endl;
 
     outStream << "\t" << "switchCornerSize = " << config.switchCornerSize() << endl;

--- a/src/gui/src/ServerConfig.h
+++ b/src/gui/src/ServerConfig.h
@@ -56,7 +56,7 @@ class ServerConfig : public BaseConfig
         int switchDelay() const { return m_SwitchDelay; }
         bool hasSwitchDoubleTap() const { return m_HasSwitchDoubleTap; }
         int switchDoubleTap() const { return m_SwitchDoubleTap; }
-        bool switchCorner(int c) const { return m_SwitchCorners[c]; }
+        bool switchCorner(SwitchCorner c) const { return m_SwitchCorners[static_cast<int>(c)]; }
         int switchCornerSize() const { return m_SwitchCornerSize; }
         const QList<bool>& switchCorners() const { return m_SwitchCorners; }
         const HotkeyList& hotkeys() const { return m_Hotkeys; }
@@ -87,7 +87,7 @@ class ServerConfig : public BaseConfig
         void setSwitchDelay(int val) { m_SwitchDelay = val; }
         void haveSwitchDoubleTap(bool on) { m_HasSwitchDoubleTap = on; }
         void setSwitchDoubleTap(int val) { m_SwitchDoubleTap = val; }
-        void setSwitchCorner(int c, bool on) { m_SwitchCorners[c] = on; }
+        void setSwitchCorner(SwitchCorner c, bool on) { m_SwitchCorners[static_cast<int>(c)] = on; }
         void setSwitchCornerSize(int val) { m_SwitchCornerSize = val; }
         void setIgnoreAutoConfigClient(bool on) { m_IgnoreAutoConfigClient = on; }
         void setEnableDragAndDrop(bool on) { m_EnableDragAndDrop = on; }

--- a/src/gui/src/ServerConfigDialog.cpp
+++ b/src/gui/src/ServerConfigDialog.cpp
@@ -48,10 +48,10 @@ ServerConfigDialog::ServerConfigDialog(QWidget* parent, ServerConfig& config, co
     m_pCheckBoxSwitchDoubleTap->setChecked(serverConfig().hasSwitchDoubleTap());
     m_pSpinBoxSwitchDoubleTap->setValue(serverConfig().switchDoubleTap());
 
-    m_pCheckBoxCornerTopLeft->setChecked(serverConfig().switchCorner(BaseConfig::TopLeft));
-    m_pCheckBoxCornerTopRight->setChecked(serverConfig().switchCorner(BaseConfig::TopRight));
-    m_pCheckBoxCornerBottomLeft->setChecked(serverConfig().switchCorner(BaseConfig::BottomLeft));
-    m_pCheckBoxCornerBottomRight->setChecked(serverConfig().switchCorner(BaseConfig::BottomRight));
+    m_pCheckBoxCornerTopLeft->setChecked(serverConfig().switchCorner(BaseConfig::SwitchCorner::TopLeft));
+    m_pCheckBoxCornerTopRight->setChecked(serverConfig().switchCorner(BaseConfig::SwitchCorner::TopRight));
+    m_pCheckBoxCornerBottomLeft->setChecked(serverConfig().switchCorner(BaseConfig::SwitchCorner::BottomLeft));
+    m_pCheckBoxCornerBottomRight->setChecked(serverConfig().switchCorner(BaseConfig::SwitchCorner::BottomRight));
     m_pSpinBoxSwitchCornerSize->setValue(serverConfig().switchCornerSize());
 
     m_pCheckBoxIgnoreAutoConfigClient->setChecked(serverConfig().ignoreAutoConfigClient());
@@ -95,10 +95,14 @@ void ServerConfigDialog::accept()
     serverConfig().haveSwitchDoubleTap(m_pCheckBoxSwitchDoubleTap->isChecked());
     serverConfig().setSwitchDoubleTap(m_pSpinBoxSwitchDoubleTap->value());
 
-    serverConfig().setSwitchCorner(BaseConfig::TopLeft, m_pCheckBoxCornerTopLeft->isChecked());
-    serverConfig().setSwitchCorner(BaseConfig::TopRight, m_pCheckBoxCornerTopRight->isChecked());
-    serverConfig().setSwitchCorner(BaseConfig::BottomLeft, m_pCheckBoxCornerBottomLeft->isChecked());
-    serverConfig().setSwitchCorner(BaseConfig::BottomRight, m_pCheckBoxCornerBottomRight->isChecked());
+    serverConfig().setSwitchCorner(BaseConfig::SwitchCorner::TopLeft,
+                                   m_pCheckBoxCornerTopLeft->isChecked());
+    serverConfig().setSwitchCorner(BaseConfig::SwitchCorner::TopRight,
+                                   m_pCheckBoxCornerTopRight->isChecked());
+    serverConfig().setSwitchCorner(BaseConfig::SwitchCorner::BottomLeft,
+                                   m_pCheckBoxCornerBottomLeft->isChecked());
+    serverConfig().setSwitchCorner(BaseConfig::SwitchCorner::BottomRight,
+                                   m_pCheckBoxCornerBottomRight->isChecked());
     serverConfig().setSwitchCornerSize(m_pSpinBoxSwitchCornerSize->value());
     serverConfig().setIgnoreAutoConfigClient(m_pCheckBoxIgnoreAutoConfigClient->isChecked());
     serverConfig().setEnableDragAndDrop(m_pCheckBoxEnableDragAndDrop->isChecked());


### PR DESCRIPTION
We were using unscoped enums which leaked the identifiers all over the place. This is a prerequisite for enabling tests.