### PR TITLE
lib/ipc: Use std::string directly instead of String typedef

### DIFF
--- a/src/lib/ipc/IpcClientProxy.cpp
+++ b/src/lib/ipc/IpcClientProxy.cpp
@@ -141,7 +141,7 @@ IpcClientProxy::send(const IpcMessage& message)
     switch (message.type()) {
     case kIpcLogLine: {
         const IpcLogLineMessage& llm = static_cast<const IpcLogLineMessage&>(message);
-        const String logLine = llm.logLine();
+        const std::string logLine = llm.logLine();
         ProtocolUtil::writef(&m_stream, kIpcMsgLogLine, &logLine);
         break;
     }
@@ -171,7 +171,7 @@ IpcClientProxy::parseHello()
 IpcCommandMessage*
 IpcClientProxy::parseCommand()
 {
-    String command;
+    std::string command;
     UInt8 elevate;
     ProtocolUtil::readf(&m_stream, kIpcMsgCommand + 4, &command, &elevate);
 

--- a/src/lib/ipc/IpcLogOutputter.cpp
+++ b/src/lib/ipc/IpcLogOutputter.cpp
@@ -109,8 +109,7 @@ IpcLogOutputter::write(ELevel, const char* text)
     return true;
 }
 
-void
-IpcLogOutputter::appendBuffer(const String& text)
+void IpcLogOutputter::appendBuffer(const std::string& text)
 {
     std::lock_guard<std::mutex> lock(m_bufferMutex);
 
@@ -173,8 +172,7 @@ IpcLogOutputter::notifyBuffer()
     ARCH->broadcastCondVar(m_notifyCond);
 }
 
-String
-IpcLogOutputter::getChunk(size_t count)
+std::string IpcLogOutputter::getChunk(size_t count)
 {
     std::lock_guard<std::mutex> lock(m_bufferMutex);
 
@@ -182,7 +180,7 @@ IpcLogOutputter::getChunk(size_t count)
         count = m_buffer.size();
     }
 
-    String chunk;
+    std::string chunk;
     for (size_t i = 0; i < count; i++) {
         chunk.append(m_buffer.front());
         chunk.append("\n");

--- a/src/lib/ipc/IpcLogOutputter.h
+++ b/src/lib/ipc/IpcLogOutputter.h
@@ -92,12 +92,12 @@ public:
 private:
     void                init();
     void                bufferThread(void*);
-    String                getChunk(size_t count);
-    void                appendBuffer(const String& text);
+    std::string getChunk(size_t count);
+    void appendBuffer(const std::string& text);
     bool                isRunning();
 
 private:
-    typedef std::deque<String> Buffer;
+    typedef std::deque<std::string> Buffer;
 
     IpcServer&            m_ipcServer;
     Buffer                m_buffer;

--- a/src/lib/ipc/IpcMessage.cpp
+++ b/src/lib/ipc/IpcMessage.cpp
@@ -47,9 +47,9 @@ IpcShutdownMessage::~IpcShutdownMessage()
 {
 }
 
-IpcLogLineMessage::IpcLogLineMessage(const String& logLine) :
-IpcMessage(kIpcLogLine),
-m_logLine(logLine)
+IpcLogLineMessage::IpcLogLineMessage(const std::string& logLine) :
+    IpcMessage(kIpcLogLine),
+    m_logLine(logLine)
 {
 }
 
@@ -57,10 +57,10 @@ IpcLogLineMessage::~IpcLogLineMessage()
 {
 }
 
-IpcCommandMessage::IpcCommandMessage(const String& command, bool elevate) :
-IpcMessage(kIpcCommand),
-m_command(command),
-m_elevate(elevate)
+IpcCommandMessage::IpcCommandMessage(const std::string& command, bool elevate) :
+    IpcMessage(kIpcCommand),
+    m_command(command),
+    m_elevate(elevate)
 {
 }
 

--- a/src/lib/ipc/IpcMessage.h
+++ b/src/lib/ipc/IpcMessage.h
@@ -20,8 +20,8 @@
 
 #include "ipc/Ipc.h"
 #include "base/EventTypes.h"
-#include "base/String.h"
 #include "base/Event.h"
+#include <string>
 
 class IpcMessage : public EventData {
 public:
@@ -58,28 +58,28 @@ public:
 
 class IpcLogLineMessage : public IpcMessage {
 public:
-    IpcLogLineMessage(const String& logLine);
+    IpcLogLineMessage(const std::string& logLine);
     virtual ~IpcLogLineMessage();
 
     //! Gets the log line.
-    String                logLine() const { return m_logLine; }
+    std::string logLine() const { return m_logLine; }
 
 private:
-    String                m_logLine;
+    std::string m_logLine;
 };
 
 class IpcCommandMessage : public IpcMessage {
 public:
-    IpcCommandMessage(const String& command, bool elevate);
+    IpcCommandMessage(const std::string& command, bool elevate);
     virtual ~IpcCommandMessage();
 
     //! Gets the command.
-    String                command() const { return m_command; }
+    std::string command() const { return m_command; }
 
     //! Gets whether or not the process should be elevated on MS Windows.
     bool                elevate() const { return m_elevate; }
 
 private:
-    String                m_command;
+    std::string m_command;
     bool                m_elevate;
 };

--- a/src/lib/ipc/IpcServerProxy.cpp
+++ b/src/lib/ipc/IpcServerProxy.cpp
@@ -94,7 +94,7 @@ IpcServerProxy::send(const IpcMessage& message)
 
     case kIpcCommand: {
         const IpcCommandMessage& cm = static_cast<const IpcCommandMessage&>(message);
-        const String command = cm.command();
+        std::string command = cm.command();
         ProtocolUtil::writef(&m_stream, kIpcMsgCommand, &command);
         break;
     }
@@ -108,7 +108,7 @@ IpcServerProxy::send(const IpcMessage& message)
 IpcLogLineMessage*
 IpcServerProxy::parseLogLine()
 {
-    String logLine;
+    std::string logLine;
     ProtocolUtil::readf(&m_stream, kIpcMsgLogLine + 4, &logLine);
     
     // must be deleted by event handler.


### PR DESCRIPTION
Having a `String` typedef that points to `std::string` does not serve any benefit and is just confusing. This PR should not result in any functionality changes, I would expect the produced binary to be exactly the same.