### PR TITLE
lib/client: Use std::string directly instead of String typedef

### DIFF
--- a/src/lib/client/Client.cpp
+++ b/src/lib/client/Client.cpp
@@ -49,12 +49,10 @@
 // Client
 //
 
-Client::Client(
-        IEventQueue* events,
-        const String& name, const NetworkAddress& address,
-        ISocketFactory* socketFactory,
-        barrier::Screen* screen,
-        ClientArgs const& args) :
+Client::Client(IEventQueue* events, const std::string& name, const NetworkAddress& address,
+               ISocketFactory* socketFactory,
+               barrier::Screen* screen,
+               ClientArgs const& args) :
     m_mock(false),
     m_name(name),
     m_serverAddress(address),
@@ -373,7 +371,7 @@ Client::setOptions(const OptionsList& options)
     m_screen->setOptions(options);
 }
 
-String
+std::string
 Client::getName() const
 {
     return m_name;
@@ -403,7 +401,7 @@ Client::sendClipboard(ClipboardID id)
         m_timeClipboard[id] = clipboard.getTime();
 
         // marshall the data
-        String data = clipboard.marshall();
+        std::string data = clipboard.marshall();
 
         // save and send data if different or not yet sent
         if (!m_sentClipboard[id] || data != m_dataClipboard[id]) {
@@ -783,7 +781,7 @@ Client::writeToDropDirThread(void*)
 }
 
 void
-Client::dragInfoReceived(UInt32 fileNum, String data)
+Client::dragInfoReceived(UInt32 fileNum, std::string data)
 {
     // TODO: fix duplicate function from CServer
     if (!m_args.m_enableDragDrop) {
@@ -830,7 +828,7 @@ Client::sendFileThread(void* filename)
 }
 
 void
-Client::sendDragInfo(UInt32 fileCount, String& info, size_t size)
+Client::sendDragInfo(UInt32 fileCount, std::string& info, size_t size)
 {
     m_server->sendDragInfo(fileCount, info.c_str(), size);
 }

--- a/src/lib/client/Client.h
+++ b/src/lib/client/Client.h
@@ -48,7 +48,7 @@ public:
     public:
         FailInfo(const char* what) : m_retry(false), m_what(what) { }
         bool            m_retry;
-        String            m_what;
+        std::string m_what;
     };
 
 public:
@@ -57,7 +57,7 @@ public:
     as its name and \p address as the server's address and \p factory
     to create the socket.  \p screen is    the local screen.
     */
-    Client(IEventQueue* events, const String& name,
+    Client(IEventQueue* events, const std::string& name,
            const NetworkAddress& address, ISocketFactory* socketFactory,
            barrier::Screen* screen, ClientArgs const& args);
 
@@ -86,13 +86,13 @@ public:
     virtual void        handshakeComplete();
 
     //! Received drag information
-    void                dragInfoReceived(UInt32 fileNum, String data);
+    void dragInfoReceived(UInt32 fileNum, std::string data);
 
     //! Create a new thread and use it to send file to Server
     void                sendFileToServer(const char* filename);
     
     //! Send dragging file information back to server
-    void                sendDragInfo(UInt32 fileCount, String& info, size_t size);
+    void sendDragInfo(UInt32 fileCount, std::string& info, size_t size);
 
     
     //@}
@@ -126,7 +126,7 @@ public:
     size_t&                getExpectedFileSize() { return m_expectedFileSize; }
 
     //! Return received file data
-    String&                getReceivedFileData() { return m_receivedFileData; }
+    std::string& getReceivedFileData() { return m_receivedFileData; }
 
     //! Return drag file list
     DragFileList        getDragFileList() { return m_dragFileList; }
@@ -160,7 +160,7 @@ public:
     virtual void        screensaver(bool activate);
     virtual void        resetOptions();
     virtual void        setOptions(const OptionsList& options);
-    virtual String        getName() const;
+    virtual std::string getName() const;
 
 private:
     void                sendClipboard(ClipboardID);
@@ -198,7 +198,7 @@ public:
     bool                m_mock;
 
 private:
-    String                m_name;
+    std::string                m_name;
     NetworkAddress        m_serverAddress;
     ISocketFactory*        m_socketFactory;
     barrier::Screen*    m_screen;
@@ -212,12 +212,12 @@ private:
     bool                m_ownClipboard[kClipboardEnd];
     bool                m_sentClipboard[kClipboardEnd];
     IClipboard::Time    m_timeClipboard[kClipboardEnd];
-    String                m_dataClipboard[kClipboardEnd];
+    std::string m_dataClipboard[kClipboardEnd];
     IEventQueue*        m_events;
     std::size_t            m_expectedFileSize;
-    String                m_receivedFileData;
+    std::string m_receivedFileData;
     DragFileList        m_dragFileList;
-    String                m_dragFileExt;
+    std::string m_dragFileExt;
     Thread*                m_sendFileThread;
     Thread*                m_writeToDropDirThread;
     TCPSocket*            m_socket;

--- a/src/lib/client/ServerProxy.cpp
+++ b/src/lib/client/ServerProxy.cpp
@@ -361,7 +361,7 @@ ServerProxy::onGrabClipboard(ClipboardID id)
 void
 ServerProxy::onClipboardChanged(ClipboardID id, const IClipboard* clipboard)
 {
-    String data = IClipboard::marshall(clipboard);
+    std::string data = IClipboard::marshall(clipboard);
     LOG((CLOG_DEBUG "sending clipboard %d seqnum=%d", id, m_seqNum));
 
     StreamChunker::sendClipboard(data, data.size(), id, m_seqNum, m_events, this);
@@ -550,7 +550,7 @@ void
 ServerProxy::setClipboard()
 {
     // parse
-    static String dataCached;
+    static std::string dataCached;
     ClipboardID id;
     UInt32 seq;
     
@@ -872,7 +872,7 @@ ServerProxy::fileChunkReceived()
     }
     else if (result == kStart) {
         if (m_client->getDragFileList().size() > 0) {
-            String filename = m_client->getDragFileList().at(0).getFilename();
+            std::string filename = m_client->getDragFileList().at(0).getFilename();
             LOG((CLOG_DEBUG "start receiving %s", filename.c_str()));
         }
     }
@@ -883,7 +883,7 @@ ServerProxy::dragInfoReceived()
 {
     // parse
     UInt32 fileNum = 0;
-    String content;
+    std::string content;
     ProtocolUtil::readf(m_stream, kMsgDDragInfo + 4, &fileNum, &content);
 
     m_client->dragInfoReceived(fileNum, content);
@@ -904,6 +904,6 @@ ServerProxy::fileChunkSending(UInt8 mark, char* data, size_t dataSize)
 void
 ServerProxy::sendDragInfo(UInt32 fileCount, const char* info, size_t size)
 {
-    String data(info, size);
+    std::string data(info, size);
     ProtocolUtil::writef(m_stream, kMsgDDragInfo, fileCount, &data);
 }

--- a/src/lib/client/ServerProxy.h
+++ b/src/lib/client/ServerProxy.h
@@ -22,7 +22,6 @@
 #include "barrier/key_types.h"
 #include "base/Event.h"
 #include "base/Stopwatch.h"
-#include "base/String.h"
 
 class Client;
 class ClientInfo;


### PR DESCRIPTION
Having a `String` typedef that points to `std::string` does not serve any benefit and is just confusing. This PR should not result in any functionality changes, I would expect the produced binary to be exactly the same.