### PR TITLE
lib/net: Use std::string directly instead of String typedef

### DIFF
--- a/src/lib/net/IDataSocket.h
+++ b/src/lib/net/IDataSocket.h
@@ -20,7 +20,6 @@
 
 #include "net/ISocket.h"
 #include "io/IStream.h"
-#include "base/String.h"
 #include "base/EventTypes.h"
 
 //! Data stream socket interface
@@ -33,7 +32,7 @@ public:
     class ConnectionFailedInfo {
     public:
         ConnectionFailedInfo(const char* what) : m_what(what) { }
-        String            m_what;
+        std::string m_what;
     };
 
     IDataSocket(IEventQueue* events) { }

--- a/src/lib/net/NetworkAddress.cpp
+++ b/src/lib/net/NetworkAddress.cpp
@@ -96,7 +96,7 @@ NetworkAddress::NetworkAddress(const NetworkAddress& addr) :
     // do nothing
 }
 
-NetworkAddress::NetworkAddress(const String& hostname, int port) :
+NetworkAddress::NetworkAddress(const std::string& hostname, int port) :
     m_address(NULL),
     m_hostname(hostname),
     m_port(port)
@@ -196,8 +196,7 @@ NetworkAddress::getPort() const
     return m_port;
 }
 
-String
-NetworkAddress::getHostname() const
+std::string NetworkAddress::getHostname() const
 {
     return m_hostname;
 }

--- a/src/lib/net/NetworkAddress.h
+++ b/src/lib/net/NetworkAddress.h
@@ -18,7 +18,6 @@
 
 #pragma once
 
-#include "base/String.h"
 #include "base/EventTypes.h"
 #include "arch/IArchNetwork.h"
 
@@ -49,7 +48,7 @@ public:
     is thrown with an error of \c XSocketAddress::kBadPort.  The hostname
     is not resolved by the c'tor;  use \c resolve to do that.
     */
-    NetworkAddress(const String& hostname, int port);
+    NetworkAddress(const std::string& hostname, int port);
 
     NetworkAddress(const NetworkAddress&);
 
@@ -109,7 +108,7 @@ public:
     /*!
     Returns the hostname passed to the c'tor sans any port suffix.
     */
-    String                getHostname() const;
+    std::string getHostname() const;
 
     //@}
 
@@ -118,6 +117,6 @@ private:
 
 private:
     ArchNetAddress        m_address;
-    String                m_hostname;
+    std::string m_hostname;
     int                    m_port;
 };

--- a/src/lib/net/SecureListenSocket.cpp
+++ b/src/lib/net/SecureListenSocket.cpp
@@ -23,6 +23,7 @@
 #include "net/TSocketMultiplexerMethodJob.h"
 #include "arch/XArch.h"
 #include "common/DataDirectories.h"
+#include "base/String.h"
 
 static const char s_certificateDir[] = { "SSL" };
 static const char s_certificateFilename[] = { "Barrier.pem" };
@@ -54,7 +55,7 @@ SecureListenSocket::accept()
             setListeningJob();
         }
 
-        String certificateFilename = barrier::string::sprintf("%s/%s/%s",
+        std::string certificateFilename = barrier::string::sprintf("%s/%s/%s",
                                         DataDirectories::profile().c_str(),
                                         s_certificateDir,
                                         s_certificateFilename);

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -23,6 +23,7 @@
 #include "mt/Lock.h"
 #include "arch/XArch.h"
 #include "base/Log.h"
+#include "base/String.h"
 #include "common/DataDirectories.h"
 
 #include <openssl/ssl.h>
@@ -328,8 +329,7 @@ SecureSocket::initSsl(bool server)
     initContext(server);
 }
 
-bool
-SecureSocket::loadCertificates(String& filename)
+bool SecureSocket::loadCertificates(std::string& filename)
 {
     if (filename.empty()) {
         showError("ssl certificate is not specified");
@@ -341,7 +341,7 @@ SecureSocket::loadCertificates(String& filename)
         file.close();
 
         if (!exist) {
-            String errorMsg("ssl certificate doesn't exist: ");
+            std::string errorMsg("ssl certificate doesn't exist: ");
             errorMsg.append(filename);
             showError(errorMsg.c_str());
             return false;
@@ -630,14 +630,13 @@ SecureSocket::showError(const char* reason)
         LOG((CLOG_ERR "%s", reason));
     }
 
-    String error = getError();
+    std::string error = getError();
     if (!error.empty()) {
         LOG((CLOG_ERR "%s", error.c_str()));
     }
 }
 
-String
-SecureSocket::getError()
+std::string SecureSocket::getError()
 {
     unsigned long e = ERR_get_error();
 
@@ -659,8 +658,7 @@ SecureSocket::disconnect()
     sendEvent(getEvents()->forIStream().inputShutdown());
 }
 
-void
-SecureSocket::formatFingerprint(String& fingerprint, bool hex, bool separator)
+void SecureSocket::formatFingerprint(std::string& fingerprint, bool hex, bool separator)
 {
     if (hex) {
         // to hexidecimal
@@ -696,11 +694,11 @@ SecureSocket::verifyCertFingerprint()
     }
 
     // format fingerprint into hexdecimal format with colon separator
-    String fingerprint(reinterpret_cast<char*>(tempFingerprint), tempFingerprintLen);
+    std::string fingerprint(reinterpret_cast<char*>(tempFingerprint), tempFingerprintLen);
     formatFingerprint(fingerprint);
     LOG((CLOG_NOTE "server fingerprint: %s", fingerprint.c_str()));
 
-    String trustedServersFilename;
+    std::string trustedServersFilename;
     trustedServersFilename = barrier::string::sprintf(
         "%s/%s/%s",
         DataDirectories::profile().c_str(),
@@ -711,7 +709,7 @@ SecureSocket::verifyCertFingerprint()
     LOG((CLOG_NOTE "trustedServersFilename: %s", trustedServersFilename.c_str() ));
 
     // check if this fingerprint exist
-    String fileLine;
+    std::string fileLine;
     std::ifstream file;
     file.open(trustedServersFilename.c_str());
 

--- a/src/lib/net/SecureSocket.h
+++ b/src/lib/net/SecureSocket.h
@@ -55,7 +55,7 @@ public:
     EJobResult            doRead() override;
     EJobResult            doWrite() override;
     void                initSsl(bool server);
-    bool                loadCertificates(String& CertFile);
+    bool loadCertificates(std::string& CertFile);
 
 private:
     // SSL
@@ -66,11 +66,9 @@ private:
     bool                showCertificate();
     void                checkResult(int n, int& retry);
     void                showError(const char* reason = NULL);
-    String                getError();
+    std::string getError();
     void                disconnect();
-    void                formatFingerprint(String& fingerprint,
-                                            bool hex = true,
-                                            bool separator = true);
+    void formatFingerprint(std::string& fingerprint, bool hex = true, bool separator = true);
     bool                verifyCertFingerprint();
 
     MultiplexerJobStatus serviceConnect(ISocketMultiplexerJob*, bool, bool, bool);

--- a/src/lib/net/XSocket.cpp
+++ b/src/lib/net/XSocket.cpp
@@ -23,8 +23,7 @@
 // XSocketAddress
 //
 
-XSocketAddress::XSocketAddress(EError error,
-                const String& hostname, int port) _NOEXCEPT :
+XSocketAddress::XSocketAddress(EError error, const std::string& hostname, int port) _NOEXCEPT :
     m_error(error),
     m_hostname(hostname),
     m_port(port)
@@ -38,7 +37,7 @@ XSocketAddress::getError() const throw()
     return m_error;
 }
 
-String
+std::string
 XSocketAddress::getHostname() const throw()
 {
     return m_hostname;
@@ -50,8 +49,7 @@ XSocketAddress::getPort() const throw()
     return m_port;
 }
 
-String
-XSocketAddress::getWhat() const throw()
+std::string XSocketAddress::getWhat() const throw()
 {
     static const char* s_errorID[] = {
         "XSocketAddressUnknown",
@@ -77,8 +75,7 @@ XSocketAddress::getWhat() const throw()
 // XSocketIOClose
 //
 
-String
-XSocketIOClose::getWhat() const throw()
+std::string XSocketIOClose::getWhat() const throw()
 {
     return format("XSocketIOClose", "close: %{1}", what());
 }
@@ -88,8 +85,7 @@ XSocketIOClose::getWhat() const throw()
 // XSocketBind
 //
 
-String
-XSocketBind::getWhat() const throw()
+std::string XSocketBind::getWhat() const throw()
 {
     return format("XSocketBind", "cannot bind address: %{1}", what());
 }
@@ -99,8 +95,7 @@ XSocketBind::getWhat() const throw()
 // XSocketConnect
 //
 
-String
-XSocketConnect::getWhat() const throw()
+std::string XSocketConnect::getWhat() const throw()
 {
     return format("XSocketConnect", "cannot connect socket: %{1}", what());
 }
@@ -110,8 +105,7 @@ XSocketConnect::getWhat() const throw()
 // XSocketCreate
 //
 
-String
-XSocketCreate::getWhat() const throw()
+std::string XSocketCreate::getWhat() const throw()
 {
     return format("XSocketCreate", "cannot create socket: %{1}", what());
 }

--- a/src/lib/net/XSocket.h
+++ b/src/lib/net/XSocket.h
@@ -20,7 +20,6 @@
 
 #include "io/XIO.h"
 #include "base/XBase.h"
-#include "base/String.h"
 #include "common/basic_types.h"
 
 //! Generic socket exception
@@ -41,7 +40,7 @@ public:
         kBadPort        //!< The port is invalid
     };
 
-    XSocketAddress(EError, const String& hostname, int port) _NOEXCEPT;
+    XSocketAddress(EError, const std::string& hostname, int port) _NOEXCEPT;
     virtual ~XSocketAddress() _NOEXCEPT { }
 
     //! @name accessors
@@ -50,7 +49,7 @@ public:
     //! Get the error code
     EError                getError() const throw();
     //! Get the hostname
-    String                getHostname() const throw();
+    std::string getHostname() const throw();
     //! Get the port
     int                    getPort() const throw();
 
@@ -58,11 +57,11 @@ public:
 
 protected:
     // XBase overrides
-    virtual String        getWhat() const throw();
+    virtual std::string getWhat() const throw();
 
 private:
     EError                m_error;
-    String                m_hostname;
+    std::string m_hostname;
     int                    m_port;
 };
 


### PR DESCRIPTION
Having a `String` typedef that points to `std::string` does not serve any benefit and is just confusing. This PR should not result in any functionality changes, I would expect the produced binary to be exactly the same.