### PR TITLE
lib/base: Use std::string directly instead of String typedef

### DIFF
--- a/src/lib/barrier/ProtocolUtil.h
+++ b/src/lib/barrier/ProtocolUtil.h
@@ -47,7 +47,7 @@ public:
     - \%1I  -- converts std::vector<UInt8>* to 1 byte integers
     - \%2I  -- converts std::vector<UInt16>* to 2 byte integers in NBO
     - \%4I  -- converts std::vector<UInt32>* to 4 byte integers in NBO
-    - \%s   -- converts String* to stream of bytes
+    - \%s   -- converts std::string* to stream of bytes
     - \%S   -- converts integer N and const UInt8* to stream of N bytes
     */
     static void            writef(barrier::IStream*,
@@ -67,7 +67,7 @@ public:
     - \%1I  -- reads 1 byte integers;  arg is std::vector<UInt8>*
     - \%2I  -- reads NBO 2 byte integers;  arg is std::vector<UInt16>*
     - \%4I  -- reads NBO 4 byte integers;  arg is std::vector<UInt32>*
-    - \%s   -- reads bytes;  argument must be a String*, \b not a char*
+    - \%s   -- reads bytes;  argument must be a std::string*, \b not a char*
     */
     static bool            readf(barrier::IStream*,
                             const char* fmt, ...);
@@ -92,5 +92,5 @@ match the format.
 class XIOReadMismatch : public XIO {
 public:
     // XBase overrides
-    virtual String        getWhat() const throw();
+    virtual std::string getWhat() const throw();
 };

--- a/src/lib/barrier/XBarrier.h
+++ b/src/lib/barrier/XBarrier.h
@@ -54,7 +54,7 @@ public:
     //@}
 
 protected:
-    virtual String        getWhat() const throw();
+    virtual std::string getWhat() const throw();
 
 private:
     int                    m_major;
@@ -68,23 +68,22 @@ a client that is already connected.
 */
 class XDuplicateClient : public XBarrier {
 public:
-    XDuplicateClient(const String& name);
+    XDuplicateClient(const std::string& name);
     virtual ~XDuplicateClient() _NOEXCEPT { }
 
     //! @name accessors
     //@{
 
     //! Get client's name
-    virtual const String&
-                        getName() const throw();
+    virtual const std::string& getName() const throw();
 
     //@}
 
 protected:
-    virtual String        getWhat() const throw();
+    virtual std::string getWhat() const throw();
 
 private:
-    String                m_name;
+    std::string m_name;
 };
 
 //! Client not in map exception
@@ -94,23 +93,22 @@ unknown to the server.
 */
 class XUnknownClient : public XBarrier {
 public:
-    XUnknownClient(const String& name);
+    XUnknownClient(const std::string& name);
     virtual ~XUnknownClient() _NOEXCEPT { }
 
     //! @name accessors
     //@{
 
     //! Get the client's name
-    virtual const String&
-                        getName() const throw();
+    virtual const std::string& getName() const throw();
 
     //@}
 
 protected:
-    virtual String        getWhat() const throw();
+    virtual std::string        getWhat() const throw();
 
 private:
-    String                m_name;
+    std::string                m_name;
 };
 
 //! Generic exit eception
@@ -128,7 +126,7 @@ public:
     int getCode() const throw();
 
 protected:
-    virtual String    getWhat() const throw();
+    virtual std::string getWhat() const throw();
     
 private:
     int    m_code;

--- a/src/lib/barrier/XScreen.cpp
+++ b/src/lib/barrier/XScreen.cpp
@@ -22,8 +22,7 @@
 // XScreenOpenFailure
 //
 
-String
-XScreenOpenFailure::getWhat() const throw()
+std::string XScreenOpenFailure::getWhat() const throw()
 {
     return format("XScreenOpenFailure", "unable to open screen");
 }
@@ -33,8 +32,7 @@ XScreenOpenFailure::getWhat() const throw()
 // XScreenXInputFailure
 //
 
-String
-XScreenXInputFailure::getWhat() const throw()
+std::string XScreenXInputFailure::getWhat() const throw()
 {
     return "";
 }
@@ -61,8 +59,7 @@ XScreenUnavailable::getRetryTime() const
     return m_timeUntilRetry;
 }
 
-String
-XScreenUnavailable::getWhat() const throw()
+std::string XScreenUnavailable::getWhat() const throw()
 {
     return format("XScreenUnavailable", "unable to open screen");
 }

--- a/src/lib/barrier/XScreen.h
+++ b/src/lib/barrier/XScreen.h
@@ -61,7 +61,7 @@ public:
     //@}
 
 protected:
-    virtual String        getWhat() const throw();
+    virtual std::string getWhat() const throw();
 
 private:
     double                m_timeUntilRetry;

--- a/src/lib/base/EventQueue.cpp
+++ b/src/lib/base/EventQueue.cpp
@@ -553,8 +553,7 @@ EventQueue::getNextTimerTimeout() const
     return m_timerQueue.top();
 }
 
-Event::Type
-EventQueue::getRegisteredType(const String& name) const
+Event::Type EventQueue::getRegisteredType(const std::string& name) const
 {
     NameMap::const_iterator found = m_nameMap.find(name);
     if (found != m_nameMap.end())

--- a/src/lib/base/EventQueue.h
+++ b/src/lib/base/EventQueue.h
@@ -61,8 +61,7 @@ public:
     virtual bool        isEmpty() const;
     virtual IEventJob*    getHandler(Event::Type type, void* target) const;
     virtual const char*    getTypeName(Event::Type type);
-    virtual Event::Type
-                        getRegisteredType(const String& name) const;
+    virtual Event::Type getRegisteredType(const std::string& name) const;
     void*                getSystemTarget();
     virtual void        waitForReady() const;
 
@@ -108,7 +107,7 @@ private:
     typedef std::map<UInt32, Event> EventTable;
     typedef std::vector<UInt32> EventIDList;
     typedef std::map<Event::Type, const char*> TypeMap;
-    typedef std::map<String, Event::Type> NameMap;
+    typedef std::map<std::string, Event::Type> NameMap;
     typedef std::map<Event::Type, IEventJob*> TypeHandlerTable;
     typedef std::map<void*, TypeHandlerTable> HandlerTable;
 

--- a/src/lib/base/IEventQueue.h
+++ b/src/lib/base/IEventQueue.h
@@ -20,7 +20,6 @@
 
 #include "common/IInterface.h"
 #include "base/Event.h"
-#include "base/String.h"
 
 class IEventJob;
 class IEventQueueBuffer;
@@ -214,7 +213,7 @@ public:
     /*!
     Returns the registered type for an event for a given name.
     */
-    virtual Event::Type getRegisteredType(const String& name) const = 0;
+    virtual Event::Type getRegisteredType(const std::string& name) const = 0;
 
     //! Get the system event type target
     /*!

--- a/src/lib/base/Log.cpp
+++ b/src/lib/base/Log.cpp
@@ -19,7 +19,6 @@
 #include "arch/Arch.h"
 #include "arch/XArch.h"
 #include "base/Log.h"
-#include "base/String.h"
 #include "base/log_outputters.h"
 #include "common/Version.h"
 

--- a/src/lib/base/String.cpp
+++ b/src/lib/base/String.cpp
@@ -35,17 +35,17 @@
 namespace barrier {
 namespace string {
 
-String
+std::string
 format(const char* fmt, ...)
 {
     va_list args;
     va_start(args, fmt);
-    String result = vformat(fmt, args);
+    std::string result = vformat(fmt, args);
     va_end(args);
     return result;
 }
 
-String
+std::string
 vformat(const char* fmt, va_list args)
 {
     // find highest indexed substitution and the locations of substitutions
@@ -111,7 +111,7 @@ vformat(const char* fmt, va_list args)
     }
 
     // substitute
-    String result;
+    std::string result;
     result.reserve(resultLength);
     size_t src = 0;
     for (int i = 0; i < n; ++i) {
@@ -124,13 +124,13 @@ vformat(const char* fmt, va_list args)
     return result;
 }
 
-String
+std::string
 sprintf(const char* fmt, ...)
 {
     char tmp[1024];
     char* buffer = tmp;
     int len      = (int)(sizeof(tmp) / sizeof(tmp[0]));
-    String result;
+    std::string result;
     while (buffer != NULL) {
         // try printing into the buffer
         va_list args;
@@ -162,23 +162,23 @@ sprintf(const char* fmt, ...)
 
 void
 findReplaceAll(
-    String& subject,
-    const String& find,
-    const String& replace)
+    std::string& subject,
+    const std::string& find,
+    const std::string& replace)
 {
     size_t pos = 0;
-    while ((pos = subject.find(find, pos)) != String::npos) {
+    while ((pos = subject.find(find, pos)) != std::string::npos) {
          subject.replace(pos, find.length(), replace);
          pos += replace.length();
     }
 }
 
-String
-removeFileExt(String filename)
+std::string
+removeFileExt(std::string filename)
 {
     size_t dot = filename.find_last_of('.');
 
-    if (dot == String::npos) {
+    if (dot == std::string::npos) {
         return filename;
     }
 
@@ -186,7 +186,7 @@ removeFileExt(String filename)
 }
 
 void
-toHex(String& subject, int width, const char fill)
+toHex(std::string& subject, int width, const char fill)
 {
     std::stringstream ss;
     ss << std::hex;
@@ -198,18 +198,18 @@ toHex(String& subject, int width, const char fill)
 }
 
 void
-uppercase(String& subject)
+uppercase(std::string& subject)
 {
     std::transform(subject.begin(), subject.end(), subject.begin(), ::toupper);
 }
 
 void
-removeChar(String& subject, const char c)
+removeChar(std::string& subject, const char c)
 {
     subject.erase(std::remove(subject.begin(), subject.end(), c), subject.end());
 }
 
-String
+std::string
 sizeTypeToString(size_t n)
 {
     std::stringstream ss;
@@ -218,7 +218,7 @@ sizeTypeToString(size_t n)
 }
 
 size_t
-stringToSizeType(String string)
+stringToSizeType(std::string string)
 {
     std::istringstream iss(string);
     size_t value;
@@ -226,14 +226,14 @@ stringToSizeType(String string)
     return value;
 }
 
-std::vector<String>
-splitString(String string, const char c)
+std::vector<std::string>
+splitString(std::string string, const char c)
 {
-    std::vector<String> results;
+    std::vector<std::string> results;
 
     size_t head = 0;
     size_t separator = string.find(c);
-    while (separator != String::npos) {
+    while (separator != std::string::npos) {
         if (head!=separator) {
             results.push_back(string.substr(head, separator - head));
         }
@@ -252,26 +252,22 @@ splitString(String string, const char c)
 // CaselessCmp
 //
 
-bool
-CaselessCmp::cmpEqual(
-    const String::value_type& a,
-    const String::value_type& b)
+bool CaselessCmp::cmpEqual(const std::string::value_type& a,
+                           const std::string::value_type& b)
 {
     // should use std::tolower but not in all versions of libstdc++ have it
     return tolower(a) == tolower(b);
 }
 
-bool
-CaselessCmp::cmpLess(
-    const String::value_type& a,
-    const String::value_type& b)
+bool CaselessCmp::cmpLess(const std::string::value_type& a,
+                          const std::string::value_type& b)
 {
     // should use std::tolower but not in all versions of libstdc++ have it
     return tolower(a) < tolower(b);
 }
 
 bool
-CaselessCmp::less(const String& a, const String& b)
+CaselessCmp::less(const std::string& a, const std::string& b)
 {
     return std::lexicographical_compare(
         a.begin(), a.end(),
@@ -280,13 +276,13 @@ CaselessCmp::less(const String& a, const String& b)
 }
 
 bool
-CaselessCmp::equal(const String& a, const String& b)
+CaselessCmp::equal(const std::string& a, const std::string& b)
 {
     return !(less(a, b) || less(b, a));
 }
 
 bool
-CaselessCmp::operator()(const String& a, const String& b) const
+CaselessCmp::operator()(const std::string& a, const std::string& b) const
 {
     return less(a, b);
 }

--- a/src/lib/base/String.h
+++ b/src/lib/base/String.h
@@ -29,7 +29,7 @@ typedef std::string String;
 
 namespace barrier {
 
-//! String utilities
+//! std::string utilities
 /*!
 Provides functions for string manipulation.
 */
@@ -45,67 +45,67 @@ characters and conversion specifications introduced by `\%':
 All arguments in the variable list are const char*.  Positional
 elements are indexed from 1.
 */
-String format(const char* fmt, ...);
+std::string format(const char* fmt, ...);
 
 //! Format positional arguments
 /*!
 Same as format() except takes va_list.
 */
-String vformat(const char* fmt, va_list);
+std::string vformat(const char* fmt, va_list);
 
 //! Print a string using sprintf-style formatting
 /*!
-Equivalent to sprintf() except the result is returned as a String.
+Equivalent to sprintf() except the result is returned as a std::string.
 */
-String sprintf(const char* fmt, ...);
+std::string sprintf(const char* fmt, ...);
 
 //! Find and replace all
 /*!
 Finds \c find inside \c subject and replaces it with \c replace
 */
-void findReplaceAll(String& subject, const String& find, const String& replace);
+void findReplaceAll(std::string& subject, const std::string& find, const std::string& replace);
 
 //! Remove file extension
 /*!
 Finds the last dot and remove all characters from the dot to the end
 */
-String removeFileExt(String filename);
+std::string removeFileExt(std::string filename);
 
 //! Convert into hexdecimal
 /*!
 Convert each character in \c subject into hexdecimal form with \c width
 */
-void toHex(String& subject, int width, const char fill = '0');
+void toHex(std::string& subject, int width, const char fill = '0');
 
 //! Convert to all uppercase
 /*!
 Convert each character in \c subject to uppercase
 */
-void uppercase(String& subject);
+void uppercase(std::string& subject);
 
 //! Remove all specific char in suject
 /*!
 Remove all specific \c c in \c suject
 */
-void removeChar(String& subject, const char c);
+void removeChar(std::string& subject, const char c);
 
 //! Convert a size type to a string
 /*!
 Convert an size type to a string
 */
-String sizeTypeToString(size_t n);
+std::string sizeTypeToString(size_t n);
 
 //! Convert a string to a size type
 /*!
 Convert an a \c string to an size type
 */
-size_t stringToSizeType(String string);
+size_t stringToSizeType(std::string string);
 
 //! Split a string into substrings
 /*!
 Split a \c string that separated by a \c c into substrings
 */
-std::vector<String> splitString(String string, const char c);
+std::vector<std::string> splitString(std::string string, const char c);
 
 //! Case-insensitive comparisons
 /*!
@@ -114,21 +114,21 @@ This class provides case-insensitve comparison functions.
 class CaselessCmp {
     public:
     //! Same as less()
-    bool            operator()(const String& a, const String& b) const;
+    bool operator()(const std::string& a, const std::string& b) const;
 
     //! Returns true iff \c a is lexicographically less than \c b
-    static bool        less(const String& a, const String& b);
+    static bool less(const std::string& a, const std::string& b);
 
     //! Returns true iff \c a is lexicographically equal to \c b
-    static bool        equal(const String& a, const String& b);
+    static bool equal(const std::string& a, const std::string& b);
 
     //! Returns true iff \c a is lexicographically less than \c b
-    static bool        cmpLess(const String::value_type& a,
-                        const String::value_type& b);
+    static bool cmpLess(const std::string::value_type& a,
+                        const std::string::value_type& b);
 
     //! Returns true iff \c a is lexicographically equal to \c b
-    static bool        cmpEqual(const String::value_type& a,
-                        const String::value_type& b);
+    static bool cmpEqual(const std::string::value_type& a,
+                         const std::string::value_type& b);
 };
 
 }

--- a/src/lib/base/Unicode.cpp
+++ b/src/lib/base/Unicode.cpp
@@ -98,7 +98,7 @@ UInt32                    Unicode::s_invalid     = 0x0000ffff;
 UInt32                    Unicode::s_replacement = 0x0000fffd;
 
 bool
-Unicode::isUTF8(const String& src)
+Unicode::isUTF8(const std::string& src)
 {
     // convert and test each character
     const UInt8* data = reinterpret_cast<const UInt8*>(src.c_str());
@@ -110,15 +110,14 @@ Unicode::isUTF8(const String& src)
     return true;
 }
 
-String
-Unicode::UTF8ToUCS2(const String& src, bool* errors)
+std::string Unicode::UTF8ToUCS2(const std::string& src, bool* errors)
 {
     // default to success
     resetError(errors);
 
     // get size of input string and reserve some space in output
     UInt32 n = (UInt32)src.size();
-    String dst;
+    std::string dst;
     dst.reserve(2 * n);
 
     // convert each character
@@ -139,15 +138,15 @@ Unicode::UTF8ToUCS2(const String& src, bool* errors)
     return dst;
 }
 
-String
-Unicode::UTF8ToUCS4(const String& src, bool* errors)
+std::string
+Unicode::UTF8ToUCS4(const std::string& src, bool* errors)
 {
     // default to success
     resetError(errors);
 
     // get size of input string and reserve some space in output
     UInt32 n = (UInt32)src.size();
-    String dst;
+    std::string dst;
     dst.reserve(4 * n);
 
     // convert each character
@@ -163,15 +162,15 @@ Unicode::UTF8ToUCS4(const String& src, bool* errors)
     return dst;
 }
 
-String
-Unicode::UTF8ToUTF16(const String& src, bool* errors)
+std::string
+Unicode::UTF8ToUTF16(const std::string& src, bool* errors)
 {
     // default to success
     resetError(errors);
 
     // get size of input string and reserve some space in output
     UInt32 n = (UInt32)src.size();
-    String dst;
+    std::string dst;
     dst.reserve(2 * n);
 
     // convert each character
@@ -201,15 +200,15 @@ Unicode::UTF8ToUTF16(const String& src, bool* errors)
     return dst;
 }
 
-String
-Unicode::UTF8ToUTF32(const String& src, bool* errors)
+std::string
+Unicode::UTF8ToUTF32(const std::string& src, bool* errors)
 {
     // default to success
     resetError(errors);
 
     // get size of input string and reserve some space in output
     UInt32 n = (UInt32)src.size();
-    String dst;
+    std::string dst;
     dst.reserve(4 * n);
 
     // convert each character
@@ -229,8 +228,8 @@ Unicode::UTF8ToUTF32(const String& src, bool* errors)
     return dst;
 }
 
-String
-Unicode::UTF8ToText(const String& src, bool* errors)
+std::string
+Unicode::UTF8ToText(const std::string& src, bool* errors)
 {
     // default to success
     resetError(errors);
@@ -243,7 +242,7 @@ Unicode::UTF8ToText(const String& src, bool* errors)
     int len   = ARCH->convStringWCToMB(NULL, tmp, size, errors);
     char* mbs = new char[len + 1];
     ARCH->convStringWCToMB(mbs, tmp, size, errors);
-    String text(mbs, len);
+    std::string text(mbs, len);
 
     // clean up
     delete[] mbs;
@@ -252,8 +251,8 @@ Unicode::UTF8ToText(const String& src, bool* errors)
     return text;
 }
 
-String
-Unicode::UCS2ToUTF8(const String& src, bool* errors)
+std::string
+Unicode::UCS2ToUTF8(const std::string& src, bool* errors)
 {
     // default to success
     resetError(errors);
@@ -263,8 +262,8 @@ Unicode::UCS2ToUTF8(const String& src, bool* errors)
     return doUCS2ToUTF8(reinterpret_cast<const UInt8*>(src.data()), n, errors);
 }
 
-String
-Unicode::UCS4ToUTF8(const String& src, bool* errors)
+std::string
+Unicode::UCS4ToUTF8(const std::string& src, bool* errors)
 {
     // default to success
     resetError(errors);
@@ -274,8 +273,8 @@ Unicode::UCS4ToUTF8(const String& src, bool* errors)
     return doUCS4ToUTF8(reinterpret_cast<const UInt8*>(src.data()), n, errors);
 }
 
-String
-Unicode::UTF16ToUTF8(const String& src, bool* errors)
+std::string
+Unicode::UTF16ToUTF8(const std::string& src, bool* errors)
 {
     // default to success
     resetError(errors);
@@ -285,8 +284,8 @@ Unicode::UTF16ToUTF8(const String& src, bool* errors)
     return doUTF16ToUTF8(reinterpret_cast<const UInt8*>(src.data()), n, errors);
 }
 
-String
-Unicode::UTF32ToUTF8(const String& src, bool* errors)
+std::string
+Unicode::UTF32ToUTF8(const std::string& src, bool* errors)
 {
     // default to success
     resetError(errors);
@@ -296,8 +295,8 @@ Unicode::UTF32ToUTF8(const String& src, bool* errors)
     return doUTF32ToUTF8(reinterpret_cast<const UInt8*>(src.data()), n, errors);
 }
 
-String
-Unicode::textToUTF8(const String& src, bool* errors)
+std::string
+Unicode::textToUTF8(const std::string& src, bool* errors)
 {
     // default to success
     resetError(errors);
@@ -309,7 +308,7 @@ Unicode::textToUTF8(const String& src, bool* errors)
     ARCH->convStringMBToWC(wcs, src.c_str(), n, errors);
 
     // convert to UTF8
-    String utf8 = wideCharToUTF8(wcs, len, errors);
+    std::string utf8 = wideCharToUTF8(wcs, len, errors);
 
     // clean up
     delete[] wcs;
@@ -318,10 +317,10 @@ Unicode::textToUTF8(const String& src, bool* errors)
 }
 
 wchar_t*
-Unicode::UTF8ToWideChar(const String& src, UInt32& size, bool* errors)
+Unicode::UTF8ToWideChar(const std::string& src, UInt32& size, bool* errors)
 {
     // convert to platform's wide character encoding
-    String tmp;
+    std::string tmp;
     switch (ARCH->getWideCharEncoding()) {
     case IArchString::kUCS2:
         tmp = UTF8ToUCS2(src, errors);
@@ -353,12 +352,12 @@ Unicode::UTF8ToWideChar(const String& src, UInt32& size, bool* errors)
     return dst;
 }
 
-String
+std::string
 Unicode::wideCharToUTF8(const wchar_t* src, UInt32 size, bool* errors)
 {
     // convert from platform's wide character encoding.
     // note -- this must include a wide nul character (independent of
-    // the String's nul character).
+    // the std::string's nul character).
     switch (ARCH->getWideCharEncoding()) {
     case IArchString::kUCS2:
         return doUCS2ToUTF8(reinterpret_cast<const UInt8*>(src), size, errors);
@@ -374,15 +373,15 @@ Unicode::wideCharToUTF8(const wchar_t* src, UInt32 size, bool* errors)
 
     default:
         assert(0 && "unknown wide character encoding");
-        return String();
+        return std::string();
     }
 }
 
-String
+std::string
 Unicode::doUCS2ToUTF8(const UInt8* data, UInt32 n, bool* errors)
 {
     // make some space
-    String dst;
+    std::string dst;
     dst.reserve(n);
 
     // check if first character is 0xfffe or 0xfeff
@@ -414,11 +413,11 @@ Unicode::doUCS2ToUTF8(const UInt8* data, UInt32 n, bool* errors)
     return dst;
 }
 
-String
+std::string
 Unicode::doUCS4ToUTF8(const UInt8* data, UInt32 n, bool* errors)
 {
     // make some space
-    String dst;
+    std::string dst;
     dst.reserve(n);
 
     // check if first character is 0xfffe or 0xfeff
@@ -450,11 +449,11 @@ Unicode::doUCS4ToUTF8(const UInt8* data, UInt32 n, bool* errors)
     return dst;
 }
 
-String
+std::string
 Unicode::doUTF16ToUTF8(const UInt8* data, UInt32 n, bool* errors)
 {
     // make some space
-    String dst;
+    std::string dst;
     dst.reserve(n);
 
     // check if first character is 0xfffe or 0xfeff
@@ -512,11 +511,11 @@ Unicode::doUTF16ToUTF8(const UInt8* data, UInt32 n, bool* errors)
     return dst;
 }
 
-String
+std::string
 Unicode::doUTF32ToUTF8(const UInt8* data, UInt32 n, bool* errors)
 {
     // make some space
-    String dst;
+    std::string dst;
     dst.reserve(n);
 
     // check if first character is 0xfffe or 0xfeff
@@ -728,7 +727,7 @@ Unicode::fromUTF8(const UInt8*& data, UInt32& n)
 }
 
 void
-Unicode::toUTF8(String& dst, UInt32 c, bool* errors)
+Unicode::toUTF8(std::string& dst, UInt32 c, bool* errors)
 {
     UInt8 data[6];
 

--- a/src/lib/base/Unicode.h
+++ b/src/lib/base/Unicode.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
-#include "base/String.h"
 #include "common/basic_types.h"
+#include <string>
 
 //! Unicode utility functions
 /*!
@@ -36,7 +36,7 @@ public:
     Returns true iff the string contains a valid sequence of UTF-8
     encoded characters.
     */
-    static bool            isUTF8(const String&);
+    static bool isUTF8(const std::string&);
 
     //! Convert from UTF-8 to UCS-2 encoding
     /*!
@@ -44,7 +44,7 @@ public:
     is set to true iff any character could not be encoded in UCS-2.
     Decoding errors do not set *errors.
     */
-    static String        UTF8ToUCS2(const String&, bool* errors = NULL);
+    static std::string UTF8ToUCS2(const std::string&, bool* errors = NULL);
 
     //! Convert from UTF-8 to UCS-4 encoding
     /*!
@@ -52,7 +52,7 @@ public:
     is set to true iff any character could not be encoded in UCS-4.
     Decoding errors do not set *errors.
     */
-    static String        UTF8ToUCS4(const String&, bool* errors = NULL);
+    static std::string UTF8ToUCS4(const std::string&, bool* errors = NULL);
 
     //! Convert from UTF-8 to UTF-16 encoding
     /*!
@@ -60,7 +60,7 @@ public:
     is set to true iff any character could not be encoded in UTF-16.
     Decoding errors do not set *errors.
     */
-    static String        UTF8ToUTF16(const String&, bool* errors = NULL);
+    static std::string UTF8ToUTF16(const std::string&, bool* errors = NULL);
 
     //! Convert from UTF-8 to UTF-32 encoding
     /*!
@@ -68,7 +68,7 @@ public:
     is set to true iff any character could not be encoded in UTF-32.
     Decoding errors do not set *errors.
     */
-    static String        UTF8ToUTF32(const String&, bool* errors = NULL);
+    static std::string UTF8ToUTF32(const std::string&, bool* errors = NULL);
 
     //! Convert from UTF-8 to the current locale encoding
     /*!
@@ -76,42 +76,42 @@ public:
     NULL then *errors is set to true iff any character could not be encoded.
     Decoding errors do not set *errors.
     */
-    static String        UTF8ToText(const String&, bool* errors = NULL);
+    static std::string UTF8ToText(const std::string&, bool* errors = NULL);
 
     //! Convert from UCS-2 to UTF-8
     /*!
     Convert from UCS-2 to UTF-8.  If errors is not NULL then *errors is
     set to true iff any character could not be decoded.
     */
-    static String        UCS2ToUTF8(const String&, bool* errors = NULL);
+    static std::string UCS2ToUTF8(const std::string&, bool* errors = NULL);
 
     //! Convert from UCS-4 to UTF-8
     /*!
     Convert from UCS-4 to UTF-8.  If errors is not NULL then *errors is
     set to true iff any character could not be decoded.
     */
-    static String        UCS4ToUTF8(const String&, bool* errors = NULL);
+    static std::string UCS4ToUTF8(const std::string&, bool* errors = NULL);
 
     //! Convert from UTF-16 to UTF-8
     /*!
     Convert from UTF-16 to UTF-8.  If errors is not NULL then *errors is
     set to true iff any character could not be decoded.
     */
-    static String        UTF16ToUTF8(const String&, bool* errors = NULL);
+    static std::string UTF16ToUTF8(const std::string&, bool* errors = NULL);
 
     //! Convert from UTF-32 to UTF-8
     /*!
     Convert from UTF-32 to UTF-8.  If errors is not NULL then *errors is
     set to true iff any character could not be decoded.
     */
-    static String        UTF32ToUTF8(const String&, bool* errors = NULL);
+    static std::string UTF32ToUTF8(const std::string&, bool* errors = NULL);
 
     //! Convert from the current locale encoding to UTF-8
     /*!
     Convert from the current locale encoding to UTF-8.  If errors is not
     NULL then *errors is set to true iff any character could not be decoded.
     */
-    static String        textToUTF8(const String&, bool* errors = NULL);
+    static std::string textToUTF8(const std::string&, bool* errors = NULL);
 
     //@}
 
@@ -120,23 +120,21 @@ private:
     // to the platform).  caller must delete[] the returned string.  the
     // string is *not* nul terminated;  the length (in characters) is
     // returned in size.
-    static wchar_t*        UTF8ToWideChar(const String&,
-                            UInt32& size, bool* errors);
+    static wchar_t* UTF8ToWideChar(const std::string&, UInt32& size, bool* errors);
 
     // convert nul terminated wchar_t string (in platform's native
     // encoding) to UTF8.
-    static String        wideCharToUTF8(const wchar_t*,
-                            UInt32 size, bool* errors);
+    static std::string wideCharToUTF8(const wchar_t*, UInt32 size, bool* errors);
 
     // internal conversion to UTF8
-    static String        doUCS2ToUTF8(const UInt8* src, UInt32 n, bool* errors);
-    static String        doUCS4ToUTF8(const UInt8* src, UInt32 n, bool* errors);
-    static String        doUTF16ToUTF8(const UInt8* src, UInt32 n, bool* errors);
-    static String        doUTF32ToUTF8(const UInt8* src, UInt32 n, bool* errors);
+    static std::string doUCS2ToUTF8(const UInt8* src, UInt32 n, bool* errors);
+    static std::string doUCS4ToUTF8(const UInt8* src, UInt32 n, bool* errors);
+    static std::string doUTF16ToUTF8(const UInt8* src, UInt32 n, bool* errors);
+    static std::string doUTF32ToUTF8(const UInt8* src, UInt32 n, bool* errors);
 
     // convert characters to/from UTF8
-    static UInt32        fromUTF8(const UInt8*& src, UInt32& size);
-    static void            toUTF8(String& dst, UInt32 c, bool* errors);
+    static UInt32 fromUTF8(const UInt8*& src, UInt32& size);
+    static void toUTF8(std::string& dst, UInt32 c, bool* errors);
 
 private:
     static UInt32        s_invalid;

--- a/src/lib/base/XBase.cpp
+++ b/src/lib/base/XBase.cpp
@@ -32,7 +32,7 @@ XBase::XBase() :
     // do nothing
 }
 
-XBase::XBase(const String& msg) :
+XBase::XBase(const std::string& msg) :
     std::runtime_error(msg)
 {
     // do nothing
@@ -54,14 +54,14 @@ XBase::what() const _NOEXCEPT
     return what;
 }
 
-String
+std::string
 XBase::format(const char* /*id*/, const char* fmt, ...) const throw()
 {
     // FIXME -- lookup message string using id as an index.  set
     // fmt to that string if it exists.
 
     // format
-    String result;
+    std::string result;
     va_list args;
     va_start(args, fmt);
     try {

--- a/src/lib/base/XBase.h
+++ b/src/lib/base/XBase.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
-#include "base/String.h"
 #include "common/stdexcept.h"
+#include <string>
 
 //! Exception base class
 /*!
@@ -30,7 +30,7 @@ public:
     //! Use getWhat() as the result of what()
     XBase();
     //! Use \c msg as the result of what()
-    XBase(const String& msg);
+    XBase(const std::string& msg);
     virtual ~XBase() _NOEXCEPT;
 
     //! Reason for exception
@@ -38,7 +38,7 @@ public:
 
 protected:
     //! Get a human readable string describing the exception
-    virtual String        getWhat() const throw() { return ""; }
+    virtual std::string getWhat() const throw() { return ""; }
 
     //! Format a string
     /*!
@@ -46,47 +46,46 @@ protected:
     no format can be found, then replaces positional parameters in
     the format string and returns the result.
     */
-    virtual String        format(const char* id,
-                            const char* defaultFormat, ...) const throw();
+    virtual std::string format(const char* id, const char* defaultFormat, ...) const throw();
 private:
-    mutable String        m_what;
+    mutable std::string        m_what;
 };
 
 /*!
 \def XBASE_SUBCLASS
 Convenience macro to subclass from XBase (or a subclass of it),
-providing the c'tor taking a const String&.  getWhat() is not
+providing the c'tor taking a const std::string&.  getWhat() is not
 declared.
 */
 #define XBASE_SUBCLASS(name_, super_)                                    \
 class name_ : public super_ {                                            \
 public:                                                                    \
     name_() : super_() { }                                                \
-    name_(const String& msg) : super_(msg) { }                            \
+    name_(const std::string& msg) : super_(msg) { }                            \
     virtual ~name_() _NOEXCEPT { }                                        \
 }
 
 /*!
 \def XBASE_SUBCLASS
 Convenience macro to subclass from XBase (or a subclass of it),
-providing the c'tor taking a const String&.  getWhat() must be
+providing the c'tor taking a const std::string&.  getWhat() must be
 implemented.
 */
 #define XBASE_SUBCLASS_WHAT(name_, super_)                                \
 class name_ : public super_ {                                            \
 public:                                                                    \
     name_() : super_() { }                                                \
-    name_(const String& msg) : super_(msg) { }                            \
+    name_(const std::string& msg) : super_(msg) { }                            \
     virtual ~name_() _NOEXCEPT { }                                        \
                                                                         \
 protected:                                                                \
-    virtual String        getWhat() const throw();                        \
+    virtual std::string        getWhat() const throw();                        \
 }
 
 /*!
 \def XBASE_SUBCLASS_FORMAT
 Convenience macro to subclass from XBase (or a subclass of it),
-providing the c'tor taking a const String&.  what() is overridden
+providing the c'tor taking a const std::string&.  what() is overridden
 to call getWhat() when first called;  getWhat() can format the
 error message and can call what() to get the message passed to the
 c'tor.
@@ -98,7 +97,7 @@ private:                                                                \
                                                                         \
 public:                                                                    \
     name_() : super_(), m_state(kDone) { }                                \
-    name_(const String& msg) : super_(msg), m_state(kFirst) { }        \
+    name_(const std::string& msg) : super_(msg), m_state(kFirst) { }        \
     virtual ~name_() _NOEXCEPT { }                                        \
                                                                         \
     virtual const char*    what() const _NOEXCEPT                            \
@@ -117,7 +116,7 @@ public:                                                                    \
     }                                                                    \
                                                                         \
 protected:                                                                \
-    virtual String        getWhat() const throw();                        \
+    virtual std::string        getWhat() const throw();                        \
                                                                         \
 private:                                                                \
     mutable EState                m_state;                                \

--- a/src/lib/base/log_outputters.cpp
+++ b/src/lib/base/log_outputters.cpp
@@ -19,6 +19,7 @@
 #include "base/log_outputters.h"
 #include "base/TMethodJob.h"
 #include "arch/Arch.h"
+#include "base/String.h"
 
 #include <fstream>
 
@@ -228,7 +229,7 @@ BufferedLogOutputter::write(ELevel, const char* message)
     while (m_buffer.size() >= m_maxBufferSize) {
         m_buffer.pop_front();
     }
-    m_buffer.push_back(String(message));
+    m_buffer.push_back(std::string(message));
     return true;
 }
 
@@ -272,7 +273,7 @@ FileLogOutputter::write(ELevel level, const char *message)
     m_handle.close();
 
     if (moveFile) {
-        String oldLogFilename = barrier::string::sprintf("%s.1", m_fileName.c_str());
+        std::string oldLogFilename = barrier::string::sprintf("%s.1", m_fileName.c_str());
         remove(oldLogFilename.c_str());
         rename(m_fileName.c_str(), oldLogFilename.c_str());
     }

--- a/src/lib/base/log_outputters.h
+++ b/src/lib/base/log_outputters.h
@@ -20,12 +20,12 @@
 
 #include "mt/Thread.h"
 #include "base/ILogOutputter.h"
-#include "base/String.h"
 #include "common/basic_types.h"
 #include "common/stddeque.h"
 
 #include <list>
 #include <fstream>
+#include <string>
 
 //! Stop traversing log chain outputter
 /*!
@@ -126,7 +126,7 @@ This outputter records the last N log messages.
 */
 class BufferedLogOutputter : public ILogOutputter {
 private:
-    typedef std::deque<String> Buffer;
+    typedef std::deque<std::string> Buffer;
 
 public:
     typedef Buffer::const_iterator const_iterator;

--- a/src/lib/io/XIO.cpp
+++ b/src/lib/io/XIO.cpp
@@ -22,8 +22,7 @@
 // XIOClosed
 //
 
-String
-XIOClosed::getWhat() const throw()
+std::string XIOClosed::getWhat() const throw()
 {
     return format("XIOClosed", "already closed");
 }
@@ -33,8 +32,7 @@ XIOClosed::getWhat() const throw()
 // XIOEndOfStream
 //
 
-String
-XIOEndOfStream::getWhat() const throw()
+std::string XIOEndOfStream::getWhat() const throw()
 {
     return format("XIOEndOfStream", "reached end of stream");
 }
@@ -44,8 +42,7 @@ XIOEndOfStream::getWhat() const throw()
 // XIOWouldBlock
 //
 
-String
-XIOWouldBlock::getWhat() const throw()
+std::string XIOWouldBlock::getWhat() const throw()
 {
     return format("XIOWouldBlock", "stream operation would block");
 }

--- a/src/lib/mt/XMT.cpp
+++ b/src/lib/mt/XMT.cpp
@@ -22,8 +22,7 @@
 // XMTThreadUnavailable
 //
 
-String
-XMTThreadUnavailable::getWhat() const throw()
+std::string XMTThreadUnavailable::getWhat() const throw()
 {
     return format("XMTThreadUnavailable", "cannot create thread");
 }

--- a/src/test/mock/barrier/MockEventQueue.h
+++ b/src/test/mock/barrier/MockEventQueue.h
@@ -41,7 +41,7 @@ public:
     MOCK_METHOD1(dispatchEvent, bool(const Event&));
     MOCK_CONST_METHOD2(getHandler, IEventJob*(Event::Type, void*));
     MOCK_METHOD1(deleteTimer, void(EventQueueTimer*));
-    MOCK_CONST_METHOD1(getRegisteredType, Event::Type(const String&));
+    MOCK_CONST_METHOD1(getRegisteredType, Event::Type(const std::string&));
     MOCK_METHOD0(getSystemTarget, void*());
     MOCK_METHOD0(forClient, ClientEvents&());
     MOCK_METHOD0(forIStream, IStreamEvents&());


### PR DESCRIPTION
Having a `String` typedef that points to `std::string` does not serve any benefit and is just confusing. This PR should not result in any functionality changes, I would expect the produced binary to be exactly the same.