### PR TITLE
lib/arch: Use std::string directly instead of String typedef

### DIFF
--- a/src/lib/arch/ArchDaemonNone.h
+++ b/src/lib/arch/ArchDaemonNone.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "arch/IArchDaemon.h"
+#include <string>
 
 #define ARCH_DAEMON ArchDaemonNone
 
@@ -46,5 +47,5 @@ public:
     virtual bool        isDaemonInstalled(const char* name);
     virtual void        installDaemon();
     virtual void        uninstallDaemon();
-    virtual std::string    commandLine() const;
+    virtual std::string commandLine() const;
 };

--- a/src/lib/arch/IArchDaemon.h
+++ b/src/lib/arch/IArchDaemon.h
@@ -19,7 +19,7 @@
 #pragma once
 
 #include "common/IInterface.h"
-#include "base/String.h"
+#include <string>
 
 //! Interface for architecture dependent daemonizing
 /*!
@@ -122,7 +122,7 @@ public:
     /*!
     Gets the command line with which the application was started.
     */
-    virtual std::string    commandLine() const = 0;
+    virtual std::string commandLine() const = 0;
 
     //@}
 };

--- a/src/lib/arch/IArchTaskBarReceiver.h
+++ b/src/lib/arch/IArchTaskBarReceiver.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
-#include "base/String.h"
 #include "common/IInterface.h"
+#include <string>
 
 class IScreen;
 class INode;
@@ -88,9 +88,9 @@ public:
     to set the tooltip is left to sublclasses.  Getting and setting
     the icon must be thread safe.
     */
-    virtual std::string    getToolTip() const = 0;
+    virtual std::string getToolTip() const = 0;
 
-    virtual void updateStatus(INode*, const String& errorMsg) = 0;
+    virtual void updateStatus(INode*, const std::string& errorMsg) = 0;
 
     virtual void cleanup() {}
 

--- a/src/lib/arch/unix/ArchInternetUnix.cpp
+++ b/src/lib/arch/unix/ArchInternetUnix.cpp
@@ -28,8 +28,8 @@ class CurlFacade {
 public:
     CurlFacade();
     ~CurlFacade();
-    String                get(const String& url);
-    String                urlEncode(const String& url);
+    std::string get(const std::string& url);
+    std::string urlEncode(const std::string& url);
 
 private:
     CURL*                m_curl;
@@ -39,15 +39,13 @@ private:
 // ArchInternetUnix
 //
 
-String
-ArchInternetUnix::get(const String& url)
+std::string ArchInternetUnix::get(const std::string& url)
 {
     CurlFacade curl;
     return curl.get(url);
 }
 
-String
-ArchInternetUnix::urlEncode(const String& url)
+std::string ArchInternetUnix::urlEncode(const std::string& url)
 {
     CurlFacade curl;
     return curl.urlEncode(url);
@@ -87,8 +85,7 @@ CurlFacade::~CurlFacade()
     curl_global_cleanup();
 }
 
-String
-CurlFacade::get(const String& url)
+std::string CurlFacade::get(const std::string& url)
 {
     curl_easy_setopt(m_curl, CURLOPT_URL, url.c_str());
     curl_easy_setopt(m_curl, CURLOPT_WRITEFUNCTION, curlWriteCallback);
@@ -110,8 +107,7 @@ CurlFacade::get(const String& url)
     return result;
 }
 
-String
-CurlFacade::urlEncode(const String& url)
+std::string CurlFacade::urlEncode(const std::string& url)
 {
     char* resultCStr = curl_easy_escape(m_curl, url.c_str(), 0);
 

--- a/src/lib/arch/unix/ArchInternetUnix.h
+++ b/src/lib/arch/unix/ArchInternetUnix.h
@@ -19,10 +19,10 @@
 
 #define ARCH_INTERNET ArchInternetUnix
 
-#include "base/String.h"
+#include <string>
 
 class ArchInternetUnix {
 public:
-    String                get(const String& url);
-    String                urlEncode(const String& url);
+    std::string get(const std::string& url);
+    std::string urlEncode(const std::string& url);
 };

--- a/src/lib/arch/win32/ArchInternetWindows.cpp
+++ b/src/lib/arch/win32/ArchInternetWindows.cpp
@@ -25,19 +25,19 @@
 #include <Shlwapi.h>
 
 struct WinINetUrl {
-    String                m_scheme;
-    String                m_host;
-    String                m_path;
+    std::string m_scheme;
+    std::string m_host;
+    std::string m_path;
     INTERNET_PORT        m_port;
     DWORD                m_flags;
 };
 
 class WinINetRequest {
 public:
-    WinINetRequest(const String& url);
+    WinINetRequest(const std::string& url);
     ~WinINetRequest();
 
-    String                send();
+    std::string send();
     void                openSession();
     void                connect();
     void                openRequest();
@@ -54,15 +54,13 @@ private:
 // ArchInternetWindows
 //
 
-String
-ArchInternetWindows::get(const String& url)
+std::string ArchInternetWindows::get(const std::string& url)
 {
     WinINetRequest request(url);
     return request.send();
 }
 
-String
-ArchInternetWindows::urlEncode(const String& url)
+std::string ArchInternetWindows::urlEncode(const std::string& url)
 {
     TCHAR buffer[1024];
     DWORD bufferSize = sizeof(buffer);
@@ -71,7 +69,7 @@ ArchInternetWindows::urlEncode(const String& url)
         throw XArch(new XArchEvalWindows());
     }
 
-    String result(buffer);
+    std::string result(buffer);
 
     // the win32 url encoding funcitons are pretty useless (to us) and only
     // escape "unsafe" chars, but not + or =, so we need to replace these
@@ -86,9 +84,9 @@ ArchInternetWindows::urlEncode(const String& url)
 // WinINetRequest
 //
 
-static WinINetUrl parseUrl(const String& url);
+static WinINetUrl parseUrl(const std::string& url);
 
-WinINetRequest::WinINetRequest(const String& url) :
+WinINetRequest::WinINetRequest(const std::string& url) :
     m_session(NULL),
     m_connect(NULL),
     m_request(NULL),
@@ -112,8 +110,7 @@ WinINetRequest::~WinINetRequest()
     }
 }
 
-String
-WinINetRequest::send()
+std::string WinINetRequest::send()
 {
     if (m_used) {
         throw XArch("class is one time use.");
@@ -124,7 +121,7 @@ WinINetRequest::send()
     connect();
     openRequest();
     
-    String headers("Content-Type: text/html");
+    std::string headers("Content-Type: text/html");
     if (!HttpSendRequest(m_request, headers.c_str(), (DWORD)headers.length(), NULL, NULL)) {
         throw XArch(new XArchEvalWindows());
     }
@@ -142,8 +139,7 @@ WinINetRequest::send()
     return result.str();
 }
 
-void
-WinINetRequest::openSession()
+void WinINetRequest::openSession()
 {
     std::stringstream userAgent;
     userAgent << "Barrier ";
@@ -200,8 +196,7 @@ WinINetRequest::openRequest()
 // nb: i tried to use InternetCrackUrl here, but couldn't quite get that to
 // work. here's some (less robust) code to split the url into components.
 // this works fine with simple urls, but doesn't consider the full url spec.
-static WinINetUrl
-parseUrl(const String& url)
+static WinINetUrl parseUrl(const std::string& url)
 {
     WinINetUrl parsed;
 
@@ -215,7 +210,7 @@ parseUrl(const String& url)
     parsed.m_port = INTERNET_DEFAULT_HTTP_PORT;
     parsed.m_flags = 0;
 
-    if (parsed.m_scheme.find("https") != String::npos) {
+    if (parsed.m_scheme.find("https") != std::string::npos) {
         parsed.m_port = INTERNET_DEFAULT_HTTPS_PORT;
         parsed.m_flags = INTERNET_FLAG_SECURE;
     }

--- a/src/lib/arch/win32/ArchInternetWindows.h
+++ b/src/lib/arch/win32/ArchInternetWindows.h
@@ -19,10 +19,10 @@
 
 #define ARCH_INTERNET ArchInternetWindows
 
-#include "base/String.h"
+#include <string>
 
 class ArchInternetWindows {
 public:
-    String                get(const String& url);
-    String                urlEncode(const String& url);
+    std::string get(const std::string& url);
+    std::string urlEncode(const std::string& url);
 };

--- a/src/lib/arch/win32/ArchMiscWindows.cpp
+++ b/src/lib/arch/win32/ArchMiscWindows.cpp
@@ -431,7 +431,7 @@ ArchMiscWindows::wakeupDisplay()
 bool
 ArchMiscWindows::wasLaunchedAsService() 
 {
-    String name;
+    std::string name;
     if (!getParentProcessName(name)) {
         LOG((CLOG_ERR "cannot determine if process was launched as service"));
         return false;
@@ -440,8 +440,7 @@ ArchMiscWindows::wasLaunchedAsService()
     return (name == SERVICE_LAUNCHER);
 }
 
-bool
-ArchMiscWindows::getParentProcessName(String &name) 
+bool ArchMiscWindows::getParentProcessName(std::string &name)
 {    
     PROCESSENTRY32 parentEntry;
     if (!getParentProcessEntry(parentEntry)){

--- a/src/lib/arch/win32/ArchMiscWindows.h
+++ b/src/lib/arch/win32/ArchMiscWindows.h
@@ -21,7 +21,6 @@
 #include "common/common.h"
 #include "common/stdstring.h"
 #include "common/stdset.h"
-#include "base/String.h"
 
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
@@ -163,7 +162,7 @@ public:
     static bool wasLaunchedAsService();
 
     //! Returns true if we got the parent process name.
-    static bool getParentProcessName(String &name);
+    static bool getParentProcessName(std::string &name);
 
     static HINSTANCE instanceWin32();
 

--- a/src/lib/arch/win32/XArchWindows.cpp
+++ b/src/lib/arch/win32/XArchWindows.cpp
@@ -18,7 +18,6 @@
 
 #include "arch/win32/XArchWindows.h"
 #include "arch/win32/ArchNetworkWinsock.h"
-#include "base/String.h"
 
 //
 // XArchEvalWindows

--- a/src/lib/barrier/ProtocolUtil.cpp
+++ b/src/lib/barrier/ProtocolUtil.cpp
@@ -20,6 +20,7 @@
 #include "io/IStream.h"
 #include "base/Log.h"
 #include "common/stdvector.h"
+#include "base/String.h"
 
 #include <cctype>
 #include <cstring>

--- a/src/lib/ipc/IpcLogOutputter.h
+++ b/src/lib/ipc/IpcLogOutputter.h
@@ -21,6 +21,7 @@
 #include "arch/Arch.h"
 #include "arch/IArchMultithread.h"
 #include "base/ILogOutputter.h"
+#include "base/String.h"
 #include "ipc/Ipc.h"
 
 #include <deque>


### PR DESCRIPTION
Having a `String` typedef that points to `std::string` does not serve any benefit and is just confusing. This PR should not result in any functionality changes, I would expect the produced binary to be exactly the same.