### PR TITLE
lib/server: Use std::string directly instead of String typedef

### DIFF
--- a/src/lib/server/BaseClientProxy.cpp
+++ b/src/lib/server/BaseClientProxy.cpp
@@ -22,7 +22,7 @@
 // BaseClientProxy
 //
 
-BaseClientProxy::BaseClientProxy(const String& name) :
+BaseClientProxy::BaseClientProxy(const std::string& name) :
     m_name(name),
     m_x(0),
     m_y(0)
@@ -49,8 +49,7 @@ BaseClientProxy::getJumpCursorPos(SInt32& x, SInt32& y) const
     y = m_y;
 }
 
-String
-BaseClientProxy::getName() const
+std::string BaseClientProxy::getName() const
 {
     return m_name;
 }

--- a/src/lib/server/BaseClientProxy.h
+++ b/src/lib/server/BaseClientProxy.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include "barrier/IClient.h"
-#include "base/String.h"
 
 namespace barrier { class IStream; }
 
@@ -29,7 +28,7 @@ public:
     /*!
     \c name is the name of the client.
     */
-    BaseClientProxy(const String& name);
+    BaseClientProxy(const std::string& name);
     ~BaseClientProxy();
 
     //! @name manipulators
@@ -89,11 +88,11 @@ public:
     virtual void        sendDragInfo(UInt32 fileCount, const char* info,
                             size_t size) = 0;
     virtual void        fileChunkSending(UInt8 mark, char* data, size_t dataSize) = 0;
-    virtual String        getName() const;
+    virtual std::string getName() const;
     virtual barrier::IStream*
                         getStream() const = 0;
 
 private:
-    String                m_name;
+    std::string m_name;
     SInt32                m_x, m_y;
 };

--- a/src/lib/server/ClientProxy.cpp
+++ b/src/lib/server/ClientProxy.cpp
@@ -27,7 +27,7 @@
 // ClientProxy
 //
 
-ClientProxy::ClientProxy(const String& name, barrier::IStream* stream) :
+ClientProxy::ClientProxy(const std::string& name, barrier::IStream* stream) :
     BaseClientProxy(name),
     m_stream(stream)
 {

--- a/src/lib/server/ClientProxy.h
+++ b/src/lib/server/ClientProxy.h
@@ -20,7 +20,6 @@
 
 #include "server/BaseClientProxy.h"
 #include "base/Event.h"
-#include "base/String.h"
 #include "base/EventTypes.h"
 
 namespace barrier { class IStream; }
@@ -31,7 +30,7 @@ public:
     /*!
     \c name is the name of the client.
     */
-    ClientProxy(const String& name, barrier::IStream* adoptedStream);
+    ClientProxy(const std::string& name, barrier::IStream* adoptedStream);
     ~ClientProxy();
 
     //! @name manipulators

--- a/src/lib/server/ClientProxy1_0.cpp
+++ b/src/lib/server/ClientProxy1_0.cpp
@@ -31,7 +31,8 @@
 // ClientProxy1_0
 //
 
-ClientProxy1_0::ClientProxy1_0(const String& name, barrier::IStream* stream, IEventQueue* events) :
+ClientProxy1_0::ClientProxy1_0(const std::string& name, barrier::IStream* stream,
+                               IEventQueue* events) :
     ClientProxy(name, stream),
     m_heartbeatTimer(NULL),
     m_parser(&ClientProxy1_0::parseHandshakeMessage),

--- a/src/lib/server/ClientProxy1_0.h
+++ b/src/lib/server/ClientProxy1_0.h
@@ -29,7 +29,7 @@ class IEventQueue;
 //! Proxy for client implementing protocol version 1.0
 class ClientProxy1_0 : public ClientProxy {
 public:
-    ClientProxy1_0(const String& name, barrier::IStream* adoptedStream, IEventQueue* events);
+    ClientProxy1_0(const std::string& name, barrier::IStream* adoptedStream, IEventQueue* events);
     ~ClientProxy1_0();
 
     // IScreen

--- a/src/lib/server/ClientProxy1_1.cpp
+++ b/src/lib/server/ClientProxy1_1.cpp
@@ -27,7 +27,8 @@
 // ClientProxy1_1
 //
 
-ClientProxy1_1::ClientProxy1_1(const String& name, barrier::IStream* stream, IEventQueue* events) :
+ClientProxy1_1::ClientProxy1_1(const std::string& name, barrier::IStream* stream,
+                               IEventQueue* events) :
     ClientProxy1_0(name, stream, events)
 {
     // do nothing

--- a/src/lib/server/ClientProxy1_1.h
+++ b/src/lib/server/ClientProxy1_1.h
@@ -23,7 +23,7 @@
 //! Proxy for client implementing protocol version 1.1
 class ClientProxy1_1 : public ClientProxy1_0 {
 public:
-    ClientProxy1_1(const String& name, barrier::IStream* adoptedStream, IEventQueue* events);
+    ClientProxy1_1(const std::string& name, barrier::IStream* adoptedStream, IEventQueue* events);
     ~ClientProxy1_1();
 
     // IClient overrides

--- a/src/lib/server/ClientProxy1_2.cpp
+++ b/src/lib/server/ClientProxy1_2.cpp
@@ -25,7 +25,8 @@
 // ClientProxy1_1
 //
 
-ClientProxy1_2::ClientProxy1_2(const String& name, barrier::IStream* stream, IEventQueue* events) :
+ClientProxy1_2::ClientProxy1_2(const std::string& name, barrier::IStream* stream,
+                               IEventQueue* events) :
     ClientProxy1_1(name, stream, events)
 {
     // do nothing

--- a/src/lib/server/ClientProxy1_2.h
+++ b/src/lib/server/ClientProxy1_2.h
@@ -25,7 +25,7 @@ class IEventQueue;
 //! Proxy for client implementing protocol version 1.2
 class ClientProxy1_2 : public ClientProxy1_1 {
 public:
-    ClientProxy1_2(const String& name, barrier::IStream* adoptedStream, IEventQueue* events);
+    ClientProxy1_2(const std::string& name, barrier::IStream* adoptedStream, IEventQueue* events);
     ~ClientProxy1_2();
 
     // IClient overrides

--- a/src/lib/server/ClientProxy1_3.cpp
+++ b/src/lib/server/ClientProxy1_3.cpp
@@ -30,7 +30,8 @@
 // ClientProxy1_3
 //
 
-ClientProxy1_3::ClientProxy1_3(const String& name, barrier::IStream* stream, IEventQueue* events) :
+ClientProxy1_3::ClientProxy1_3(const std::string& name, barrier::IStream* stream,
+                               IEventQueue* events) :
     ClientProxy1_2(name, stream, events),
     m_keepAliveRate(kKeepAliveRate),
     m_keepAliveTimer(NULL),

--- a/src/lib/server/ClientProxy1_3.h
+++ b/src/lib/server/ClientProxy1_3.h
@@ -23,7 +23,7 @@
 //! Proxy for client implementing protocol version 1.3
 class ClientProxy1_3 : public ClientProxy1_2 {
 public:
-    ClientProxy1_3(const String& name, barrier::IStream* adoptedStream, IEventQueue* events);
+    ClientProxy1_3(const std::string& name, barrier::IStream* adoptedStream, IEventQueue* events);
     ~ClientProxy1_3();
 
     // IClient overrides

--- a/src/lib/server/ClientProxy1_4.cpp
+++ b/src/lib/server/ClientProxy1_4.cpp
@@ -31,7 +31,8 @@
 // ClientProxy1_4
 //
 
-ClientProxy1_4::ClientProxy1_4(const String& name, barrier::IStream* stream, Server* server, IEventQueue* events) :
+ClientProxy1_4::ClientProxy1_4(const std::string& name, barrier::IStream* stream, Server* server,
+                               IEventQueue* events) :
     ClientProxy1_3(name, stream, events), m_server(server)
 {
     assert(m_server != NULL);

--- a/src/lib/server/ClientProxy1_4.h
+++ b/src/lib/server/ClientProxy1_4.h
@@ -25,7 +25,8 @@ class Server;
 //! Proxy for client implementing protocol version 1.4
 class ClientProxy1_4 : public ClientProxy1_3 {
 public:
-    ClientProxy1_4(const String& name, barrier::IStream* adoptedStream, Server* server, IEventQueue* events);
+    ClientProxy1_4(const std::string& name, barrier::IStream* adoptedStream, Server* server,
+                   IEventQueue* events);
     ~ClientProxy1_4();
 
     //! @name accessors

--- a/src/lib/server/ClientProxy1_5.cpp
+++ b/src/lib/server/ClientProxy1_5.cpp
@@ -31,7 +31,8 @@
 // ClientProxy1_5
 //
 
-ClientProxy1_5::ClientProxy1_5(const String& name, barrier::IStream* stream, Server* server, IEventQueue* events) :
+ClientProxy1_5::ClientProxy1_5(const std::string& name, barrier::IStream* stream, Server* server,
+                               IEventQueue* events) :
     ClientProxy1_4(name, stream, server, events),
     m_events(events)
 {
@@ -50,7 +51,7 @@ ClientProxy1_5::~ClientProxy1_5()
 void
 ClientProxy1_5::sendDragInfo(UInt32 fileCount, const char* info, size_t size)
 {
-    String data(info, size);
+    std::string data(info, size);
 
     ProtocolUtil::writef(getStream(), kMsgDDragInfo, fileCount, &data);
 }
@@ -92,7 +93,7 @@ ClientProxy1_5::fileChunkReceived()
     }
     else if (result == kStart) {
         if (server->getFakeDragFileList().size() > 0) {
-            String filename = server->getFakeDragFileList().at(0).getFilename();
+            std::string filename = server->getFakeDragFileList().at(0).getFilename();
             LOG((CLOG_DEBUG "start receiving %s", filename.c_str()));
         }
     }
@@ -103,7 +104,7 @@ ClientProxy1_5::dragInfoReceived()
 {
     // parse
     UInt32 fileNum = 0;
-    String content;
+    std::string content;
     ProtocolUtil::readf(getStream(), kMsgDDragInfo + 4, &fileNum, &content);
     
     m_server->dragInfoReceived(fileNum, content);

--- a/src/lib/server/ClientProxy1_5.h
+++ b/src/lib/server/ClientProxy1_5.h
@@ -27,7 +27,8 @@ class IEventQueue;
 //! Proxy for client implementing protocol version 1.5
 class ClientProxy1_5 : public ClientProxy1_4 {
 public:
-    ClientProxy1_5(const String& name, barrier::IStream* adoptedStream, Server* server, IEventQueue* events);
+    ClientProxy1_5(const std::string& name, barrier::IStream* adoptedStream, Server* server,
+                   IEventQueue* events);
     ~ClientProxy1_5();
 
     virtual void        sendDragInfo(UInt32 fileCount, const char* info, size_t size);

--- a/src/lib/server/ClientProxy1_6.cpp
+++ b/src/lib/server/ClientProxy1_6.cpp
@@ -29,7 +29,8 @@
 // ClientProxy1_6
 //
 
-ClientProxy1_6::ClientProxy1_6(const String& name, barrier::IStream* stream, Server* server, IEventQueue* events) :
+ClientProxy1_6::ClientProxy1_6(const std::string& name, barrier::IStream* stream, Server* server,
+                               IEventQueue* events) :
     ClientProxy1_5(name, stream, server, events),
     m_events(events)
 {
@@ -52,7 +53,7 @@ ClientProxy1_6::setClipboard(ClipboardID id, const IClipboard* clipboard)
         m_clipboard[id].m_dirty = false;
         Clipboard::copy(&m_clipboard[id].m_clipboard, clipboard);
 
-        String data = m_clipboard[id].m_clipboard.marshall();
+        std::string data = m_clipboard[id].m_clipboard.marshall();
 
         size_t size = data.size();
         LOG((CLOG_DEBUG "sending clipboard %d to \"%s\"", id, getName().c_str()));
@@ -71,7 +72,7 @@ bool
 ClientProxy1_6::recvClipboard()
 {
     // parse message
-    static String dataCached;
+    static std::string dataCached;
     ClipboardID id;
     UInt32 seq;
 

--- a/src/lib/server/ClientProxy1_6.h
+++ b/src/lib/server/ClientProxy1_6.h
@@ -25,7 +25,8 @@ class IEventQueue;
 //! Proxy for client implementing protocol version 1.6
 class ClientProxy1_6 : public ClientProxy1_5 {
 public:
-    ClientProxy1_6(const String& name, barrier::IStream* adoptedStream, Server* server, IEventQueue* events);
+    ClientProxy1_6(const std::string& name, barrier::IStream* adoptedStream, Server* server,
+                   IEventQueue* events);
     ~ClientProxy1_6();
 
     virtual void        setClipboard(ClipboardID id, const IClipboard* clipboard);

--- a/src/lib/server/ClientProxyUnknown.cpp
+++ b/src/lib/server/ClientProxyUnknown.cpp
@@ -32,7 +32,6 @@
 #include "io/IStream.h"
 #include "io/XIO.h"
 #include "base/Log.h"
-#include "base/String.h"
 #include "base/IEventQueue.h"
 #include "base/TMethodEventJob.h"
 
@@ -176,7 +175,7 @@ ClientProxyUnknown::handleData(const Event&, void*)
 {
     LOG((CLOG_DEBUG1 "parsing hello reply"));
 
-    String name("<unknown>");
+    std::string name("<unknown>");
     try {
         // limit the maximum length of the hello
         UInt32 n = m_stream->getSize();

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -48,7 +48,7 @@ Config::~Config()
 }
 
 bool
-Config::addScreen(const String& name)
+Config::addScreen(const std::string& name)
 {
 	// alias name must not exist
 	if (m_nameToCanonicalName.find(name) != m_nameToCanonicalName.end()) {
@@ -64,12 +64,10 @@ Config::addScreen(const String& name)
 	return true;
 }
 
-bool
-Config::renameScreen(const String& oldName,
-							const String& newName)
+bool Config::renameScreen(const std::string& oldName, const std::string& newName)
 {
 	// get canonical name and find cell
-	String oldCanonical = getCanonicalName(oldName);
+    std::string oldCanonical = getCanonicalName(oldName);
 	CellMap::iterator index = m_map.find(oldCanonical);
 	if (index == m_map.end()) {
 		return false;
@@ -111,11 +109,10 @@ Config::renameScreen(const String& oldName,
 	return true;
 }
 
-void
-Config::removeScreen(const String& name)
+void Config::removeScreen(const std::string& name)
 {
 	// get canonical name and find cell
-	String canonical = getCanonicalName(name);
+    std::string canonical = getCanonicalName(name);
 	CellMap::iterator index = m_map.find(canonical);
 	if (index == m_map.end()) {
 		return;
@@ -149,8 +146,7 @@ Config::removeAllScreens()
 	m_nameToCanonicalName.clear();
 }
 
-bool
-Config::addAlias(const String& canonical, const String& alias)
+bool Config::addAlias(const std::string& canonical, const std::string& alias)
 {
 	// alias name must not exist
 	if (m_nameToCanonicalName.find(alias) != m_nameToCanonicalName.end()) {
@@ -168,8 +164,7 @@ Config::addAlias(const String& canonical, const String& alias)
 	return true;
 }
 
-bool
-Config::removeAlias(const String& alias)
+bool Config::removeAlias(const std::string& alias)
 {
 	// must not be a canonical name
 	if (m_map.find(alias) != m_map.end()) {
@@ -188,8 +183,7 @@ Config::removeAlias(const String& alias)
 	return true;
 }
 
-bool
-Config::removeAliases(const String& canonical)
+bool Config::removeAliases(const std::string& canonical)
 {
 	// must be a canonical name
 	if (m_map.find(canonical) == m_map.end()) {
@@ -224,12 +218,9 @@ Config::removeAllAliases()
 	}
 }
 
-bool
-Config::connect(const String& srcName,
-				EDirection srcSide,
-				float srcStart, float srcEnd,
-				const String& dstName,
-				float dstStart, float dstEnd)
+bool Config::connect(const std::string& srcName, EDirection srcSide,
+                     float srcStart, float srcEnd, const std::string& dstName,
+                     float dstStart, float dstEnd)
 {
 	assert(srcSide >= kFirstDirection && srcSide <= kLastDirection);
 
@@ -245,8 +236,7 @@ Config::connect(const String& srcName,
 	return index->second.add(srcEdge, dstEdge);
 }
 
-bool
-Config::disconnect(const String& srcName, EDirection srcSide)
+bool Config::disconnect(const std::string& srcName, EDirection srcSide)
 {
 	assert(srcSide >= kFirstDirection && srcSide <= kLastDirection);
 
@@ -262,8 +252,7 @@ Config::disconnect(const String& srcName, EDirection srcSide)
 	return true;
 }
 
-bool
-Config::disconnect(const String& srcName, EDirection srcSide, float position)
+bool Config::disconnect(const std::string& srcName, EDirection srcSide, float position)
 {
 	assert(srcSide >= kFirstDirection && srcSide <= kLastDirection);
 
@@ -285,8 +274,7 @@ Config::setBarrierAddress(const NetworkAddress& addr)
 	m_barrierAddress = addr;
 }
 
-bool
-Config::addOption(const String& name, OptionID option, OptionValue value)
+bool Config::addOption(const std::string& name, OptionID option, OptionValue value)
 {
 	// find options
 	ScreenOptions* options = NULL;
@@ -308,8 +296,7 @@ Config::addOption(const String& name, OptionID option, OptionValue value)
 	return true;
 }
 
-bool
-Config::removeOption(const String& name, OptionID option)
+bool Config::removeOption(const std::string& name, OptionID option)
 {
 	// find options
 	ScreenOptions* options = NULL;
@@ -331,8 +318,7 @@ Config::removeOption(const String& name, OptionID option)
 	return true;
 }
 
-bool
-Config::removeOptions(const String& name)
+bool Config::removeOptions(const std::string& name)
 {
 	// find options
 	ScreenOptions* options = NULL;
@@ -354,8 +340,7 @@ Config::removeOptions(const String& name)
 	return true;
 }
 
-bool
-Config::isValidScreenName(const String& name) const
+bool Config::isValidScreenName(const std::string& name) const
 {
 	// name is valid if matches validname
 	//  name      ::= [_A-Za-z0-9] | [_A-Za-z0-9][-_A-Za-z0-9]*[_A-Za-z0-9]
@@ -370,7 +355,7 @@ Config::isValidScreenName(const String& name) const
 	}
 
 	// check each dot separated part
-	String::size_type b = 0;
+    std::string::size_type b = 0;
 	for (;;) {
 		// accept trailing .
 		if (b == name.size()) {
@@ -378,8 +363,8 @@ Config::isValidScreenName(const String& name) const
 		}
 
 		// find end of part
-		String::size_type e = name.find('.', b);
-		if (e == String::npos) {
+        std::string::size_type e = name.find('.', b);
+                if (e == std::string::npos) {
 			e = name.size();
 		}
 
@@ -395,7 +380,7 @@ Config::isValidScreenName(const String& name) const
 		}
 
 		// check interior characters
-		for (String::size_type i = b; i < e; ++i) {
+        for (std::string::size_type i = b; i < e; ++i) {
 			if (!isalnum(name[i]) && name[i] != '_' && name[i] != '-') {
 				return false;
 			}
@@ -437,40 +422,38 @@ Config::endAll() const
 }
 
 bool
-Config::isScreen(const String& name) const
+Config::isScreen(const std::string& name) const
 {
 	return (m_nameToCanonicalName.count(name) > 0);
 }
 
 bool
-Config::isCanonicalName(const String& name) const
+Config::isCanonicalName(const std::string& name) const
 {
 	return (!name.empty() &&
 			CaselessCmp::equal(getCanonicalName(name), name));
 }
 
-String
-Config::getCanonicalName(const String& name) const
+std::string Config::getCanonicalName(const std::string& name) const
 {
 	NameMap::const_iterator index = m_nameToCanonicalName.find(name);
 	if (index == m_nameToCanonicalName.end()) {
-		return String();
+        return std::string();
 	}
 	else {
 		return index->second;
 	}
 }
 
-String
-Config::getNeighbor(const String& srcName, EDirection srcSide,
-				float position, float* positionOut) const
+std::string Config::getNeighbor(const std::string& srcName, EDirection srcSide,
+                                float position, float* positionOut) const
 {
 	assert(srcSide >= kFirstDirection && srcSide <= kLastDirection);
 
 	// find source cell
 	CellMap::const_iterator index = m_map.find(getCanonicalName(srcName));
 	if (index == m_map.end()) {
-		return String();
+        return std::string();
 	}
 
 	// find edge
@@ -491,15 +474,13 @@ Config::getNeighbor(const String& srcName, EDirection srcSide,
 	}
 }
 
-bool
-Config::hasNeighbor(const String& srcName, EDirection srcSide) const
+bool Config::hasNeighbor(const std::string& srcName, EDirection srcSide) const
 {
 	return hasNeighbor(srcName, srcSide, 0.0f, 1.0f);
 }
 
-bool
-Config::hasNeighbor(const String& srcName, EDirection srcSide,
-							float start, float end) const
+bool Config::hasNeighbor(const std::string& srcName, EDirection srcSide,
+                         float start, float end) const
 {
 	assert(srcSide >= kFirstDirection && srcSide <= kLastDirection);
 
@@ -512,16 +493,14 @@ Config::hasNeighbor(const String& srcName, EDirection srcSide,
 	return index->second.overlaps(CellEdge(srcSide, Interval(start, end)));
 }
 
-Config::link_const_iterator
-Config::beginNeighbor(const String& srcName) const
+Config::link_const_iterator Config::beginNeighbor(const std::string& srcName) const
 {
 	CellMap::const_iterator index = m_map.find(getCanonicalName(srcName));
 	assert(index != m_map.end());
 	return index->second.begin();
 }
 
-Config::link_const_iterator
-Config::endNeighbor(const String& srcName) const
+Config::link_const_iterator Config::endNeighbor(const std::string& srcName) const
 {
 	CellMap::const_iterator index = m_map.find(getCanonicalName(srcName));
 	assert(index != m_map.end());
@@ -534,8 +513,7 @@ Config::getBarrierAddress() const
 	return m_barrierAddress;
 }
 
-const Config::ScreenOptions*
-Config::getOptions(const String& name) const
+const Config::ScreenOptions* Config::getOptions(const std::string& name) const
 {
 	// find options
 	const ScreenOptions* options = NULL;
@@ -641,8 +619,7 @@ Config::getInputFilter()
 	return &m_inputFilter;
 }
 
-String
-Config::formatInterval(const Interval& x)
+std::string Config::formatInterval(const Interval& x)
 {
 	if (x.first == 0.0f && x.second == 1.0f) {
 		return "";
@@ -660,7 +637,7 @@ Config::readSection(ConfigReadContext& s)
 	static const char s_links[]   = "links";
 	static const char s_aliases[] = "aliases";
 
-	String line;
+    std::string line;
 	if (!s.readLine(line)) {
 		// no more sections
 		return;
@@ -672,13 +649,13 @@ Config::readSection(ConfigReadContext& s)
 	}
 
 	// get section name
-	String::size_type i = line.find_first_not_of(" \t", sizeof(s_section) - 1);
-	if (i == String::npos) {
+    std::string::size_type i = line.find_first_not_of(" \t", sizeof(s_section) - 1);
+    if (i == std::string::npos) {
 		throw XConfigRead(s, "section name is missing");
 	}
-	String name = line.substr(i);
+    std::string name = line.substr(i);
 	i = name.find_first_of(" \t");
-	if (i != String::npos) {
+    if (i != std::string::npos) {
 		throw XConfigRead(s, "unexpected data after section name");
 	}
 
@@ -703,7 +680,7 @@ Config::readSection(ConfigReadContext& s)
 void
 Config::readSectionOptions(ConfigReadContext& s)
 {
-	String line;
+    std::string line;
 	while (s.readLine(line)) {
 		// check for end of section
 		if (line == "end") {
@@ -714,8 +691,8 @@ Config::readSectionOptions(ConfigReadContext& s)
 		//   nameAndArgs  := <name>[(arg[,...])]
 		//   values       := valueAndArgs[,valueAndArgs]...
 		//   valueAndArgs := <value>[(arg[,...])]
-		String::size_type i = 0;
-		String name, value;
+        std::string::size_type i = 0;
+        std::string name, value;
 		ConfigReadContext::ArgList nameArgs, valueArgs;
 		s.parseNameWithArgs("name", line, "=", i, name, nameArgs);
 		++i;
@@ -728,8 +705,7 @@ Config::readSectionOptions(ConfigReadContext& s)
 				m_barrierAddress.resolve();
 			}
 			catch (XSocketAddress& e) {
-				throw XConfigRead(s,
-							String("invalid address argument ") + e.what());
+                throw XConfigRead(s, std::string("invalid address argument ") + e.what());
 			}
 		}
 		else if (name == "heartbeat") {
@@ -799,7 +775,7 @@ Config::readSectionOptions(ConfigReadContext& s)
 			if (i < line.length() && line[i] == ';') {
 				// allow trailing ';'
 				i = line.find_first_not_of(" \t", i + 1);
-				if (i == String::npos) {
+                if (i == std::string::npos) {
 					i = line.length();
 				}
 				else {
@@ -825,9 +801,9 @@ Config::readSectionOptions(ConfigReadContext& s)
 void
 Config::readSectionScreens(ConfigReadContext& s)
 {
-	String line;
-	String screen;
-	while (s.readLine(line)) {
+    std::string line;
+    std::string screen;
+    while (s.readLine(line)) {
 		// check for end of section
 		if (line == "end") {
 			return;
@@ -853,21 +829,21 @@ Config::readSectionScreens(ConfigReadContext& s)
 		}
 		else {
 			// parse argument:  `<name>=<value>'
-			String::size_type i = line.find_first_of(" \t=");
+            std::string::size_type i = line.find_first_of(" \t=");
 			if (i == 0) {
 				throw XConfigRead(s, "missing argument name");
 			}
-			if (i == String::npos) {
+                        if (i == std::string::npos) {
 				throw XConfigRead(s, "missing =");
 			}
-			String name = line.substr(0, i);
+            std::string name = line.substr(0, i);
 			i = line.find_first_not_of(" \t", i);
-			if (i == String::npos || line[i] != '=') {
+                        if (i == std::string::npos || line[i] != '=') {
 				throw XConfigRead(s, "missing =");
 			}
 			i = line.find_first_not_of(" \t", i + 1);
-			String value;
-			if (i != String::npos) {
+            std::string value;
+            if (i != std::string::npos) {
 				value = line.substr(i);
 			}
 
@@ -936,8 +912,8 @@ Config::readSectionScreens(ConfigReadContext& s)
 void
 Config::readSectionLinks(ConfigReadContext& s)
 {
-	String line;
-	String screen;
+    std::string line;
+    std::string screen;
 	while (s.readLine(line)) {
 		// check for end of section
 		if (line == "end") {
@@ -965,8 +941,8 @@ Config::readSectionLinks(ConfigReadContext& s)
 			// the stuff in brackets is optional.  interval values must be
 			// in the range [0,100] and start < end.  if not given the
 			// interval is taken to be (0,100).
-			String::size_type i = 0;
-			String side, dstScreen, srcArgString, dstArgString;
+            std::string::size_type i = 0;
+            std::string side, dstScreen, srcArgString, dstArgString;
 			ConfigReadContext::ArgList srcArgs, dstArgs;
 			s.parseNameWithArgs("link", line, "=", i, side, srcArgs);
 			++i;
@@ -1009,8 +985,8 @@ Config::readSectionLinks(ConfigReadContext& s)
 void
 Config::readSectionAliases(ConfigReadContext& s)
 {
-	String line;
-	String screen;
+    std::string line;
+    std::string screen;
 	while (s.readLine(line)) {
 		// check for end of section
 		if (line == "end") {
@@ -1049,9 +1025,8 @@ Config::readSectionAliases(ConfigReadContext& s)
 }
 
 
-InputFilter::Condition*
-Config::parseCondition(ConfigReadContext& s,
-				const String& name, const std::vector<String>& args)
+InputFilter::Condition* Config::parseCondition(ConfigReadContext& s, const std::string& name,
+                                               const std::vector<std::string>& args)
 {
 	if (name == "keystroke") {
 		if (args.size() != 1) {
@@ -1078,7 +1053,7 @@ Config::parseCondition(ConfigReadContext& s,
 			throw XConfigRead(s, "syntax for condition: connect([screen])");
 		}
 
-		String screen = args[0];
+        std::string screen = args[0];
 		if (isScreen(screen)) {
 			screen = getCanonicalName(screen);
 		}
@@ -1092,10 +1067,9 @@ Config::parseCondition(ConfigReadContext& s,
 	throw XConfigRead(s, "unknown argument \"%{1}\"", name);
 }
 
-void
-Config::parseAction(ConfigReadContext& s,
-				const String& name, const std::vector<String>& args,
-				InputFilter::Rule& rule, bool activate)
+void Config::parseAction(ConfigReadContext& s, const std::string& name,
+                         const std::vector<std::string>& args,
+                         InputFilter::Rule& rule, bool activate)
 {
 	InputFilter::Action* action;
 
@@ -1109,7 +1083,7 @@ Config::parseAction(ConfigReadContext& s,
 			keyInfo = s.parseKeystroke(args[0]);
 		}
 		else {
-			std::set<String> screens;
+            std::set<std::string> screens;
 			parseScreens(s, args[1], screens);
 			keyInfo = s.parseKeystroke(args[0], screens);
 		}
@@ -1171,7 +1145,7 @@ Config::parseAction(ConfigReadContext& s,
 			throw XConfigRead(s, "syntax for action: switchToScreen(name)");
 		}
 
-		String screen = args[0];
+        std::string screen = args[0];
 		if (isScreen(screen)) {
 			screen = getCanonicalName(screen);
 		}
@@ -1258,7 +1232,7 @@ Config::parseAction(ConfigReadContext& s,
 			}
 		}
 
-		std::set<String> screens;
+        std::set<std::string> screens;
 		if (args.size() >= 2) {
 			parseScreens(s, args[1], screens);
 		}
@@ -1273,22 +1247,21 @@ Config::parseAction(ConfigReadContext& s,
 	rule.adoptAction(action, activate);
 }
 
-void
-Config::parseScreens(ConfigReadContext& c,
-				const String& s, std::set<String>& screens) const
+void Config::parseScreens(ConfigReadContext& c, const std::string& s,
+                          std::set<std::string>& screens) const
 {
 	screens.clear();
 
-	String::size_type i = 0;
+    std::string::size_type i = 0;
 	while (i < s.size()) {
 		// find end of next screen name
-		String::size_type j = s.find(':', i);
-		if (j == String::npos) {
+        std::string::size_type j = s.find(':', i);
+        if (j == std::string::npos) {
 			j = s.size();
 		}
 
 		// extract name
-		String rawName;
+        std::string rawName;
 		i = s.find_first_not_of(" \t", i);
 		if (i < j) {
 			rawName = s.substr(i, s.find_last_not_of(" \t", j - 1) - i + 1);
@@ -1299,7 +1272,7 @@ Config::parseScreens(ConfigReadContext& c,
 			screens.insert("*");
 		}
 		else if (!rawName.empty()) {
-			String name = getCanonicalName(rawName);
+            std::string name = getCanonicalName(rawName);
 			if (name.empty()) {
 				throw XConfigRead(c, "unknown screen name \"%{1}\"", rawName);
 			}
@@ -1386,8 +1359,7 @@ Config::getOptionName(OptionID id)
 	return NULL;
 }
 
-String
-Config::getOptionValue(OptionID id, OptionValue value)
+std::string Config::getOptionValue(OptionID id, OptionValue value)
 {
 	if (id == kOptionHalfDuplexCapsLock ||
 		id == kOptionHalfDuplexNumLock ||
@@ -1463,17 +1435,16 @@ Config::getOptionValue(OptionID id, OptionValue value)
 // Config::Name
 //
 
-Config::Name::Name(Config* config, const String& name) :
+Config::Name::Name(Config* config, const std::string& name) :
 	m_config(config),
 	m_name(config->getCanonicalName(name))
 {
 	// do nothing
 }
 
-bool
-Config::Name::operator==(const String& name) const
+bool Config::Name::operator==(const std::string& name) const
 {
-	String canonical = m_config->getCanonicalName(name);
+    std::string canonical = m_config->getCanonicalName(name);
 	return CaselessCmp::equal(canonical, m_name);
 }
 
@@ -1496,8 +1467,7 @@ Config::CellEdge::CellEdge(EDirection side, const Interval& interval)
 	init("", side, interval);
 }
 
-Config::CellEdge::CellEdge(const String& name,
-				EDirection side, const Interval& interval)
+Config::CellEdge::CellEdge(const std::string& name, EDirection side, const Interval& interval)
 {
 	assert(interval.first >= 0.0f);
 	assert(interval.second <= 1.0f);
@@ -1511,9 +1481,7 @@ Config::CellEdge::~CellEdge()
 	// do nothing
 }
 
-void
-Config::CellEdge::init(const String& name, EDirection side,
-				const Interval& interval)
+void Config::CellEdge::init(const std::string& name, EDirection side, const Interval& interval)
 {
 	assert(side != kNoDirection);
 
@@ -1528,14 +1496,12 @@ Config::CellEdge::getInterval() const
 	return m_interval;
 }
 
-void
-Config::CellEdge::setName(const String& newName)
+void Config::CellEdge::setName(const std::string& newName)
 {
 	m_name = newName;
 }
 
-String
-Config::CellEdge::getName() const
+std::string Config::CellEdge::getName() const
 {
 	return m_name;
 }
@@ -1662,8 +1628,7 @@ Config::Cell::remove(const Name& name)
 	}
 }
 
-void
-Config::Cell::rename(const Name& oldName, const String& newName)
+void Config::Cell::rename(const Name& oldName, const std::string& newName)
 {
 	for (EdgeLinks::iterator j = m_neighbors.begin();
 							j != m_neighbors.end(); ++j) {
@@ -1789,8 +1754,7 @@ operator<<(std::ostream& s, const Config& config)
 								option  = options->begin();
 								option != options->end(); ++option) {
 				const char* name = Config::getOptionName(option->first);
-				String value    = Config::getOptionValue(option->first,
-															option->second);
+                std::string value = Config::getOptionValue(option->first, option->second);
 				if (name != NULL && !value.empty()) {
 					s << "\t\t" << name << " = " << value << std::endl;
 				}
@@ -1800,7 +1764,7 @@ operator<<(std::ostream& s, const Config& config)
 	s << "end" << std::endl;
 
 	// links section
-	String neighbor;
+    std::string neighbor;
 	s << "section: links" << std::endl;
 	for (Config::const_iterator screen = config.begin();
 								screen != config.end(); ++screen) {
@@ -1821,8 +1785,7 @@ operator<<(std::ostream& s, const Config& config)
 	// aliases section (if there are any)
 	if (config.m_map.size() != config.m_nameToCanonicalName.size()) {
 		// map canonical to alias
-		typedef std::multimap<String, String,
-								CaselessCmp> CMNameMap;
+        typedef std::multimap<std::string, std::string, CaselessCmp> CMNameMap;
 		CMNameMap aliases;
 		for (Config::NameMap::const_iterator
 								index = config.m_nameToCanonicalName.begin();
@@ -1834,7 +1797,7 @@ operator<<(std::ostream& s, const Config& config)
 		}
 
 		// dump it
-		String screen;
+        std::string screen;
 		s << "section: aliases" << std::endl;
 		for (CMNameMap::const_iterator index = aliases.begin();
 								index != aliases.end(); ++index) {
@@ -1855,8 +1818,7 @@ operator<<(std::ostream& s, const Config& config)
 							option  = options->begin();
 							option != options->end(); ++option) {
 			const char* name = Config::getOptionName(option->first);
-			String value    = Config::getOptionValue(option->first,
-														option->second);
+            std::string value = Config::getOptionValue(option->first, option->second);
 			if (name != NULL && !value.empty()) {
 				s << "\t" << name << " = " << value << std::endl;
 			}
@@ -1889,24 +1851,23 @@ ConfigReadContext::~ConfigReadContext()
 	// do nothing
 }
 
-bool
-ConfigReadContext::readLine(String& line)
+bool ConfigReadContext::readLine(std::string& line)
 {
 	++m_line;
 	while (std::getline(m_stream, line)) {
 		// strip leading whitespace
-		String::size_type i = line.find_first_not_of(" \t");
-		if (i != String::npos) {
-			line.erase(0, i);
+        std::string::size_type i = line.find_first_not_of(" \t");
+        if (i != std::string::npos) {
+            line.erase(0, i);
 		}
 
 		// strip comments and then trailing whitespace
 		i = line.find('#');
-		if (i != String::npos) {
+        if (i != std::string::npos) {
 			line.erase(i);
 		}
 		i = line.find_last_not_of(" \r\t");
-		if (i != String::npos) {
+        if (i != std::string::npos) {
 			line.erase(i + 1);
 		}
 
@@ -1942,8 +1903,7 @@ ConfigReadContext::operator!() const
 	return !m_stream;
 }
 
-OptionValue
-ConfigReadContext::parseBoolean(const String& arg) const
+OptionValue ConfigReadContext::parseBoolean(const std::string& arg) const
 {
 	if (CaselessCmp::equal(arg, "true")) {
 		return static_cast<OptionValue>(true);
@@ -1954,8 +1914,7 @@ ConfigReadContext::parseBoolean(const String& arg) const
 	throw XConfigRead(*this, "invalid boolean argument \"%{1}\"", arg);
 }
 
-OptionValue
-ConfigReadContext::parseInt(const String& arg) const
+OptionValue ConfigReadContext::parseInt(const std::string& arg) const
 {
 	const char* s = arg.c_str();
 	char* end;
@@ -1972,8 +1931,7 @@ ConfigReadContext::parseInt(const String& arg) const
 	return value;
 }
 
-OptionValue
-ConfigReadContext::parseModifierKey(const String& arg) const
+OptionValue ConfigReadContext::parseModifierKey(const std::string& arg) const
 {
 	if (CaselessCmp::equal(arg, "shift")) {
 		return static_cast<OptionValue>(kKeyModifierIDShift);
@@ -1999,8 +1957,7 @@ ConfigReadContext::parseModifierKey(const String& arg) const
 	throw XConfigRead(*this, "invalid argument \"%{1}\"", arg);
 }
 
-OptionValue
-ConfigReadContext::parseCorner(const String& arg) const
+OptionValue ConfigReadContext::parseCorner(const std::string& arg) const
 {
 	if (CaselessCmp::equal(arg, "left")) {
 		return kTopLeftMask | kBottomLeftMask;
@@ -2035,22 +1992,21 @@ ConfigReadContext::parseCorner(const String& arg) const
 	throw XConfigRead(*this, "invalid argument \"%{1}\"", arg);
 }
 
-OptionValue
-ConfigReadContext::parseCorners(const String& args) const
+OptionValue ConfigReadContext::parseCorners(const std::string& args) const
 {
 	// find first token
-	String::size_type i = args.find_first_not_of(" \t", 0);
-	if (i == String::npos) {
+    std::string::size_type i = args.find_first_not_of(" \t", 0);
+    if (i == std::string::npos) {
 		throw XConfigRead(*this, "missing corner argument");
 	}
-	String::size_type j = args.find_first_of(" \t", i);
+    std::string::size_type j = args.find_first_of(" \t", i);
 
 	// parse first corner token
 	OptionValue corners = parseCorner(args.substr(i, j - i));
 
 	// get +/-
 	i = args.find_first_not_of(" \t", j);
-	while (i != String::npos) {
+    while (i != std::string::npos) {
 		// parse +/-
 		bool add;
 		if (args[i] == '-') {
@@ -2060,15 +2016,14 @@ ConfigReadContext::parseCorners(const String& args) const
 			add = true;
 		}
 		else {
-			throw XConfigRead(*this,
-							"invalid corner operator \"%{1}\"",
-							String(args.c_str() + i, 1));
+            throw XConfigRead(*this, "invalid corner operator \"%{1}\"",
+                              std::string(args.c_str() + i, 1));
 		}
 
 		// get next corner token
 		i = args.find_first_not_of(" \t", i + 1);
 		j = args.find_first_of(" \t", i);
-		if (i == String::npos) {
+        if (i == std::string::npos) {
 			throw XConfigRead(*this, "missing corner argument");
 		}
 
@@ -2114,21 +2069,19 @@ ConfigReadContext::parseInterval(const ArgList& args) const
 	return Config::Interval(startValue / 100.0f, endValue / 100.0f);
 }
 
-void
-ConfigReadContext::parseNameWithArgs(
-				const String& type, const String& line,
-				const String& delim, String::size_type& index,
-				String& name, ArgList& args) const
+void ConfigReadContext::parseNameWithArgs(const std::string& type, const std::string& line,
+                                          const std::string& delim, std::string::size_type& index,
+                                          std::string& name, ArgList& args) const
 {
 	// skip leading whitespace
-	String::size_type i = line.find_first_not_of(" \t", index);
-	if (i == String::npos) {
-		throw XConfigRead(*this, String("missing ") + type);
+    std::string::size_type i = line.find_first_not_of(" \t", index);
+    if (i == std::string::npos) {
+        throw XConfigRead(*this, std::string("missing ") + type);
 	}
 
 	// find end of name
-	String::size_type j = line.find_first_of(" \t(" + delim, i);
-	if (j == String::npos) {
+    std::string::size_type j = line.find_first_of(" \t(" + delim, i);
+    if (j == std::string::npos) {
 		j = line.length();
 	}
 
@@ -2137,15 +2090,15 @@ ConfigReadContext::parseNameWithArgs(
 	args.clear();
 
 	// is it okay to not find a delimiter?
-	bool needDelim = (!delim.empty() && delim.find('\n') == String::npos);
+    bool needDelim = (!delim.empty() && delim.find('\n') == std::string::npos);
 
 	// skip whitespace
 	i = line.find_first_not_of(" \t", j);
-	if (i == String::npos && needDelim) {
+    if (i == std::string::npos && needDelim) {
 		// expected delimiter but didn't find it
-		throw XConfigRead(*this, String("missing ") + delim[0]);
+        throw XConfigRead(*this, std::string("missing ") + delim[0]);
 	}
-	if (i == String::npos) {
+        if (i == std::string::npos) {
 		// no arguments
 		index = line.length();
 		return;
@@ -2161,18 +2114,18 @@ ConfigReadContext::parseNameWithArgs(
 
 	// parse arguments
 	j = line.find_first_of(",)", i);
-	while (j != String::npos) {
+    while (j != std::string::npos) {
 		// extract arg
-		String arg(line.substr(i, j - i));
+        std::string arg(line.substr(i, j - i));
 		i = j;
 
 		// trim whitespace
 		j = arg.find_first_not_of(" \t");
-		if (j != String::npos) {
+        if (j != std::string::npos) {
 			arg.erase(0, j);
 		}
 		j = arg.find_last_not_of(" \t");
-		if (j != String::npos) {
+        if (j != std::string::npos) {
 			arg.erase(j + 1);
 		}
 
@@ -2192,7 +2145,7 @@ ConfigReadContext::parseNameWithArgs(
 	}
 
 	// verify ')'
-	if (j == String::npos) {
+    if (j == std::string::npos) {
 		// expected )
 		throw XConfigRead(*this, "missing )");
 	}
@@ -2202,17 +2155,17 @@ ConfigReadContext::parseNameWithArgs(
 
 	// skip whitespace
 	j = line.find_first_not_of(" \t", i);
-	if (j == String::npos && needDelim) {
+    if (j == std::string::npos && needDelim) {
 		// expected delimiter but didn't find it
-		throw XConfigRead(*this, String("missing ") + delim[0]);
+        throw XConfigRead(*this, std::string("missing ") + delim[0]);
 	}
 
 	// verify delimiter
-	if (needDelim && delim.find(line[j]) == String::npos) {
-		throw XConfigRead(*this, String("expected ") + delim[0]);
+        if (needDelim && delim.find(line[j]) == std::string::npos) {
+                throw XConfigRead(*this, std::string("expected ") + delim[0]);
 	}
 
-	if (j == String::npos) {
+    if (j == std::string::npos) {
 		j = line.length();
 	}
 
@@ -2220,17 +2173,15 @@ ConfigReadContext::parseNameWithArgs(
 	return;
 }
 
-IPlatformScreen::KeyInfo*
-ConfigReadContext::parseKeystroke(const String& keystroke) const
+IPlatformScreen::KeyInfo* ConfigReadContext::parseKeystroke(const std::string& keystroke) const
 {
-	return parseKeystroke(keystroke, std::set<String>());
+        return parseKeystroke(keystroke, std::set<std::string>());
 }
 
-IPlatformScreen::KeyInfo*
-ConfigReadContext::parseKeystroke(const String& keystroke,
-				const std::set<String>& screens) const
+IPlatformScreen::KeyInfo* ConfigReadContext::parseKeystroke(const std::string& keystroke,
+                                                            const std::set<std::string>& screens) const
 {
-	String s = keystroke;
+    std::string s = keystroke;
 
 	KeyModifierMask mask;
 	if (!barrier::KeyMap::parseModifiers(s, mask)) {
@@ -2250,9 +2201,9 @@ ConfigReadContext::parseKeystroke(const String& keystroke,
 }
 
 IPlatformScreen::ButtonInfo*
-ConfigReadContext::parseMouse(const String& mouse) const
+ConfigReadContext::parseMouse(const std::string& mouse) const
 {
-	String s = mouse;
+    std::string s = mouse;
 
 	KeyModifierMask mask;
 	if (!barrier::KeyMap::parseModifiers(s, mask)) {
@@ -2271,10 +2222,9 @@ ConfigReadContext::parseMouse(const String& mouse) const
 	return IPlatformScreen::ButtonInfo::alloc(button, mask);
 }
 
-KeyModifierMask
-ConfigReadContext::parseModifier(const String& modifiers) const
+KeyModifierMask ConfigReadContext::parseModifier(const std::string& modifiers) const
 {
-	String s = modifiers;
+    std::string s = modifiers;
 
 	KeyModifierMask mask;
 	if (!barrier::KeyMap::parseModifiers(s, mask)) {
@@ -2288,10 +2238,9 @@ ConfigReadContext::parseModifier(const String& modifiers) const
 	return mask;
 }
 
-String
-ConfigReadContext::concatArgs(const ArgList& args)
+std::string ConfigReadContext::concatArgs(const ArgList& args)
 {
-	String s("(");
+    std::string s("(");
 	for (size_t i = 0; i < args.size(); ++i) {
 		if (i != 0) {
 			s += ",";
@@ -2307,16 +2256,15 @@ ConfigReadContext::concatArgs(const ArgList& args)
 // Config I/O exceptions
 //
 
-XConfigRead::XConfigRead(const ConfigReadContext& context,
-				const String& error) :
+XConfigRead::XConfigRead(const ConfigReadContext& context, const std::string& error) :
 	m_error(barrier::string::sprintf("line %d: %s",
 							context.getLineNumber(), error.c_str()))
 {
 	// do nothing
 }
 
-XConfigRead::XConfigRead(const ConfigReadContext& context,
-				const char* errorFmt, const String& arg) :
+XConfigRead::XConfigRead(const ConfigReadContext& context, const char* errorFmt,
+                         const std::string& arg) :
 	m_error(barrier::string::sprintf("line %d: ", context.getLineNumber()) +
 							barrier::string::format(errorFmt, arg.c_str()))
 {
@@ -2328,8 +2276,7 @@ XConfigRead::~XConfigRead() _NOEXCEPT
 	// do nothing
 }
 
-String
-XConfigRead::getWhat() const throw()
+std::string XConfigRead::getWhat() const throw()
 {
 	return format("XConfigRead", "read error: %{1}", m_error.c_str());
 }

--- a/src/lib/server/Config.h
+++ b/src/lib/server/Config.h
@@ -23,7 +23,6 @@
 #include "barrier/protocol_types.h"
 #include "barrier/IPlatformScreen.h"
 #include "net/NetworkAddress.h"
-#include "base/String.h"
 #include "base/XBase.h"
 #include "common/stdmap.h"
 #include "common/stdset.h"
@@ -37,11 +36,11 @@ class IEventQueue;
 namespace std {
 template <>
 struct iterator_traits<Config> {
-    typedef String                        value_type;
+    typedef std::string value_type;
     typedef ptrdiff_t                    difference_type;
     typedef bidirectional_iterator_tag    iterator_category;
-    typedef String*                    pointer;
-    typedef String&                    reference;
+    typedef std::string* pointer;
+    typedef std::string& reference;
 };
 };
 
@@ -64,12 +63,12 @@ public:
     public:
         CellEdge(EDirection side, float position);
         CellEdge(EDirection side, const Interval&);
-        CellEdge(const String& name, EDirection side, const Interval&);
+        CellEdge(const std::string& name, EDirection side, const Interval&);
         ~CellEdge();
 
         Interval        getInterval() const;
-        void            setName(const String& newName);
-        String            getName() const;
+        void setName(const std::string& newName);
+        std::string getName() const;
         EDirection        getSide() const;
         bool            overlaps(const CellEdge&) const;
         bool            isInside(float x) const;
@@ -88,11 +87,10 @@ public:
         bool            operator!=(const CellEdge&) const;
 
     private:
-        void            init(const String& name, EDirection side,
-                            const Interval&);
+        void init(const std::string& name, EDirection side, const Interval&);
 
     private:
-        String            m_name;
+        std::string m_name;
         EDirection        m_side;
         Interval        m_interval;
     };
@@ -100,13 +98,13 @@ public:
 private:
     class Name {
     public:
-        Name(Config*, const String& name);
+        Name(Config*, const std::string& name);
 
-        bool            operator==(const String& name) const;
+        bool operator==(const std::string& name) const;
 
     private:
         Config*            m_config;
-        String            m_name;
+        std::string m_name;
     };
 
     class Cell {
@@ -120,7 +118,7 @@ private:
         void            remove(EDirection side);
         void            remove(EDirection side, float position);
         void            remove(const Name& destinationName);
-        void            rename(const Name& oldName, const String& newName);
+        void            rename(const Name& oldName, const std::string& newName);
 
         bool            hasEdge(const CellEdge&) const;
         bool            overlaps(const CellEdge&) const;
@@ -140,8 +138,8 @@ private:
     public:
         ScreenOptions    m_options;
     };
-    typedef std::map<String, Cell, barrier::string::CaselessCmp> CellMap;
-    typedef std::map<String, String, barrier::string::CaselessCmp> NameMap;
+    typedef std::map<std::string, Cell, barrier::string::CaselessCmp> CellMap;
+    typedef std::map<std::string, std::string, barrier::string::CaselessCmp> NameMap;
 
 public:
     typedef Cell::const_iterator link_const_iterator;
@@ -156,8 +154,8 @@ public:
             m_i = i.m_i;
             return *this;
         }
-        String            operator*() { return m_i->first; }
-        const String*    operator->() { return &(m_i->first); }
+        std::string operator*() { return m_i->first; }
+        const std::string* operator->() { return &(m_i->first); }
         const_iterator&    operator++() { ++m_i;  return *this; }
         const_iterator    operator++(int) { return const_iterator(m_i++); }
         const_iterator&    operator--() { --m_i;  return *this; }
@@ -188,15 +186,14 @@ public:
     Adds a screen, returning true iff successful.  If a screen or
     alias with the given name exists then it fails.
     */
-    bool                addScreen(const String& name);
+    bool addScreen(const std::string& name);
 
     //! Rename screen
     /*!
     Renames a screen.  All references to the name are updated.
     Returns true iff successful.
     */
-    bool                renameScreen(const String& oldName,
-                            const String& newName);
+    bool renameScreen(const std::string& oldName, const std::string& newName);
 
     //! Remove screen
     /*!
@@ -204,7 +201,7 @@ public:
     disconnects any connections to the screen.  \c name may be an
     alias.
     */
-    void                removeScreen(const String& name);
+    void removeScreen(const std::string& name);
 
     //! Remove all screens
     /*!
@@ -219,22 +216,21 @@ public:
     Returns false if the alias name already exists or the canonical
     name is unknown, otherwise returns true.
     */
-    bool                addAlias(const String& canonical,
-                            const String& alias);
+    bool addAlias(const std::string& canonical, const std::string& alias);
 
     //! Remove alias
     /*!
     Removes an alias for a screen name.  It returns false if the
     alias is unknown or a canonical name, otherwise returns true.
     */
-    bool                removeAlias(const String& alias);
+    bool removeAlias(const std::string& alias);
 
     //! Remove aliases
     /*!
     Removes all aliases for a canonical screen name.  It returns false
     if the canonical name is unknown, otherwise returns true.
     */
-    bool                removeAliases(const String& canonical);
+    bool removeAliases(const std::string& canonical);
 
     //! Remove all aliases
     /*!
@@ -258,19 +254,15 @@ public:
     and all of \c srcStart, \c srcEnd, \c dstStart, or \c dstEnd must
     be inside the range [0,1].
     */
-    bool                connect(const String& srcName,
-                            EDirection srcSide,
-                            float srcStart, float srcEnd,
-                            const String& dstName,
-                            float dstStart, float dstEnd);
+    bool connect(const std::string& srcName, EDirection srcSide, float srcStart, float srcEnd,
+                 const std::string& dstName, float dstStart, float dstEnd);
 
     //! Disconnect screens
     /*!
     Removes all connections created by connect() on side \c srcSide.
     Returns false if \c srcName is unknown.
     */
-    bool                disconnect(const String& srcName,
-                            EDirection srcSide);
+    bool disconnect(const std::string& srcName, EDirection srcSide);
 
     //! Disconnect screens
     /*!
@@ -278,8 +270,7 @@ public:
     covering position \c position.  Returns false if \c srcName is
     unknown.
     */
-    bool                disconnect(const String& srcName,
-                            EDirection srcSide, float position);
+    bool disconnect(const std::string& srcName, EDirection srcSide, float position);
 
     //! Set server address
     /*!
@@ -294,8 +285,7 @@ public:
     existing option's value if there is one.  Returns true iff \c name
     is a known screen.
     */
-    bool                addOption(const String& name,
-                            OptionID option, OptionValue value);
+    bool addOption(const std::string& name, OptionID option, OptionValue value);
 
     //! Remove a screen option
     /*!
@@ -303,14 +293,14 @@ public:
     nothing if the option doesn't exist on the screen.  Returns true
     iff \c name is a known screen.
     */
-    bool                removeOption(const String& name, OptionID option);
+    bool removeOption(const std::string& name, OptionID option);
 
     //! Remove a screen options
     /*!
     Removes all options and values from the named screen.  Returns true
     iff \c name is a known screen.
     */
-    bool                removeOptions(const String& name);
+    bool removeOptions(const std::string& name);
 
     //! Get the hot key input filter
     /*!
@@ -328,7 +318,7 @@ public:
     /*!
     Returns true iff \c name is a valid screen name.
     */
-    bool                isValidScreenName(const String& name) const;
+    bool isValidScreenName(const std::string& name) const;
 
     //! Get beginning (canonical) screen name iterator
     const_iterator        begin() const;
@@ -344,20 +334,20 @@ public:
     /*!
     Returns true iff \c name names a screen.
     */
-    virtual bool        isScreen(const String& name) const;
+    virtual bool isScreen(const std::string& name) const;
 
     //! Test for canonical screen name
     /*!
     Returns true iff \c name is the canonical name of a screen.
     */
-    bool                isCanonicalName(const String& name) const;
+    bool isCanonicalName(const std::string& name) const;
 
     //! Get canonical name
     /*!
     Returns the canonical name of a screen or the empty string if
     the name is unknown.  Returns the canonical name if one is given.
     */
-    String                getCanonicalName(const String& name) const;
+    std::string getCanonicalName(const std::string& name) const;
 
     //! Get neighbor
     /*!
@@ -367,7 +357,7 @@ public:
     saves the position on the neighbor in \c positionOut if it's not
     \c NULL.
     */
-    String                getNeighbor(const String&, EDirection,
+    std::string getNeighbor(const std::string&, EDirection,
                             float position, float* positionOut) const;
 
     //! Check for neighbor
@@ -375,20 +365,19 @@ public:
     Returns \c true if the screen has a neighbor anywhere along the edge
     given by the direction.
     */
-    bool                hasNeighbor(const String&, EDirection) const;
+    bool hasNeighbor(const std::string&, EDirection) const;
 
     //! Check for neighbor
     /*!
     Returns \c true if the screen has a neighbor in the given range along
     the edge given by the direction.
     */
-    bool                hasNeighbor(const String&, EDirection,
-                            float start, float end) const;
+    bool hasNeighbor(const std::string&, EDirection, float start, float end) const;
 
     //! Get beginning neighbor iterator
-    link_const_iterator    beginNeighbor(const String&) const;
+    link_const_iterator beginNeighbor(const std::string&) const;
     //! Get ending neighbor iterator
-    link_const_iterator    endNeighbor(const String&) const;
+    link_const_iterator endNeighbor(const std::string&) const;
 
     //! Get the server address
     const NetworkAddress&
@@ -400,8 +389,7 @@ public:
     if the screen is unknown and an empty collection if there are no
     options.
     */
-    const ScreenOptions*
-                        getOptions(const String& name) const;
+    const ScreenOptions* getOptions(const std::string& name) const;
 
     //! Check for lock to screen action
     /*!
@@ -446,7 +434,7 @@ public:
     /*!
     Returns an interval as a parseable string.
     */
-    static String        formatInterval(const Interval&);
+    static std::string formatInterval(const Interval&);
 
     //@}
 
@@ -457,19 +445,16 @@ private:
     void                readSectionLinks(ConfigReadContext&);
     void                readSectionAliases(ConfigReadContext&);
 
-    InputFilter::Condition*
-                        parseCondition(ConfigReadContext&,
-                            const String& condition,
-                            const std::vector<String>& args);
-    void                parseAction(ConfigReadContext&,
-                            const String& action,
-                            const std::vector<String>& args,
-                            InputFilter::Rule&, bool activate);
+    InputFilter::Condition* parseCondition(ConfigReadContext&, const std::string& condition,
+                                           const std::vector<std::string>& args);
 
-    void                parseScreens(ConfigReadContext&, const String&,
-                            std::set<String>& screens) const;
+    void parseAction(ConfigReadContext&, const std::string& action,
+                     const std::vector<std::string>& args, InputFilter::Rule&, bool activate);
+
+    void parseScreens(ConfigReadContext&, const std::string&, std::set<std::string>& screens) const;
+
     static const char*    getOptionName(OptionID);
-    static String        getOptionValue(OptionID, OptionValue);
+    static std::string getOptionValue(OptionID, OptionValue);
 
 private:
     CellMap                m_map;
@@ -487,42 +472,41 @@ Maintains a context when reading a configuration from a stream.
 */
 class ConfigReadContext {
 public:
-    typedef std::vector<String> ArgList;
+    typedef std::vector<std::string> ArgList;
 
     ConfigReadContext(std::istream&, SInt32 firstLine = 1);
     ~ConfigReadContext();
 
-    bool                readLine(String&);
+    bool                readLine(std::string&);
     UInt32                getLineNumber() const;
 
     bool                operator!() const;
 
-    OptionValue            parseBoolean(const String&) const;
-    OptionValue            parseInt(const String&) const;
-    OptionValue            parseModifierKey(const String&) const;
-    OptionValue            parseCorner(const String&) const;
-    OptionValue            parseCorners(const String&) const;
-    Config::Interval
-                        parseInterval(const ArgList& args) const;
-    void                parseNameWithArgs(
-                            const String& type, const String& line,
-                            const String& delim, String::size_type& index,
-                            String& name, ArgList& args) const;
-    IPlatformScreen::KeyInfo*
-                        parseKeystroke(const String& keystroke) const;
-    IPlatformScreen::KeyInfo*
-                        parseKeystroke(const String& keystroke,
-                            const std::set<String>& screens) const;
-    IPlatformScreen::ButtonInfo*
-                        parseMouse(const String& mouse) const;
-    KeyModifierMask        parseModifier(const String& modifiers) const;
+    OptionValue parseBoolean(const std::string&) const;
+    OptionValue parseInt(const std::string&) const;
+    OptionValue parseModifierKey(const std::string&) const;
+    OptionValue parseCorner(const std::string&) const;
+    OptionValue parseCorners(const std::string&) const;
+
+    Config::Interval parseInterval(const ArgList& args) const;
+
+    void parseNameWithArgs(const std::string& type, const std::string& line,
+                           const std::string& delim, std::string::size_type& index,
+                           std::string& name, ArgList& args) const;
+
+    IPlatformScreen::KeyInfo* parseKeystroke(const std::string& keystroke) const;
+    IPlatformScreen::KeyInfo* parseKeystroke(const std::string& keystroke,
+                                             const std::set<std::string>& screens) const;
+    IPlatformScreen::ButtonInfo* parseMouse(const std::string& mouse) const;
+    KeyModifierMask parseModifier(const std::string& modifiers) const;
+
     std::istream&        getStream() const { return m_stream; };
 
 private:
     // not implemented
     ConfigReadContext&    operator=(const ConfigReadContext&);
 
-    static String        concatArgs(const ArgList& args);
+    static std::string        concatArgs(const ArgList& args);
 
 private:
     std::istream&        m_stream;
@@ -535,15 +519,14 @@ Thrown when a configuration stream cannot be parsed.
 */
 class XConfigRead : public XBase {
 public:
-    XConfigRead(const ConfigReadContext& context, const String&);
-    XConfigRead(const ConfigReadContext& context,
-                            const char* errorFmt, const String& arg);
+    XConfigRead(const ConfigReadContext& context, const std::string&);
+    XConfigRead(const ConfigReadContext& contex, const char* errorFmt, const std::string& arg);
     virtual ~XConfigRead() _NOEXCEPT;
 
 protected:
     // XBase overrides
-    virtual String        getWhat() const throw();
+    virtual std::string        getWhat() const throw();
 
 private:
-    String                m_error;
+    std::string                m_error;
 };

--- a/src/lib/server/InputFilter.cpp
+++ b/src/lib/server/InputFilter.cpp
@@ -95,8 +95,7 @@ InputFilter::KeystrokeCondition::clone() const
     return new KeystrokeCondition(m_events, m_key, m_mask);
 }
 
-String
-InputFilter::KeystrokeCondition::format() const
+std::string InputFilter::KeystrokeCondition::format() const
 {
     return barrier::string::sprintf("keystroke(%s)",
                             barrier::KeyMap::formatKey(m_key, m_mask).c_str());
@@ -183,10 +182,9 @@ InputFilter::MouseButtonCondition::clone() const
     return new MouseButtonCondition(m_events, m_button, m_mask);
 }
 
-String
-InputFilter::MouseButtonCondition::format() const
+std::string InputFilter::MouseButtonCondition::format() const
 {
-    String key = barrier::KeyMap::formatKey(kKeyNone, m_mask);
+    std::string key = barrier::KeyMap::formatKey(kKeyNone, m_mask);
     if (!key.empty()) {
         key += "+";
     }
@@ -226,8 +224,8 @@ InputFilter::MouseButtonCondition::match(const Event& event)
     return status;
 }
 
-InputFilter::ScreenConnectedCondition::ScreenConnectedCondition(
-        IEventQueue* events, const String& screen) :
+InputFilter::ScreenConnectedCondition::ScreenConnectedCondition(IEventQueue* events,
+                                                                const std::string& screen) :
     m_screen(screen),
     m_events(events)
 {
@@ -245,8 +243,7 @@ InputFilter::ScreenConnectedCondition::clone() const
     return new ScreenConnectedCondition(m_events, m_screen);
 }
 
-String
-InputFilter::ScreenConnectedCondition::format() const
+std::string InputFilter::ScreenConnectedCondition::format() const
 {
     return barrier::string::sprintf("connect(%s)", m_screen.c_str());
 }
@@ -298,8 +295,7 @@ InputFilter::LockCursorToScreenAction::clone() const
     return new LockCursorToScreenAction(*this);
 }
 
-String
-InputFilter::LockCursorToScreenAction::format() const
+std::string InputFilter::LockCursorToScreenAction::format() const
 {
     static const char* s_mode[] = { "off", "on", "toggle" };
 
@@ -323,16 +319,15 @@ InputFilter::LockCursorToScreenAction::perform(const Event& event)
                                 Event::kDeliverImmediately));
 }
 
-InputFilter::SwitchToScreenAction::SwitchToScreenAction(
-        IEventQueue* events, const String& screen) :
+InputFilter::SwitchToScreenAction::SwitchToScreenAction(IEventQueue* events,
+                                                        const std::string& screen) :
     m_screen(screen),
     m_events(events)
 {
     // do nothing
 }
 
-String
-InputFilter::SwitchToScreenAction::getScreen() const
+std::string InputFilter::SwitchToScreenAction::getScreen() const
 {
     return m_screen;
 }
@@ -343,8 +338,7 @@ InputFilter::SwitchToScreenAction::clone() const
     return new SwitchToScreenAction(*this);
 }
 
-String
-InputFilter::SwitchToScreenAction::format() const
+std::string InputFilter::SwitchToScreenAction::format() const
 {
     return barrier::string::sprintf("switchToScreen(%s)", m_screen.c_str());
 }
@@ -354,7 +348,7 @@ InputFilter::SwitchToScreenAction::perform(const Event& event)
 {
     // pick screen name.  if m_screen is empty then use the screen from
     // event if it has one.
-    String screen = m_screen;
+    std::string screen = m_screen;
     if (screen.empty() && event.getType() == m_events->forServer().connected()) {
         Server::ScreenConnectedInfo* info = 
             static_cast<Server::ScreenConnectedInfo*>(event.getData());
@@ -389,8 +383,7 @@ InputFilter::SwitchInDirectionAction::clone() const
     return new SwitchInDirectionAction(*this);
 }
 
-String
-InputFilter::SwitchInDirectionAction::format() const
+std::string InputFilter::SwitchInDirectionAction::format() const
 {
     static const char* s_names[] = {
         "",
@@ -421,10 +414,8 @@ InputFilter::KeyboardBroadcastAction::KeyboardBroadcastAction(
     // do nothing
 }
 
-InputFilter::KeyboardBroadcastAction::KeyboardBroadcastAction(
-        IEventQueue* events,
-        Mode mode,
-        const std::set<String>& screens) :
+InputFilter::KeyboardBroadcastAction::KeyboardBroadcastAction(IEventQueue* events, Mode mode,
+                                                              const std::set<std::string>& screens) :
     m_mode(mode),
     m_screens(IKeyState::KeyInfo::join(screens)),
     m_events(events)
@@ -438,10 +429,9 @@ InputFilter::KeyboardBroadcastAction::getMode() const
     return m_mode;
 }
 
-std::set<String>
-InputFilter::KeyboardBroadcastAction::getScreens() const
+std::set<std::string> InputFilter::KeyboardBroadcastAction::getScreens() const
 {
-    std::set<String> screens;
+    std::set<std::string> screens;
     IKeyState::KeyInfo::split(m_screens.c_str(), screens);
     return screens;
 }
@@ -452,8 +442,7 @@ InputFilter::KeyboardBroadcastAction::clone() const
     return new KeyboardBroadcastAction(*this);
 }
 
-String
-InputFilter::KeyboardBroadcastAction::format() const
+std::string InputFilter::KeyboardBroadcastAction::format() const
 {
     static const char* s_mode[] = { "off", "on", "toggle" };
     static const char* s_name = "keyboardBroadcast";
@@ -525,8 +514,7 @@ InputFilter::KeystrokeAction::clone() const
     return new KeystrokeAction(m_events, info, m_press);
 }
 
-String
-InputFilter::KeystrokeAction::format() const
+std::string InputFilter::KeystrokeAction::format() const
 {
     const char* type = formatName();
 
@@ -607,12 +595,11 @@ InputFilter::MouseButtonAction::clone() const
     return new MouseButtonAction(m_events, info, m_press);
 }
 
-String
-InputFilter::MouseButtonAction::format() const
+std::string InputFilter::MouseButtonAction::format() const
 {
     const char* type = formatName();
 
-    String key = barrier::KeyMap::formatKey(kKeyNone, m_buttonInfo->m_mask);
+    std::string key = barrier::KeyMap::formatKey(kKeyNone, m_buttonInfo->m_mask);
     return barrier::string::sprintf("%s(%s%s%d)", type,
                             key.c_str(), key.empty() ? "" : "+",
                             m_buttonInfo->m_button);
@@ -820,10 +807,9 @@ InputFilter::Rule::handleEvent(const Event& event)
     return true;
 }
 
-String
-InputFilter::Rule::format() const
+std::string InputFilter::Rule::format() const
 {
-    String s;
+    std::string s;
     if (m_condition != NULL) {
         // condition
         s += m_condition->format();
@@ -1019,10 +1005,9 @@ InputFilter::setPrimaryClient(PrimaryClient* client)
     }
 }
 
-String
-InputFilter::format(const String& linePrefix) const
+std::string InputFilter::format(const std::string& linePrefix) const
 {
-    String s;
+    std::string s;
     for (RuleList::const_iterator i = m_ruleList.begin();
                                 i != m_ruleList.end(); ++i) {
         s += linePrefix;
@@ -1048,7 +1033,7 @@ InputFilter::operator==(const InputFilter& x) const
 
     // compare rule lists.  the easiest way to do that is to format each
     // rule into a string, sort the strings, then compare the results.
-    std::vector<String> aList, bList;
+    std::vector<std::string> aList, bList;
     for (RuleList::const_iterator i = m_ruleList.begin();
                                 i != m_ruleList.end(); ++i) {
         aList.push_back(i->format());

--- a/src/lib/server/InputFilter.h
+++ b/src/lib/server/InputFilter.h
@@ -22,7 +22,6 @@
 #include "barrier/mouse_types.h"
 #include "barrier/protocol_types.h"
 #include "barrier/IPlatformScreen.h"
-#include "base/String.h"
 #include "common/stdmap.h"
 #include "common/stdset.h"
 
@@ -47,7 +46,7 @@ public:
         virtual ~Condition();
 
         virtual Condition*        clone() const = 0;
-        virtual String            format() const = 0;
+        virtual std::string format() const = 0;
 
         virtual EFilterStatus    match(const Event&) = 0;
 
@@ -67,7 +66,7 @@ public:
 
         // Condition overrides
         virtual Condition*        clone() const;
-        virtual String            format() const;
+        virtual std::string format() const;
         virtual EFilterStatus    match(const Event&);
         virtual void            enablePrimary(PrimaryClient*);
         virtual void            disablePrimary(PrimaryClient*);
@@ -91,7 +90,7 @@ public:
 
         // Condition overrides
         virtual Condition*        clone() const;
-        virtual String            format() const;
+        virtual std::string format() const;
         virtual EFilterStatus    match(const Event&);
 
     private:
@@ -103,16 +102,16 @@ public:
     // ScreenConnectedCondition
     class ScreenConnectedCondition : public Condition {
     public:
-        ScreenConnectedCondition(IEventQueue* events, const String& screen);
+        ScreenConnectedCondition(IEventQueue* events, const std::string& screen);
         virtual ~ScreenConnectedCondition();
 
         // Condition overrides
         virtual Condition*        clone() const;
-        virtual String            format() const;
+        virtual std::string format() const;
         virtual EFilterStatus    match(const Event&);
 
     private:
-        String                    m_screen;
+        std::string m_screen;
         IEventQueue*            m_events;
     };
 
@@ -126,7 +125,7 @@ public:
         virtual    ~Action();
 
         virtual Action*        clone() const = 0;
-        virtual String            format() const = 0;
+        virtual std::string format() const = 0;
 
         virtual void            perform(const Event&) = 0;
     };
@@ -142,7 +141,7 @@ public:
 
         // Action overrides
         virtual Action*        clone() const;
-        virtual String            format() const;
+        virtual std::string format() const;
         virtual void            perform(const Event&);
 
     private:
@@ -153,17 +152,17 @@ public:
     // SwitchToScreenAction
     class SwitchToScreenAction : public Action {
     public:
-        SwitchToScreenAction(IEventQueue* events, const String& screen);
+        SwitchToScreenAction(IEventQueue* events, const std::string& screen);
 
-        String                    getScreen() const;
+        std::string getScreen() const;
 
         // Action overrides
         virtual Action*        clone() const;
-        virtual String            format() const;
+        virtual std::string format() const;
         virtual void            perform(const Event&);
 
     private:
-        String                    m_screen;
+        std::string                    m_screen;
         IEventQueue*            m_events;
     };
     
@@ -176,7 +175,7 @@ public:
 
         // Action overrides
         virtual Action*        clone() const;
-        virtual String            format() const;
+        virtual std::string format() const;
         virtual void            perform(const Event&);
 
     private:
@@ -190,19 +189,19 @@ public:
         enum Mode { kOff, kOn, kToggle };
 
         KeyboardBroadcastAction(IEventQueue* events, Mode = kToggle);
-        KeyboardBroadcastAction(IEventQueue* events, Mode, const std::set<String>& screens);
+        KeyboardBroadcastAction(IEventQueue* events, Mode, const std::set<std::string>& screens);
 
         Mode                    getMode() const;
-        std::set<String>        getScreens() const;
+        std::set<std::string> getScreens() const;
 
         // Action overrides
         virtual Action*        clone() const;
-        virtual String            format() const;
+        virtual std::string format() const;
         virtual void            perform(const Event&);
 
     private:
         Mode                    m_mode;
-        String                    m_screens;
+        std::string                    m_screens;
         IEventQueue*            m_events;
     };
 
@@ -219,7 +218,7 @@ public:
 
         // Action overrides
         virtual Action*        clone() const;
-        virtual String            format() const;
+        virtual std::string format() const;
         virtual void            perform(const Event&);
 
     protected:
@@ -245,7 +244,7 @@ public:
 
         // Action overrides
         virtual Action*        clone() const;
-        virtual String            format() const;
+        virtual std::string format() const;
         virtual void            perform(const Event&);
 
     protected:
@@ -287,7 +286,7 @@ public:
         bool            handleEvent(const Event&);
 
         // convert rule to a string
-        String            format() const;
+        std::string format() const;
 
         // get the rule's condition
         const Condition*
@@ -340,7 +339,7 @@ public:
     virtual void        setPrimaryClient(PrimaryClient* client);
 
     // convert rules to a string
-    String                format(const String& linePrefix) const;
+    std::string format(const std::string& linePrefix) const;
 
     // get number of rules
     UInt32                getNumRules() const;

--- a/src/lib/server/PrimaryClient.cpp
+++ b/src/lib/server/PrimaryClient.cpp
@@ -26,7 +26,7 @@
 // PrimaryClient
 //
 
-PrimaryClient::PrimaryClient(const String& name, barrier::Screen* screen) :
+PrimaryClient::PrimaryClient(const std::string& name, barrier::Screen* screen) :
     BaseClientProxy(name),
     m_screen(screen),
     m_fakeInputCount(0)

--- a/src/lib/server/PrimaryClient.h
+++ b/src/lib/server/PrimaryClient.h
@@ -34,7 +34,7 @@ public:
     /*!
     \c name is the name of the server and \p screen is primary screen.
     */
-    PrimaryClient(const String& name, barrier::Screen* screen);
+    PrimaryClient(const std::string& name, barrier::Screen* screen);
     ~PrimaryClient();
 
 #ifdef TEST_ENV

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -101,7 +101,7 @@ Server::Server(
 	assert(config.isScreen(primaryClient->getName()));
 	assert(m_screen != NULL);
 
-	String primaryName = getName(primaryClient);
+    std::string primaryName = getName(primaryClient);
 
 	// clear clipboards
 	for (ClipboardID id = 0; id < kClipboardEnd; ++id) {
@@ -370,7 +370,7 @@ Server::getNumClients() const
 }
 
 void
-Server::getClients(std::vector<String>& list) const
+Server::getClients(std::vector<std::string>& list) const
 {
 	list.clear();
 	for (ClientList::const_iterator index = m_clients.begin();
@@ -379,10 +379,9 @@ Server::getClients(std::vector<String>& list) const
 	}
 }
 
-String
-Server::getName(const BaseClientProxy* client) const
+std::string Server::getName(const BaseClientProxy* client) const
 {
-	String name = m_config->getCanonicalName(client->getName());
+    std::string name = m_config->getCanonicalName(client->getName());
 	if (name.empty()) {
 		name = client->getName();
 	}
@@ -600,7 +599,7 @@ Server::getNeighbor(BaseClientProxy* src,
 	assert(src != NULL);
 
 	// get source screen name
-	String srcName = getName(src);
+    std::string srcName = getName(src);
 	assert(!srcName.empty());
 	LOG((CLOG_DEBUG2 "find neighbor on %s of \"%s\"", Config::dirName(dir), srcName.c_str()));
 
@@ -610,7 +609,7 @@ Server::getNeighbor(BaseClientProxy* src,
 	// search for the closest neighbor that exists in direction dir
 	float tTmp;
 	for (;;) {
-		String dstName(m_config->getNeighbor(srcName, dir, t, &tTmp));
+        std::string dstName(m_config->getNeighbor(srcName, dir, t, &tTmp));
 
 		// if nothing in that direction then return NULL. if the
 		// destination is the source then we can make no more
@@ -755,7 +754,7 @@ Server::avoidJumpZone(BaseClientProxy* dst,
 		return;
 	}
 
-	const String dstName(getName(dst));
+    const std::string dstName(getName(dst));
 	SInt32 dx, dy, dw, dh;
 	dst->getShape(dx, dy, dw, dh);
 	float t = mapToFraction(dst, dir, x, y);
@@ -1533,7 +1532,7 @@ Server::onClipboardChanged(BaseClientProxy* sender,
 	sender->getClipboard(id, &clipboard.m_clipboard);
 
 	// ignore if data hasn't changed
-	String data = clipboard.m_clipboard.marshall();
+    std::string data = clipboard.m_clipboard.marshall();
 	if (data == clipboard.m_clipboardData) {
 		LOG((CLOG_DEBUG "ignored screen \"%s\" update of clipboard %d (unchanged)", clipboard.m_clipboardOwner.c_str(), id));
 		return;
@@ -1703,7 +1702,7 @@ Server::onMouseUp(ButtonID id)
 
 	if (m_args.m_enableDragDrop) {
 		if (!m_screen->isOnScreen()) {
-			String& file = m_screen->getDraggingFilename();
+            std::string& file = m_screen->getDraggingFilename();
 			if (!file.empty()) {
 				sendFileToClient(file.c_str());
 			}
@@ -1829,7 +1828,7 @@ Server::sendDragInfoThread(void* arg)
 	BaseClientProxy* newScreen = static_cast<BaseClientProxy*>(arg);
 
 	m_dragFileList.clear();
-	String& dragFileList = m_screen->getDraggingFilename();
+    std::string& dragFileList = m_screen->getDraggingFilename();
 	if (!dragFileList.empty()) {
 		DragInformation di;
 		di.setFilename(dragFileList);
@@ -1856,7 +1855,7 @@ Server::sendDragInfoThread(void* arg)
 void
 Server::sendDragInfo(BaseClientProxy* newScreen)
 {
-	String infoString;
+    std::string infoString;
 	UInt32 fileCount = DragInformation::setupDragInfo(m_dragFileList, infoString);
 
 	if (fileCount > 0) {
@@ -2089,7 +2088,7 @@ Server::writeToDropDirThread(void*)
 bool
 Server::addClient(BaseClientProxy* client)
 {
-	String name = getName(client);
+    std::string name = getName(client);
 	if (m_clients.count(name) != 0) {
 		return false;
 	}
@@ -2313,7 +2312,7 @@ Server::LockCursorToScreenInfo::alloc(State state)
 //
 
 Server::SwitchToScreenInfo*
-Server::SwitchToScreenInfo::alloc(const String& screen)
+Server::SwitchToScreenInfo::alloc(const std::string& screen)
 {
 	SwitchToScreenInfo* info =
 		(SwitchToScreenInfo*)malloc(sizeof(SwitchToScreenInfo) +
@@ -2351,7 +2350,7 @@ Server::KeyboardBroadcastInfo::alloc(State state)
 }
 
 Server::KeyboardBroadcastInfo*
-Server::KeyboardBroadcastInfo::alloc(State state, const String& screens)
+Server::KeyboardBroadcastInfo::alloc(State state, const std::string& screens)
 {
 	KeyboardBroadcastInfo* info =
 		(KeyboardBroadcastInfo*)malloc(sizeof(KeyboardBroadcastInfo) +
@@ -2396,7 +2395,7 @@ Server::sendFileThread(void* data)
 }
 
 void
-Server::dragInfoReceived(UInt32 fileNum, String content)
+Server::dragInfoReceived(UInt32 fileNum, std::string content)
 {
 	if (!m_args.m_enableDragDrop) {
 		LOG((CLOG_DEBUG "drag drop not enabled, ignoring drag info."));

--- a/src/lib/server/Server.h
+++ b/src/lib/server/Server.h
@@ -62,7 +62,7 @@ public:
     //! Switch to screen data
     class SwitchToScreenInfo {
     public:
-        static SwitchToScreenInfo* alloc(const String& screen);
+        static SwitchToScreenInfo* alloc(const std::string& screen);
 
     public:
         // this is a C-string;  this type is a variable size structure
@@ -81,10 +81,10 @@ public:
     //! Screen connected data
     class ScreenConnectedInfo {
     public:
-        ScreenConnectedInfo(String screen) : m_screen(screen) { }
+        ScreenConnectedInfo(std::string screen) : m_screen(screen) { }
 
     public:
-        String            m_screen; // was char[1]
+        std::string m_screen;
     };
 
     //! Keyboard broadcast data
@@ -94,7 +94,7 @@ public:
 
         static KeyboardBroadcastInfo* alloc(State state = kToggle);
         static KeyboardBroadcastInfo* alloc(State state,
-                                            const String& screens);
+                                            const std::string& screens);
 
     public:
         State            m_state;
@@ -146,7 +146,7 @@ public:
     void                sendFileToClient(const char* filename);
 
     //! Received dragging information from client
-    void                dragInfoReceived(UInt32 fileNum, String content);
+    void dragInfoReceived(UInt32 fileNum, std::string content);
 
     //! Store ClientListener pointer
     void                setListener(ClientListener* p) { m_clientListener = p; }
@@ -165,7 +165,7 @@ public:
     /*!
     Set the \c list to the names of the currently connected clients.
     */
-    void                getClients(std::vector<String>& list) const;
+    void getClients(std::vector<std::string>& list) const;
     
     //! Return true if recieved file size is valid
     bool                isReceivedFileSizeValid();
@@ -174,7 +174,7 @@ public:
     size_t&                getExpectedFileSize() { return m_expectedFileSize; }
 
     //! Return received file data
-    String&                getReceivedFileData() { return m_receivedFileData; }
+    std::string& getReceivedFileData() { return m_receivedFileData; }
 
     //! Return fake drag file list
     DragFileList        getFakeDragFileList() { return m_fakeDragFileList; }
@@ -183,7 +183,7 @@ public:
 
 private:
     // get canonical name of client
-    String                getName(const BaseClientProxy*) const;
+    std::string getName(const BaseClientProxy*) const;
 
     // get the sides of the primary screen that have neighbors
     UInt32                getActivePrimarySides() const;
@@ -378,8 +378,8 @@ private:
 
     public:
         Clipboard        m_clipboard;
-        String            m_clipboardData;
-        String            m_clipboardOwner;
+        std::string m_clipboardData;
+        std::string m_clipboardOwner;
         UInt32            m_clipboardSeqNum;
     };
 
@@ -387,7 +387,7 @@ private:
     PrimaryClient*        m_primaryClient;
 
     // all clients (including the primary client) indexed by name
-    typedef std::map<String, BaseClientProxy*> ClientList;
+    typedef std::map<std::string, BaseClientProxy*> ClientList;
     typedef std::set<BaseClientProxy*> ClientSet;
     ClientList            m_clients;
     ClientSet            m_clientSet;
@@ -454,7 +454,7 @@ private:
     // flag whether or not we have broadcasting enabled and the screens to
     // which we should send broadcasted keys.
     bool                m_keyboardBroadcasting;
-    String                m_keyboardBroadcastingScreens;
+    std::string m_keyboardBroadcastingScreens;
 
     // screen locking (former scroll lock)
     bool                m_lockedToScreen;
@@ -466,12 +466,12 @@ private:
 
     // file transfer
     size_t                m_expectedFileSize;
-    String                m_receivedFileData;
+    std::string m_receivedFileData;
     DragFileList        m_dragFileList;
     DragFileList        m_fakeDragFileList;
     Thread*                m_sendFileThread;
     Thread*                m_writeToDropDirThread;
-    String                m_dragFileExt;
+    std::string m_dragFileExt;
     bool                m_ignoreFileTransfer;
     bool                m_enableClipboard;
 


### PR DESCRIPTION
Having a `String` typedef that points to `std::string` does not serve any benefit and is just confusing. This PR should not result in any functionality changes, I would expect the produced binary to be exactly the same.