### PR TITLE
lib/platform: Use std::string directly instead of String typedef

### DIFF
--- a/src/lib/net/IDataSocket.h
+++ b/src/lib/net/IDataSocket.h
@@ -21,6 +21,7 @@
 #include "net/ISocket.h"
 #include "io/IStream.h"
 #include "base/EventTypes.h"
+#include <string>
 
 //! Data stream socket interface
 /*!

--- a/src/lib/platform/MSWindowsClipboard.cpp
+++ b/src/lib/platform/MSWindowsClipboard.cpp
@@ -98,7 +98,7 @@ MSWindowsClipboard::empty()
 }
 
 void
-MSWindowsClipboard::add(EFormat format, const String& data)
+MSWindowsClipboard::add(EFormat format, const std::string& data)
 {
     LOG((CLOG_DEBUG "add %d bytes to clipboard format: %d", data.size(), format));
 
@@ -165,8 +165,7 @@ MSWindowsClipboard::has(EFormat format) const
     return false;
 }
 
-String
-MSWindowsClipboard::get(EFormat format) const
+std::string MSWindowsClipboard::get(EFormat format) const
 {
     // find the converter for the first clipboard format we can handle
     IMSWindowsClipboardConverter* converter = NULL;
@@ -183,7 +182,7 @@ MSWindowsClipboard::get(EFormat format) const
     // if no converter then we don't recognize any formats
     if (converter == NULL) {
         LOG((CLOG_WARN "no converter for format %d", format));
-        return String();
+        return {};
     }
 
     // get a handle to the clipboard data
@@ -192,7 +191,7 @@ MSWindowsClipboard::get(EFormat format) const
         // nb: can't cause this using integ tests; this is only caused when
         // the selected converter returns an invalid format -- which you
         // cannot cause using public functions.
-        return String();
+        return {};
     }
 
     // convert

--- a/src/lib/platform/MSWindowsClipboard.h
+++ b/src/lib/platform/MSWindowsClipboard.h
@@ -55,21 +55,21 @@ public:
 
     // IClipboard overrides
     virtual bool        empty();
-    virtual void        add(EFormat, const String& data);
+    virtual void add(EFormat, const std::string& data);
     virtual bool        open(Time) const;
     virtual void        close() const;
     virtual Time        getTime() const;
     virtual bool        has(EFormat) const;
-    virtual String        get(EFormat) const;
+    virtual std::string get(EFormat) const;
 
     void setFacade(IMSWindowsClipboardFacade& facade);
 
 private:
     void                clearConverters();
 
-    UINT                convertFormatToWin32(EFormat) const;
-    HANDLE                convertTextToWin32(const String& data) const;
-    String                convertTextFromWin32(HANDLE) const;
+    UINT convertFormatToWin32(EFormat) const;
+    HANDLE convertTextToWin32(const std::string& data) const;
+    std::string convertTextFromWin32(HANDLE) const;
 
     static UINT            getOwnershipFormat();
 
@@ -105,9 +105,9 @@ public:
     // the input data must be in the IClipboard format returned by
     // getFormat().  the return data will be in the win32 clipboard
     // format returned by getWin32Format(), allocated by GlobalAlloc().
-    virtual HANDLE        fromIClipboard(const String&) const = 0;
+    virtual HANDLE fromIClipboard(const std::string&) const = 0;
 
     // convert from the win32 clipboard format to the IClipboard format
     // (i.e., the reverse of fromIClipboard()).
-    virtual String        toIClipboard(HANDLE data) const = 0;
+    virtual std::string toIClipboard(HANDLE data) const = 0;
 };

--- a/src/lib/platform/MSWindowsClipboardAnyTextConverter.cpp
+++ b/src/lib/platform/MSWindowsClipboardAnyTextConverter.cpp
@@ -38,11 +38,10 @@ MSWindowsClipboardAnyTextConverter::getFormat() const
     return IClipboard::kText;
 }
 
-HANDLE
-MSWindowsClipboardAnyTextConverter::fromIClipboard(const String& data) const
+HANDLE MSWindowsClipboardAnyTextConverter::fromIClipboard(const std::string& data) const
 {
     // convert linefeeds and then convert to desired encoding
-    String text = doFromIClipboard(convertLinefeedToWin32(data));
+    std::string text = doFromIClipboard(convertLinefeedToWin32(data));
     UInt32 size  = (UInt32)text.size();
 
     // copy to memory handle
@@ -63,18 +62,17 @@ MSWindowsClipboardAnyTextConverter::fromIClipboard(const String& data) const
     return gData;
 }
 
-String
-MSWindowsClipboardAnyTextConverter::toIClipboard(HANDLE data) const
+std::string MSWindowsClipboardAnyTextConverter::toIClipboard(HANDLE data) const
 {
     // get datator
     const char* src = (const char*)GlobalLock(data);
     UInt32 srcSize = (UInt32)GlobalSize(data);
     if (src == NULL || srcSize <= 1) {
-        return String();
+        return {};
     }
 
     // convert text
-    String text = doToIClipboard(String(src, srcSize));
+    std::string text = doToIClipboard(std::string(src, srcSize));
 
     // release handle
     GlobalUnlock(data);
@@ -83,9 +81,7 @@ MSWindowsClipboardAnyTextConverter::toIClipboard(HANDLE data) const
     return convertLinefeedToUnix(text);
 }
 
-String
-MSWindowsClipboardAnyTextConverter::convertLinefeedToWin32(
-                const String& src) const
+std::string MSWindowsClipboardAnyTextConverter::convertLinefeedToWin32(const std::string& src) const
 {
     // note -- we assume src is a valid UTF-8 string
 
@@ -102,7 +98,7 @@ MSWindowsClipboardAnyTextConverter::convertLinefeedToWin32(
     }
 
     // allocate new string
-    String dst;
+    std::string dst;
     dst.reserve(src.size() + numNewlines);
 
     // copy string, converting newlines
@@ -117,9 +113,7 @@ MSWindowsClipboardAnyTextConverter::convertLinefeedToWin32(
     return dst;
 }
 
-String
-MSWindowsClipboardAnyTextConverter::convertLinefeedToUnix(
-                const String& src) const
+std::string MSWindowsClipboardAnyTextConverter::convertLinefeedToUnix(const std::string& src) const
 {
     // count newlines in string
     UInt32 numNewlines = 0;
@@ -134,7 +128,7 @@ MSWindowsClipboardAnyTextConverter::convertLinefeedToUnix(
     }
 
     // allocate new string
-    String dst;
+    std::string dst;
     dst.reserve(src.size());
 
     // copy string, converting newlines

--- a/src/lib/platform/MSWindowsClipboardAnyTextConverter.h
+++ b/src/lib/platform/MSWindowsClipboardAnyTextConverter.h
@@ -31,8 +31,8 @@ public:
     virtual IClipboard::EFormat
                         getFormat() const;
     virtual UINT        getWin32Format() const = 0;
-    virtual HANDLE        fromIClipboard(const String&) const;
-    virtual String        toIClipboard(HANDLE) const;
+    virtual HANDLE fromIClipboard(const std::string&) const;
+    virtual std::string toIClipboard(HANDLE) const;
 
 protected:
     //! Convert from IClipboard format
@@ -40,18 +40,18 @@ protected:
     Do UTF-8 conversion only.  Memory handle allocation and
     linefeed conversion is done by this class.  doFromIClipboard()
     must include the nul terminator in the returned string (not
-    including the String's nul terminator).
+    including the std::string's nul terminator).
     */
-    virtual String        doFromIClipboard(const String&) const = 0;
+    virtual std::string doFromIClipboard(const std::string&) const = 0;
 
     //! Convert to IClipboard format
     /*!
     Do UTF-8 conversion only.  Memory handle allocation and
     linefeed conversion is done by this class.
     */
-    virtual String        doToIClipboard(const String&) const = 0;
+    virtual std::string doToIClipboard(const std::string&) const = 0;
 
 private:
-    String                convertLinefeedToWin32(const String&) const;
-    String                convertLinefeedToUnix(const String&) const;
+    std::string convertLinefeedToWin32(const std::string&) const;
+    std::string convertLinefeedToUnix(const std::string&) const;
 };

--- a/src/lib/platform/MSWindowsClipboardBitmapConverter.cpp
+++ b/src/lib/platform/MSWindowsClipboardBitmapConverter.cpp
@@ -46,8 +46,7 @@ MSWindowsClipboardBitmapConverter::getWin32Format() const
     return CF_DIB;
 }
 
-HANDLE
-MSWindowsClipboardBitmapConverter::fromIClipboard(const String& data) const
+HANDLE MSWindowsClipboardBitmapConverter::fromIClipboard(const std::string& data) const
 {
     // copy to memory handle
     HGLOBAL gData = GlobalAlloc(GMEM_MOVEABLE | GMEM_DDESHARE, data.size());
@@ -67,13 +66,12 @@ MSWindowsClipboardBitmapConverter::fromIClipboard(const String& data) const
     return gData;
 }
 
-String
-MSWindowsClipboardBitmapConverter::toIClipboard(HANDLE data) const
+std::string MSWindowsClipboardBitmapConverter::toIClipboard(HANDLE data) const
 {
     // get datator
     LPVOID src = GlobalLock(data);
     if (src == NULL) {
-        return String();
+        return {};
     }
     UInt32 srcSize = (UInt32)GlobalSize(data);
 
@@ -85,7 +83,7 @@ MSWindowsClipboardBitmapConverter::toIClipboard(HANDLE data) const
         bitmap->bmiHeader.biBitCount == 32) &&
         bitmap->bmiHeader.biCompression == BI_RGB) {
         // already in canonical form
-        String image(static_cast<char const*>(src), srcSize);
+        std::string image(static_cast<char const*>(src), srcSize);
         GlobalUnlock(data);
         return image;
     }
@@ -138,7 +136,7 @@ MSWindowsClipboardBitmapConverter::toIClipboard(HANDLE data) const
     GdiFlush();
 
     // extract data
-    String image((const char*)&info, info.biSize);
+    std::string image((const char*)&info, info.biSize);
     image.append((const char*)raw, 4 * w * h);
 
     // clean up GDI

--- a/src/lib/platform/MSWindowsClipboardBitmapConverter.h
+++ b/src/lib/platform/MSWindowsClipboardBitmapConverter.h
@@ -31,6 +31,6 @@ public:
     virtual IClipboard::EFormat
                         getFormat() const;
     virtual UINT        getWin32Format() const;
-    virtual HANDLE        fromIClipboard(const String&) const;
-    virtual String        toIClipboard(HANDLE) const;
+    virtual HANDLE fromIClipboard(const std::string&) const;
+    virtual std::string toIClipboard(HANDLE) const;
 };

--- a/src/lib/platform/MSWindowsClipboardHTMLConverter.cpp
+++ b/src/lib/platform/MSWindowsClipboardHTMLConverter.cpp
@@ -46,15 +46,14 @@ MSWindowsClipboardHTMLConverter::getWin32Format() const
     return m_format;
 }
 
-String
-MSWindowsClipboardHTMLConverter::doFromIClipboard(const String& data) const
+std::string MSWindowsClipboardHTMLConverter::doFromIClipboard(const std::string& data) const
 {
     // prepare to CF_HTML format prefix and suffix
-    String prefix("Version:0.9\r\nStartHTML:0000000105\r\n"
+    std::string prefix("Version:0.9\r\nStartHTML:0000000105\r\n"
                     "EndHTML:ZZZZZZZZZZ\r\n"
                     "StartFragment:XXXXXXXXXX\r\nEndFragment:YYYYYYYYYY\r\n"
                     "<!DOCTYPE><HTML><BODY><!--StartFragment-->");
-    String suffix("<!--EndFragment--></BODY></HTML>\r\n");
+    std::string suffix("<!--EndFragment--></BODY></HTML>\r\n");
 
     // Get byte offsets for header
     UInt32 StartFragment = (UInt32)prefix.size();
@@ -75,45 +74,43 @@ MSWindowsClipboardHTMLConverter::doFromIClipboard(const String& data) const
     return prefix;
 }
 
-String
-MSWindowsClipboardHTMLConverter::doToIClipboard(const String& data) const
+std::string MSWindowsClipboardHTMLConverter::doToIClipboard(const std::string& data) const
 {
     // get fragment start/end args
-    String startArg = findArg(data, "StartFragment");
-    String endArg   = findArg(data, "EndFragment");
+    std::string startArg = findArg(data, "StartFragment");
+    std::string endArg   = findArg(data, "EndFragment");
     if (startArg.empty() || endArg.empty()) {
-        return String();
+        return std::string();
     }
 
     // convert args to integers
     SInt32 start = (SInt32)atoi(startArg.c_str());
     SInt32 end   = (SInt32)atoi(endArg.c_str());
     if (start <= 0 || end <= 0 || start >= end) {
-        return String();
+        return std::string();
     }
 
     // extract the fragment
     return data.substr(start, end - start);
 }
 
-String
-MSWindowsClipboardHTMLConverter::findArg(
-                const String& data, const String& name) const
+std::string MSWindowsClipboardHTMLConverter::findArg(const std::string& data,
+                                                     const std::string& name) const
 {
-    String::size_type i = data.find(name);
-    if (i == String::npos) {
-        return String();
+    std::string::size_type i = data.find(name);
+    if (i == std::string::npos) {
+        return std::string();
     }
     i = data.find_first_of(":\r\n", i);
-    if (i == String::npos || data[i] != ':') {
-        return String();
+    if (i == std::string::npos || data[i] != ':') {
+        return std::string();
     }
     i = data.find_first_of("0123456789\r\n", i + 1);
-    if (i == String::npos || data[i] == '\r' || data[i] == '\n') {
-        return String();
+    if (i == std::string::npos || data[i] == '\r' || data[i] == '\n') {
+        return std::string();
     }
-    String::size_type j = data.find_first_not_of("0123456789", i);
-    if (j == String::npos) {
+    std::string::size_type j = data.find_first_not_of("0123456789", i);
+    if (j == std::string::npos) {
         j = data.size();
     }
     return data.substr(i, j - i);

--- a/src/lib/platform/MSWindowsClipboardHTMLConverter.h
+++ b/src/lib/platform/MSWindowsClipboardHTMLConverter.h
@@ -34,11 +34,11 @@ public:
 
 protected:
     // MSWindowsClipboardAnyTextConverter overrides
-    virtual String        doFromIClipboard(const String&) const;
-    virtual String        doToIClipboard(const String&) const;
+    virtual std::string doFromIClipboard(const std::string&) const;
+    virtual std::string doToIClipboard(const std::string&) const;
 
 private:
-    String                findArg(const String& data, const String& name) const;
+    std::string findArg(const std::string& data, const std::string& name) const;
 
 private:
     UINT                m_format;

--- a/src/lib/platform/MSWindowsClipboardTextConverter.cpp
+++ b/src/lib/platform/MSWindowsClipboardTextConverter.cpp
@@ -40,20 +40,18 @@ MSWindowsClipboardTextConverter::getWin32Format() const
     return CF_TEXT;
 }
 
-String
-MSWindowsClipboardTextConverter::doFromIClipboard(const String& data) const
+std::string MSWindowsClipboardTextConverter::doFromIClipboard(const std::string& data) const
 {
     // convert and add nul terminator
     return Unicode::UTF8ToText(data) += '\0';
 }
 
-String
-MSWindowsClipboardTextConverter::doToIClipboard(const String& data) const
+std::string MSWindowsClipboardTextConverter::doToIClipboard(const std::string& data) const
 {
     // convert and truncate at first nul terminator
-    String dst          = Unicode::textToUTF8(data);
-    String::size_type n = dst.find('\0');
-    if (n != String::npos) {
+    std::string dst = Unicode::textToUTF8(data);
+    std::string::size_type n = dst.find('\0');
+    if (n != std::string::npos) {
         dst.erase(n);
     }
     return dst;

--- a/src/lib/platform/MSWindowsClipboardTextConverter.h
+++ b/src/lib/platform/MSWindowsClipboardTextConverter.h
@@ -32,6 +32,6 @@ public:
 
 protected:
     // MSWindowsClipboardAnyTextConverter overrides
-    virtual String        doFromIClipboard(const String&) const;
-    virtual String        doToIClipboard(const String&) const;
+    virtual std::string doFromIClipboard(const std::string&) const;
+    virtual std::string doToIClipboard(const std::string&) const;
 };

--- a/src/lib/platform/MSWindowsClipboardUTF16Converter.cpp
+++ b/src/lib/platform/MSWindowsClipboardUTF16Converter.cpp
@@ -40,20 +40,18 @@ MSWindowsClipboardUTF16Converter::getWin32Format() const
     return CF_UNICODETEXT;
 }
 
-String
-MSWindowsClipboardUTF16Converter::doFromIClipboard(const String& data) const
+std::string MSWindowsClipboardUTF16Converter::doFromIClipboard(const std::string& data) const
 {
     // convert and add nul terminator
     return Unicode::UTF8ToUTF16(data).append(sizeof(wchar_t), 0);
 }
 
-String
-MSWindowsClipboardUTF16Converter::doToIClipboard(const String& data) const
+std::string MSWindowsClipboardUTF16Converter::doToIClipboard(const std::string& data) const
 {
     // convert and strip nul terminator
-    String dst          = Unicode::UTF16ToUTF8(data);
-    String::size_type n = dst.find('\0');
-    if (n != String::npos) {
+    std::string dst = Unicode::UTF16ToUTF8(data);
+    std::string::size_type n = dst.find('\0');
+    if (n != std::string::npos) {
         dst.erase(n);
     }
     return dst;

--- a/src/lib/platform/MSWindowsClipboardUTF16Converter.h
+++ b/src/lib/platform/MSWindowsClipboardUTF16Converter.h
@@ -32,6 +32,6 @@ public:
 
 protected:
     // MSWindowsClipboardAnyTextConverter overrides
-    virtual String        doFromIClipboard(const String&) const;
-    virtual String        doToIClipboard(const String&) const;
+    virtual std::string doFromIClipboard(const std::string&) const;
+    virtual std::string doToIClipboard(const std::string&) const;
 };

--- a/src/lib/platform/MSWindowsDesks.cpp
+++ b/src/lib/platform/MSWindowsDesks.cpp
@@ -746,8 +746,7 @@ MSWindowsDesks::deskThread(void* vdesk)
     }
 }
 
-MSWindowsDesks::Desk*
-MSWindowsDesks::addDesk(const String& name, HDESK hdesk)
+MSWindowsDesks::Desk* MSWindowsDesks::addDesk(const std::string& name, HDESK hdesk)
 {
     Desk* desk      = new Desk;
     desk->m_name     = name;
@@ -782,7 +781,7 @@ MSWindowsDesks::checkDesk()
     // get current desktop.  if we already know about it then return.
     Desk* desk;
     HDESK hdesk  = openInputDesktop();
-    String name = getDesktopName(hdesk);
+    std::string name = getDesktopName(hdesk);
     Desks::const_iterator index = m_desks.find(name);
     if (index == m_desks.end()) {
         desk = addDesk(name, hdesk);
@@ -900,18 +899,17 @@ MSWindowsDesks::closeDesktop(HDESK desk)
     }
 }
 
-String
-MSWindowsDesks::getDesktopName(HDESK desk)
+std::string MSWindowsDesks::getDesktopName(HDESK desk)
 {
     if (desk == NULL) {
-        return String();
+        return {}
     }
     else {
         DWORD size;
         GetUserObjectInformation(desk, UOI_NAME, NULL, 0, &size);
         TCHAR* name = (TCHAR*)alloca(size + sizeof(TCHAR));
         GetUserObjectInformation(desk, UOI_NAME, name, size, &size);
-        String result(name);
+        std::string result(name);
         return result;
     }
 }

--- a/src/lib/platform/MSWindowsDesks.h
+++ b/src/lib/platform/MSWindowsDesks.h
@@ -25,8 +25,8 @@
 #include "barrier/option_types.h"
 #include "mt/CondVar.h"
 #include "mt/Mutex.h"
-#include "base/String.h"
 #include "common/stdmap.h"
+#include <string>
 
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
@@ -195,7 +195,7 @@ public:
 private:
     class Desk {
     public:
-        String            m_name;
+        std::string m_name;
         Thread*        m_thread;
         DWORD            m_threadID;
         DWORD            m_targetID;
@@ -204,7 +204,7 @@ private:
         HWND            m_foregroundWindow;
         bool            m_lowLevel;
     };
-    typedef std::map<String, Desk*> Desks;
+    typedef std::map<std::string, Desk*> Desks;
 
     // initialization and shutdown operations
     HCURSOR                createBlankCursor() const;
@@ -222,7 +222,7 @@ private:
     void                deskThread(void* vdesk);
 
     // desk switch checking and handling
-    Desk*                addDesk(const String& name, HDESK hdesk);
+    Desk* addDesk(const std::string& name, HDESK hdesk);
     void                removeDesks();
     void                checkDesk();
     bool                isDeskAccessible(const Desk* desk) const;
@@ -238,7 +238,7 @@ private:
     // desk API wrappers
     HDESK                openInputDesktop();
     void                closeDesktop(HDESK);
-    String                getDesktopName(HDESK);
+    std::string getDesktopName(HDESK);
 
     // our desk window procs
     static LRESULT CALLBACK primaryDeskProc(HWND, UINT, WPARAM, LPARAM);
@@ -276,7 +276,7 @@ private:
 
     // the current desk and it's name
     Desk*                m_activeDesk;
-    String                m_activeDeskName;
+    std::string m_activeDeskName;
 
     // one desk per desktop and a cond var to communicate with it
     Mutex                m_mutex;

--- a/src/lib/platform/MSWindowsKeyState.h
+++ b/src/lib/platform/MSWindowsKeyState.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include "barrier/KeyState.h"
-#include "base/String.h"
 #include "common/stdvector.h"
 
 #define WIN32_LEAN_AND_MEAN

--- a/src/lib/platform/MSWindowsScreen.cpp
+++ b/src/lib/platform/MSWindowsScreen.cpp
@@ -38,7 +38,6 @@
 #include "arch/Arch.h"
 #include "base/FunctionJob.h"
 #include "base/Log.h"
-#include "base/String.h"
 #include "base/IEventQueue.h"
 #include "base/TMethodEventJob.h"
 #include "base/TMethodJob.h"
@@ -150,7 +149,7 @@ MSWindowsScreen::MSWindowsScreen(
         // SHGetFolderPath is deprecated in vista, but use it for xp support.
         char desktopPath[MAX_PATH];
         if (SUCCEEDED(SHGetFolderPath(NULL, CSIDL_DESKTOP, NULL, 0, desktopPath))) {
-            m_desktopPath = String(desktopPath);
+            m_desktopPath = std::string(desktopPath);
             LOG((CLOG_DEBUG "using desktop for drop target: %s", m_desktopPath.c_str()));
         }
         else {
@@ -378,7 +377,7 @@ MSWindowsScreen::leave()
 void
 MSWindowsScreen::sendDragThread(void*)
 {
-    String& draggingFilename = getDraggingFilename();
+    std::string& draggingFilename = getDraggingFilename();
     size_t size = draggingFilename.size();
 
     if (draggingFilename.empty() == false) {
@@ -1867,8 +1866,7 @@ MSWindowsScreen::fakeDraggingFiles(DragFileList fileList)
     // exception from being thrown.
 }
 
-String&
-MSWindowsScreen::getDraggingFilename()
+std::string& MSWindowsScreen::getDraggingFilename()
 {
     if (m_draggingStarted) {
         m_dropTarget->clearDraggingFilename();
@@ -1894,7 +1892,7 @@ MSWindowsScreen::getDraggingFilename()
         fakeKeyUp(1);
         fakeMouseButton(kButtonLeft, false);
 
-        String filename;
+        std::string filename;
         DOUBLE timeout = ARCH->time() + .5f;
         while (ARCH->time() < timeout) {
             ARCH->sleep(.05f);
@@ -1923,8 +1921,7 @@ MSWindowsScreen::getDraggingFilename()
     return m_draggingFilename;
 }
 
-const String&
-MSWindowsScreen::getDropTarget() const
+const std::string& MSWindowsScreen::getDropTarget() const
 {
     return m_desktopPath;
 }

--- a/src/lib/platform/MSWindowsScreen.h
+++ b/src/lib/platform/MSWindowsScreen.h
@@ -25,7 +25,7 @@
 #include "platform/synwinhk.h"
 #include "mt/CondVar.h"
 #include "mt/Mutex.h"
-#include "base/String.h"
+#include <string>
 
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
@@ -118,9 +118,8 @@ public:
     virtual void        setSequenceNumber(UInt32);
     virtual bool        isPrimary() const;
     virtual void        fakeDraggingFiles(DragFileList fileList);
-    virtual String&    getDraggingFilename();
-    virtual const String&    
-                        getDropTarget() const;
+    virtual std::string& getDraggingFilename();
+    virtual const std::string& getDropTarget() const;
 
 protected:
     // IPlatformScreen overrides
@@ -333,7 +332,7 @@ private:
     
     IEventQueue*        m_events;
 
-    String                m_desktopPath;
+    std::string                m_desktopPath;
 
     MSWindowsDropTarget*
                         m_dropTarget;

--- a/src/lib/platform/MSWindowsScreenSaver.h
+++ b/src/lib/platform/MSWindowsScreenSaver.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include "barrier/IScreenSaver.h"
-#include "base/String.h"
 
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>

--- a/src/lib/platform/MSWindowsSession.cpp
+++ b/src/lib/platform/MSWindowsSession.cpp
@@ -172,10 +172,9 @@ MSWindowsSession::nextProcessEntry(HANDLE snapshot, LPPROCESSENTRY32 entry)
     return gotEntry;
 }
 
-String
-MSWindowsSession::getActiveDesktopName()
+std::string MSWindowsSession::getActiveDesktopName()
 {
-    String result;
+    std::string result;
     try {
         HDESK hd = OpenInputDesktop(0, TRUE, GENERIC_READ);
         if (hd != NULL) {

--- a/src/lib/platform/MSWindowsSession.h
+++ b/src/lib/platform/MSWindowsSession.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "base/String.h"
+#include <string>
 
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
@@ -42,7 +42,7 @@ public:
 
     void                updateActiveSession();
 
-    String                getActiveDesktopName();
+    std::string getActiveDesktopName();
 
 private:
     BOOL                nextProcessEntry(HANDLE snapshot, LPPROCESSENTRY32 entry);

--- a/src/lib/platform/MSWindowsUtil.cpp
+++ b/src/lib/platform/MSWindowsUtil.cpp
@@ -18,29 +18,25 @@
 
 #include "platform/MSWindowsUtil.h"
 
-#include "base/String.h"
-
 #include <stdio.h>
 
 //
 // MSWindowsUtil
 //
 
-String
-MSWindowsUtil::getString(HINSTANCE instance, DWORD id)
+std::string MSWindowsUtil::getString(HINSTANCE instance, DWORD id)
 {
     char* msg = NULL;
     int n = LoadString(instance, id, reinterpret_cast<LPSTR>(&msg), 0);
 
     if (n <= 0) {
-        return String();
+        return {};
     }
 
-    return String (msg, n);
+    return std::string (msg, n);
 }
 
-String
-MSWindowsUtil::getErrorString(HINSTANCE hinstance, DWORD error, DWORD id)
+std::string MSWindowsUtil::getErrorString(HINSTANCE hinstance, DWORD error, DWORD id)
 {
     char* buffer;
     if (FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER |
@@ -52,12 +48,12 @@ MSWindowsUtil::getErrorString(HINSTANCE hinstance, DWORD error, DWORD id)
                                 (LPTSTR)&buffer,
                                 0,
                                 NULL) == 0) {
-        String errorString = barrier::string::sprintf("%d", error);
+        std::string errorString = barrier::string::sprintf("%d", error);
         return barrier::string::format(getString(hinstance, id).c_str(),
                             errorString.c_str());
     }
     else {
-        String result(buffer);
+        std::string result(buffer);
         LocalFree(buffer);
         return result;
     }

--- a/src/lib/platform/MSWindowsUtil.h
+++ b/src/lib/platform/MSWindowsUtil.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include "base/String.h"
+#include <string>
 
 #define WINDOWS_LEAN_AND_MEAN
 #include <Windows.h>
@@ -29,14 +29,14 @@ public:
     /*!
     Gets a string for \p id from the string table of \p instance.
     */
-    static String        getString(HINSTANCE instance, DWORD id);
+    static std::string getString(HINSTANCE instance, DWORD id);
 
     //! Get error string
     /*!
     Gets a system error message for \p error.  If the error cannot be
     found return the string for \p id, replacing ${1} with \p error.
     */
-    static String        getErrorString(HINSTANCE, DWORD error, DWORD id);
+    static std::string getErrorString(HINSTANCE, DWORD error, DWORD id);
 
     //! Create directory
     /*!

--- a/src/lib/platform/MSWindowsWatchdog.cpp
+++ b/src/lib/platform/MSWindowsWatchdog.cpp
@@ -327,8 +327,7 @@ MSWindowsWatchdog::startProcess()
     }
 }
 
-BOOL
-MSWindowsWatchdog::doStartProcessAsSelf(String& command)
+BOOL MSWindowsWatchdog::doStartProcessAsSelf(std::string& command)
 {
     DWORD creationFlags =
         NORMAL_PRIORITY_CLASS |
@@ -347,8 +346,8 @@ MSWindowsWatchdog::doStartProcessAsSelf(String& command)
     return CreateProcess(NULL, LPSTR(command.c_str()), NULL, NULL, FALSE, creationFlags, NULL, NULL, &si, &m_processInfo);
 }
 
-BOOL
-MSWindowsWatchdog::doStartProcessAsUser(String& command, HANDLE userToken, LPSECURITY_ATTRIBUTES sa)
+BOOL MSWindowsWatchdog::doStartProcessAsUser(std::string& command, HANDLE userToken,
+                                             LPSECURITY_ATTRIBUTES sa)
 {
     // clear, as we're reusing process info struct
     ZeroMemory(&m_processInfo, sizeof(PROCESS_INFORMATION));

--- a/src/lib/platform/MSWindowsWatchdog.h
+++ b/src/lib/platform/MSWindowsWatchdog.h
@@ -55,8 +55,8 @@ private:
     HANDLE                duplicateProcessToken(HANDLE process, LPSECURITY_ATTRIBUTES security);
     HANDLE                getUserToken(LPSECURITY_ATTRIBUTES security);
     void                startProcess();
-    BOOL                doStartProcessAsUser(String& command, HANDLE userToken, LPSECURITY_ATTRIBUTES sa);
-    BOOL                doStartProcessAsSelf(String& command);
+    BOOL doStartProcessAsUser(std::string& command, HANDLE userToken, LPSECURITY_ATTRIBUTES sa);
+    BOOL doStartProcessAsSelf(std::string& command);
 
 private:
     Thread*                m_thread;
@@ -85,8 +85,8 @@ An error occured in the process watchdog.
 */
 class XMSWindowsWatchdogError : public XBarrier {
 public:
-    XMSWindowsWatchdogError(const String& msg) : XBarrier(msg) { }
+    XMSWindowsWatchdogError(const std::string& msg) : XBarrier(msg) { }
 
     // XBase overrides
-    virtual String        getWhat() const throw() { return what(); }
+    virtual std::string getWhat() const throw() { return what(); }
 };

--- a/src/lib/platform/OSXClipboard.cpp
+++ b/src/lib/platform/OSXClipboard.cpp
@@ -92,8 +92,7 @@ OSXClipboard::synchronize()
     return false;
 }    
 
-    void
-OSXClipboard::add(EFormat format, const String & data)
+void OSXClipboard::add(EFormat format, const std::string& data)
 {
     if (m_pboard == NULL)
         return;
@@ -116,7 +115,7 @@ OSXClipboard::add(EFormat format, const String & data)
 
         // skip converters for other formats
         if (converter->getFormat() == format) {
-            String osXData = converter->fromIClipboard(data);
+            std::string osXData = converter->fromIClipboard(data);
             CFStringRef flavorType = converter->getOSXFormat();
             CFDataRef dataRef = CFDataCreate(kCFAllocatorDefault, (UInt8 *)osXData.data(), osXData.size());
             PasteboardItemID itemID = 0;
@@ -185,12 +184,11 @@ OSXClipboard::has(EFormat format) const
     return false;
 }
 
-String
-OSXClipboard::get(EFormat format) const
+std::string OSXClipboard::get(EFormat format) const
 {
     CFStringRef type;
     PasteboardItemID item;
-    String result;
+    std::string result;
 
     if (m_pboard == NULL)
         return result;
@@ -229,7 +227,7 @@ OSXClipboard::get(EFormat format) const
             throw err;
         }
 
-        result = String((char *) CFDataGetBytePtr(buffer), CFDataGetLength(buffer));
+        result = std::string((char *) CFDataGetBytePtr(buffer), CFDataGetLength(buffer));
     }
     catch (OSStatus err) {
         LOG((CLOG_DEBUG "exception thrown in OSXClipboard::get MacError (%d)", err));

--- a/src/lib/platform/OSXClipboard.h
+++ b/src/lib/platform/OSXClipboard.h
@@ -21,6 +21,7 @@
 #include "barrier/IClipboard.h"
 
 #include <Carbon/Carbon.h>
+#include <string>
 #include <vector>
 
 class IOSXClipboardConverter;
@@ -36,12 +37,12 @@ public:
 
     // IClipboard overrides
     virtual bool        empty();
-    virtual void        add(EFormat, const String& data);
+    virtual void add(EFormat, const std::string& data);
     virtual bool        open(Time) const;
     virtual void        close() const;
     virtual Time        getTime() const;
     virtual bool        has(EFormat) const;
-    virtual String        get(EFormat) const;
+    virtual std::string get(EFormat) const;
 
     bool                synchronize();
 private:
@@ -72,8 +73,7 @@ public:
                         getFormat() const = 0;
 
     //! returns the scrap flavor type that this object converts from/to
-    virtual CFStringRef
-                        getOSXFormat() const = 0;
+    virtual CFStringRef getOSXFormat() const = 0;
 
     //! Convert from IClipboard format
     /*!
@@ -82,14 +82,14 @@ public:
     getFormat().  The return data will be in the scrap
     format returned by getOSXFormat().
     */
-    virtual String        fromIClipboard(const String&) const = 0;
+    virtual std::string fromIClipboard(const std::string&) const = 0;
 
     //! Convert to IClipboard format
     /*!
     Convert from the carbon scrap format to the IClipboard format
     (i.e., the reverse of fromIClipboard()).
     */
-    virtual String        toIClipboard(const String&) const = 0;
+    virtual std::string toIClipboard(const std::string&) const = 0;
 
     //@}
 };

--- a/src/lib/platform/OSXClipboardAnyBitmapConverter.cpp
+++ b/src/lib/platform/OSXClipboardAnyBitmapConverter.cpp
@@ -35,14 +35,12 @@ OSXClipboardAnyBitmapConverter::getFormat() const
     return IClipboard::kBitmap;
 }
 
-String
-OSXClipboardAnyBitmapConverter::fromIClipboard(const String& data) const
+std::string OSXClipboardAnyBitmapConverter::fromIClipboard(const std::string& data) const
 {
     return doFromIClipboard(data);
 }
 
-String
-OSXClipboardAnyBitmapConverter::toIClipboard(const String& data) const
+std::string OSXClipboardAnyBitmapConverter::toIClipboard(const std::string& data) const
 {
     return doToIClipboard(data);
 }

--- a/src/lib/platform/OSXClipboardAnyBitmapConverter.h
+++ b/src/lib/platform/OSXClipboardAnyBitmapConverter.h
@@ -30,19 +30,19 @@ public:
     virtual IClipboard::EFormat
                         getFormat() const;
     virtual CFStringRef    getOSXFormat() const = 0;
-    virtual String        fromIClipboard(const String &) const;
-    virtual String        toIClipboard(const String &) const;
+    virtual std::string fromIClipboard(const std::string &) const;
+    virtual std::string toIClipboard(const std::string &) const;
 
 protected:
     //! Convert from IClipboard format
     /*!
      Do UTF-8 conversion and linefeed conversion.
     */
-    virtual String        doFromIClipboard(const String&) const = 0;
+    virtual std::string doFromIClipboard(const std::string&) const = 0;
 
     //! Convert to IClipboard format
     /*!
      Do UTF-8 conversion and Linefeed conversion.
     */
-    virtual String        doToIClipboard(const String&) const = 0;
+    virtual std::string doToIClipboard(const std::string&) const = 0;
 };

--- a/src/lib/platform/OSXClipboardAnyTextConverter.cpp
+++ b/src/lib/platform/OSXClipboardAnyTextConverter.cpp
@@ -40,15 +40,13 @@ OSXClipboardAnyTextConverter::getFormat() const
     return IClipboard::kText;
 }
 
-String
-OSXClipboardAnyTextConverter::fromIClipboard(const String& data) const
+std::string OSXClipboardAnyTextConverter::fromIClipboard(const std::string& data) const
 {
     // convert linefeeds and then convert to desired encoding
     return doFromIClipboard(convertLinefeedToMacOS(data));
 }
 
-String
-OSXClipboardAnyTextConverter::toIClipboard(const String& data) const
+std::string OSXClipboardAnyTextConverter::toIClipboard(const std::string& data) const
 {
     // convert text then newlines
     return convertLinefeedToUnix(doToIClipboard(data));
@@ -68,21 +66,19 @@ isCR(char ch)
     return (ch == '\r');
 }
 
-String
-OSXClipboardAnyTextConverter::convertLinefeedToMacOS(const String& src)
+std::string OSXClipboardAnyTextConverter::convertLinefeedToMacOS(const std::string& src)
 {
     // note -- we assume src is a valid UTF-8 string
-    String copy = src;
+    std::string copy = src;
 
     std::replace_if(copy.begin(), copy.end(), isLF, '\r');
 
     return copy;
 }
 
-String
-OSXClipboardAnyTextConverter::convertLinefeedToUnix(const String& src)
+std::string OSXClipboardAnyTextConverter::convertLinefeedToUnix(const std::string& src)
 {
-    String copy = src;
+    std::string copy = src;
 
     std::replace_if(copy.begin(), copy.end(), isCR, '\n');
 

--- a/src/lib/platform/OSXClipboardAnyTextConverter.h
+++ b/src/lib/platform/OSXClipboardAnyTextConverter.h
@@ -29,25 +29,24 @@ public:
     // IOSXClipboardConverter overrides
     virtual IClipboard::EFormat
                         getFormat() const;
-    virtual CFStringRef
-                        getOSXFormat() const = 0;
-    virtual String        fromIClipboard(const String &) const;
-    virtual String        toIClipboard(const String &) const;
+    virtual CFStringRef getOSXFormat() const = 0;
+    virtual std::string fromIClipboard(const std::string &) const;
+    virtual std::string toIClipboard(const std::string &) const;
 
 protected:
     //! Convert from IClipboard format
     /*!
     Do UTF-8 conversion and linefeed conversion.
     */
-    virtual String        doFromIClipboard(const String&) const = 0;
+    virtual std::string doFromIClipboard(const std::string&) const = 0;
 
     //! Convert to IClipboard format
     /*!
     Do UTF-8 conversion and Linefeed conversion.
     */
-    virtual String        doToIClipboard(const String&) const = 0;
+    virtual std::string doToIClipboard(const std::string&) const = 0;
 
 private:
-    static String        convertLinefeedToMacOS(const String&);
-    static String        convertLinefeedToUnix(const String&);
+    static std::string convertLinefeedToMacOS(const std::string&);
+    static std::string convertLinefeedToUnix(const std::string&);
 };

--- a/src/lib/platform/OSXClipboardBMPConverter.cpp
+++ b/src/lib/platform/OSXClipboardBMPConverter.cpp
@@ -91,8 +91,7 @@ OSXClipboardBMPConverter::getOSXFormat() const
     return CFSTR("com.microsoft.bmp");
 }
 
-String
-OSXClipboardBMPConverter::fromIClipboard(const String& bmp) const
+std::string OSXClipboardBMPConverter::fromIClipboard(const std::string& bmp) const
 {
     LOG((CLOG_DEBUG1 "ENTER OSXClipboardBMPConverter::doFromIClipboard()"));
     // create BMP image
@@ -104,21 +103,20 @@ OSXClipboardBMPConverter::fromIClipboard(const String& bmp) const
     toLE(dst, static_cast<UInt16>(0));
     toLE(dst, static_cast<UInt16>(0));
     toLE(dst, static_cast<UInt32>(14 + 40));
-    return String(reinterpret_cast<const char*>(header), 14) + bmp;
+    return std::string(reinterpret_cast<const char*>(header), 14) + bmp;
 }
 
-String
-OSXClipboardBMPConverter::toIClipboard(const String& bmp) const
+std::string OSXClipboardBMPConverter::toIClipboard(const std::string& bmp) const
 {
     // make sure data is big enough for a BMP file
     if (bmp.size() <= 14 + 40) {
-        return String();
+        return {};
     }
 
     // check BMP file header
     const UInt8* rawBMPHeader = reinterpret_cast<const UInt8*>(bmp.data());
     if (rawBMPHeader[0] != 'B' || rawBMPHeader[1] != 'M') {
-        return String();
+        return {};
     }
 
     // get offset to image data

--- a/src/lib/platform/OSXClipboardBMPConverter.h
+++ b/src/lib/platform/OSXClipboardBMPConverter.h
@@ -34,11 +34,10 @@ public:
                         getOSXFormat() const;
 
     // OSXClipboardAnyBMPConverter overrides
-    virtual String        fromIClipboard(const String&) const;
-    virtual String        toIClipboard(const String&) const;
+    virtual std::string fromIClipboard(const std::string&) const;
+    virtual std::string toIClipboard(const std::string&) const;
 
     // generic encoding converter
-    static String        convertString(const String& data,
-                            CFStringEncoding fromEncoding,
-                            CFStringEncoding toEncoding);
+    static std::string convertString(const std::string& data, CFStringEncoding fromEncoding,
+                                     CFStringEncoding toEncoding);
 };

--- a/src/lib/platform/OSXClipboardHTMLConverter.cpp
+++ b/src/lib/platform/OSXClipboardHTMLConverter.cpp
@@ -42,18 +42,16 @@ OSXClipboardHTMLConverter::getOSXFormat() const
     return CFSTR("public.html");
 }
 
-String 
-OSXClipboardHTMLConverter::convertString(
-                                const String& data,
-                                CFStringEncoding fromEncoding,
-                                CFStringEncoding toEncoding)
+std::string OSXClipboardHTMLConverter::convertString(const std::string& data,
+                                                     CFStringEncoding fromEncoding,
+                                                     CFStringEncoding toEncoding)
 {
     CFStringRef stringRef = CFStringCreateWithCString(
                                 kCFAllocatorDefault,
                                 data.c_str(), fromEncoding);
 
     if (stringRef == NULL) {
-        return String();
+        return {};
     }
 
     CFIndex buffSize;
@@ -66,13 +64,13 @@ OSXClipboardHTMLConverter::convertString(
 
     if (buffer == NULL) {
         CFRelease(stringRef);
-        return String();
+        return {};
     }
     
     CFStringGetBytes(stringRef, entireString, toEncoding,
         0, false, (UInt8*)buffer, buffSize, NULL);
 
-    String result(buffer, buffSize);
+    std::string result(buffer, buffSize);
 
     delete[] buffer;
     CFRelease(stringRef);
@@ -80,15 +78,13 @@ OSXClipboardHTMLConverter::convertString(
     return result;
 }
 
-String
-OSXClipboardHTMLConverter::doFromIClipboard(const String& data) const
+std::string OSXClipboardHTMLConverter::doFromIClipboard(const std::string& data) const
 {
     return convertString(data, kCFStringEncodingUTF8,
                 CFStringGetSystemEncoding());
 }
 
-String
-OSXClipboardHTMLConverter::doToIClipboard(const String& data) const
+std::string OSXClipboardHTMLConverter::doToIClipboard(const std::string& data) const
 {
     return convertString(data, CFStringGetSystemEncoding(),
                 kCFStringEncodingUTF8);

--- a/src/lib/platform/OSXClipboardHTMLConverter.h
+++ b/src/lib/platform/OSXClipboardHTMLConverter.h
@@ -34,11 +34,10 @@ public:
 
 protected:
     // OSXClipboardAnyTextConverter overrides
-    virtual String        doFromIClipboard(const String&) const;
-    virtual String        doToIClipboard(const String&) const;
+    virtual std::string doFromIClipboard(const std::string&) const;
+    virtual std::string doToIClipboard(const std::string&) const;
 
     // generic encoding converter
-    static String        convertString(const String& data,
-                            CFStringEncoding fromEncoding,
-                            CFStringEncoding toEncoding);
+    static std::string convertString(const std::string& data, CFStringEncoding fromEncoding,
+                                     CFStringEncoding toEncoding);
 };

--- a/src/lib/platform/OSXClipboardTextConverter.cpp
+++ b/src/lib/platform/OSXClipboardTextConverter.cpp
@@ -40,18 +40,16 @@ OSXClipboardTextConverter::getOSXFormat() const
     return CFSTR("public.plain-text");
 }
 
-String 
-OSXClipboardTextConverter::convertString(
-                const String& data, 
-                CFStringEncoding fromEncoding,
-                CFStringEncoding toEncoding)
+std::string OSXClipboardTextConverter::convertString(const std::string& data,
+                                                     CFStringEncoding fromEncoding,
+                                                     CFStringEncoding toEncoding)
 {
     CFStringRef stringRef =
         CFStringCreateWithCString(kCFAllocatorDefault,
                             data.c_str(), fromEncoding);
 
     if (stringRef == NULL) {
-        return String();
+        return {};
     }
 
     CFIndex buffSize;
@@ -64,13 +62,13 @@ OSXClipboardTextConverter::convertString(
     
     if (buffer == NULL) {
         CFRelease(stringRef);
-        return String();
+        return {};
     }
     
     CFStringGetBytes(stringRef, entireString, toEncoding,
                             0, false, (UInt8*)buffer, buffSize, NULL);
 
-    String result(buffer, buffSize);
+    std::string result(buffer, buffSize);
 
     delete[] buffer;
     CFRelease(stringRef);
@@ -78,15 +76,13 @@ OSXClipboardTextConverter::convertString(
     return result;
 }
 
-String
-OSXClipboardTextConverter::doFromIClipboard(const String& data) const
+std::string OSXClipboardTextConverter::doFromIClipboard(const std::string& data) const
 {
     return convertString(data, kCFStringEncodingUTF8,
                             CFStringGetSystemEncoding());
 }
 
-String
-OSXClipboardTextConverter::doToIClipboard(const String& data) const
+std::string OSXClipboardTextConverter::doToIClipboard(const std::string& data) const
 {
     return convertString(data, CFStringGetSystemEncoding(),
                             kCFStringEncodingUTF8);

--- a/src/lib/platform/OSXClipboardTextConverter.h
+++ b/src/lib/platform/OSXClipboardTextConverter.h
@@ -32,11 +32,10 @@ public:
 
 protected:
     // OSXClipboardAnyTextConverter overrides
-    virtual String        doFromIClipboard(const String&) const;
-    virtual String        doToIClipboard(const String&) const;
+    virtual std::string doFromIClipboard(const std::string&) const;
+    virtual std::string doToIClipboard(const std::string&) const;
 
     // generic encoding converter
-    static String        convertString(const String& data,  
-                            CFStringEncoding fromEncoding,
-                            CFStringEncoding toEncoding);
+    static std::string convertString(const std::string& data, CFStringEncoding fromEncoding,
+                                     CFStringEncoding toEncoding);
 };

--- a/src/lib/platform/OSXClipboardUTF16Converter.cpp
+++ b/src/lib/platform/OSXClipboardUTF16Converter.cpp
@@ -40,15 +40,13 @@ OSXClipboardUTF16Converter::getOSXFormat() const
     return CFSTR("public.utf16-plain-text");
 }
 
-String
-OSXClipboardUTF16Converter::doFromIClipboard(const String& data) const
+std::string OSXClipboardUTF16Converter::doFromIClipboard(const std::string& data) const
 {
     // convert and add nul terminator
     return Unicode::UTF8ToUTF16(data);
 }
 
-String
-OSXClipboardUTF16Converter::doToIClipboard(const String& data) const
+std::string OSXClipboardUTF16Converter::doToIClipboard(const std::string& data) const
 {
     // convert and strip nul terminator
     return Unicode::UTF16ToUTF8(data);

--- a/src/lib/platform/OSXClipboardUTF16Converter.h
+++ b/src/lib/platform/OSXClipboardUTF16Converter.h
@@ -32,6 +32,6 @@ public:
 
 protected:
     // OSXClipboardAnyTextConverter overrides
-    virtual String        doFromIClipboard(const String&) const;
-    virtual String        doToIClipboard(const String&) const;
+    virtual std::string doFromIClipboard(const std::string&) const;
+    virtual std::string doToIClipboard(const std::string&) const;
 };

--- a/src/lib/platform/OSXScreen.h
+++ b/src/lib/platform/OSXScreen.h
@@ -97,9 +97,9 @@ public:
     virtual void        setSequenceNumber(UInt32);
     virtual bool        isPrimary() const;
     virtual void        fakeDraggingFiles(DragFileList fileList);
-    virtual String&    getDraggingFilename();
+    virtual std::string& getDraggingFilename();
     
-    const String&        getDropTarget() const { return m_dropTarget; }
+    const std::string& getDropTarget() const { return m_dropTarget; }
     void                waitForCarbonLoop() const;
     
 protected:
@@ -338,7 +338,7 @@ private:
     IEventQueue*            m_events;
     
     Thread*                m_getDropTargetThread;
-    String                    m_dropTarget;
+    std::string m_dropTarget;
     
 #if defined(MAC_OS_X_VERSION_10_7)
     Mutex*                    m_carbonLoopMutex;

--- a/src/lib/platform/XWindowsClipboard.cpp
+++ b/src/lib/platform/XWindowsClipboard.cpp
@@ -170,7 +170,7 @@ XWindowsClipboard::addSimpleRequest(Window requestor,
     }
 
     // handle targets
-    String data;
+    std::string data;
     Atom type  = None;
     int format = 0;
     if (target == m_atomTargets) {
@@ -303,8 +303,7 @@ XWindowsClipboard::empty()
     return true;
 }
 
-void
-XWindowsClipboard::add(EFormat format, const String& data)
+void XWindowsClipboard::add(EFormat format, const std::string& data)
 {
     assert(m_open);
     assert(m_owner);
@@ -387,8 +386,7 @@ XWindowsClipboard::has(EFormat format) const
     return m_added[format];
 }
 
-String
-XWindowsClipboard::get(EFormat format) const
+std::string XWindowsClipboard::get(EFormat format) const
 {
     assert(m_open);
 
@@ -513,7 +511,7 @@ XWindowsClipboard::icccmFillCache()
     // instead of the correct type ATOM;  allow either.
     const Atom atomTargets = m_atomTargets;
     Atom target;
-    String data;
+    std::string data;
     if (!icccmGetSelection(atomTargets, &target, &data) ||
         (target != m_atomAtom && target != m_atomTargets)) {
         LOG((CLOG_DEBUG1 "selection doesn't support TARGETS"));
@@ -557,7 +555,7 @@ XWindowsClipboard::icccmFillCache()
 
         // get the data
         Atom actualTarget;
-        String targetData;
+        std::string targetData;
         if (!icccmGetSelection(target, &actualTarget, &targetData)) {
             LOG((CLOG_DEBUG1 "  no data for target %s", XWindowsUtil::atomToString(m_display, target).c_str()));
             continue;
@@ -573,7 +571,7 @@ XWindowsClipboard::icccmFillCache()
 
 bool
 XWindowsClipboard::icccmGetSelection(Atom target,
-                Atom* actualTarget, String* data) const
+                Atom* actualTarget, std::string* data) const
 {
     assert(actualTarget != NULL);
     assert(data         != NULL);
@@ -597,7 +595,7 @@ IClipboard::Time
 XWindowsClipboard::icccmGetTime() const
 {
     Atom actualTarget;
-    String data;
+    std::string data;
     if (icccmGetSelection(m_atomTimestamp, &actualTarget, &data) &&
         actualTarget == m_atomInteger) {
         Time time = *reinterpret_cast<const Time*>(data.data());
@@ -668,7 +666,7 @@ XWindowsClipboard::motifOwnsClipboard() const
     // get the Motif clipboard header property from the root window
     Atom target;
     SInt32 format;
-    String data;
+    std::string data;
     Window root = RootWindow(m_display, DefaultScreen(m_display));
     if (!XWindowsUtil::getWindowProperty(m_display, root,
                                 m_atomMotifClipHeader,
@@ -697,7 +695,7 @@ XWindowsClipboard::motifFillCache()
     // get the Motif clipboard header property from the root window
     Atom target;
     SInt32 format;
-    String data;
+    std::string data;
     Window root = RootWindow(m_display, DefaultScreen(m_display));
     if (!XWindowsUtil::getWindowProperty(m_display, root,
                                 m_atomMotifClipHeader,
@@ -741,13 +739,13 @@ XWindowsClipboard::motifFillCache()
                                 static_cast<const char*>(data.data()));
 
     // get the available formats
-    typedef std::map<Atom, String> MotifFormatMap;
+    typedef std::map<Atom, std::string> MotifFormatMap;
     MotifFormatMap motifFormats;
     for (SInt32 i = 0; i < numFormats; ++i) {
         // get Motif format property from the root window
         sprintf(name, "_MOTIF_CLIP_ITEM_%d", formats[i]);
         Atom atomFormat = m_impl->XInternAtom(m_display, name, False);
-        String data;
+        std::string data;
         if (!XWindowsUtil::getWindowProperty(m_display, root,
                                     atomFormat, &data,
                                     &target, &format, False)) {
@@ -797,7 +795,7 @@ XWindowsClipboard::motifFillCache()
 
         // get the data (finally)
         Atom actualTarget;
-        String targetData;
+        std::string targetData;
         if (!motifGetSelection(&motifFormat, &actualTarget, &targetData)) {
             LOG((CLOG_DEBUG1 "  no data for target %s", XWindowsUtil::atomToString(m_display, target).c_str()));
             continue;
@@ -813,7 +811,7 @@ XWindowsClipboard::motifFillCache()
 
 bool
 XWindowsClipboard::motifGetSelection(const MotifClipFormat* format,
-                            Atom* actualTarget, String* data) const
+                            Atom* actualTarget, std::string* data) const
 {
     // if the current clipboard owner and the owner indicated by the
     // motif clip header are the same then transfer via a property on
@@ -849,7 +847,7 @@ XWindowsClipboard::insertMultipleReply(Window requestor,
     // get the requested targets
     Atom target;
     SInt32 format;
-    String data;
+    std::string data;
     if (!XWindowsUtil::getWindowProperty(m_display, requestor,
                                 property, &data, &target, &format, False)) {
         // can't get the requested targets
@@ -887,7 +885,7 @@ XWindowsClipboard::insertMultipleReply(Window requestor,
 
     // add reply for MULTIPLE request
     insertReply(new Reply(requestor, m_atomMultiple,
-                                time, property, String(), None, 32));
+                                time, property, std::string(), None, 32));
 
     return true;
 }
@@ -1101,7 +1099,7 @@ XWindowsClipboard::sendReply(Reply* reply)
             LOG((CLOG_DEBUG2 "properties of 0x%08x:", reply->m_requestor));
             for (int i = 0; i < n; ++i) {
                 Atom target;
-                String data;
+                std::string data;
                 char* name = m_impl->XGetAtomName(m_display, props[i]);
                 if (!XWindowsUtil::getWindowProperty(m_display,
                                 reply->m_requestor,
@@ -1112,9 +1110,9 @@ XWindowsClipboard::sendReply(Reply* reply)
                     // if there are any non-ascii characters in string
                     // then print the binary data.
                     static const char* hex = "0123456789abcdef";
-                    for (String::size_type j = 0; j < data.size(); ++j) {
+                    for (std::string::size_type j = 0; j < data.size(); ++j) {
                         if (data[j] < 32 || data[j] > 126) {
-                            String tmp;
+                            std::string tmp;
                             tmp.reserve(data.size() * 3);
                             for (j = 0; j < data.size(); ++j) {
                                 unsigned char v = (unsigned char)data[j];
@@ -1221,8 +1219,7 @@ XWindowsClipboard::wasOwnedAtTime(::Time time) const
     return (/*when >= 0 &&*/ when <= duration);
 }
 
-Atom
-XWindowsClipboard::getTargetsData(String& data, int* format) const
+Atom XWindowsClipboard::getTargetsData(std::string& data, int* format) const
 {
     assert(format != NULL);
 
@@ -1246,8 +1243,7 @@ XWindowsClipboard::getTargetsData(String& data, int* format) const
     return m_atomAtom;
 }
 
-Atom
-XWindowsClipboard::getTimestampData(String& data, int* format) const
+Atom XWindowsClipboard::getTimestampData(std::string& data, int* format) const
 {
     assert(format != NULL);
 
@@ -1285,7 +1281,7 @@ XWindowsClipboard::CICCCMGetClipboard::~CICCCMGetClipboard()
 
 bool
 XWindowsClipboard::CICCCMGetClipboard::readClipboard(Display* display,
-                Atom selection, Atom target, Atom* actualTarget, String* data)
+                Atom selection, Atom target, Atom* actualTarget, std::string* data)
 {
     assert(actualTarget != NULL);
     assert(data         != NULL);
@@ -1430,7 +1426,7 @@ XWindowsClipboard::CICCCMGetClipboard::processEvent(
 
     // get the data from the property
     Atom target;
-    const String::size_type oldSize = m_data->size();
+    const std::string::size_type oldSize = m_data->size();
     if (!XWindowsUtil::getWindowProperty(display, m_requestor,
                                 m_property, m_data, &target, NULL, True)) {
         // unable to read property
@@ -1515,7 +1511,7 @@ XWindowsClipboard::Reply::Reply(Window requestor, Atom target, ::Time time) :
 }
 
 XWindowsClipboard::Reply::Reply(Window requestor, Atom target, ::Time time,
-                Atom property, const String& data, Atom type, int format) :
+                Atom property, const std::string& data, Atom type, int format) :
     m_requestor(requestor),
     m_target(target),
     m_time(time),

--- a/src/lib/platform/XWindowsClipboard.h
+++ b/src/lib/platform/XWindowsClipboard.h
@@ -90,12 +90,12 @@ public:
 
     // IClipboard overrides
     virtual bool        empty();
-    virtual void        add(EFormat, const String& data);
+    virtual void add(EFormat, const std::string& data);
     virtual bool        open(Time) const;
     virtual void        close() const;
     virtual Time        getTime() const;
     virtual bool        has(EFormat) const;
-    virtual String        get(EFormat) const;
+    virtual std::string get(EFormat) const;
 
 private:
     // remove all converters from our list
@@ -148,7 +148,7 @@ private:
         // cannot be performed (in which case *actualTarget == None).
         bool            readClipboard(Display* display,
                             Atom selection, Atom target,
-                            Atom* actualTarget, String* data);
+                            Atom* actualTarget, std::string* data);
 
     private:
         bool            processEvent(Display* display, XEvent* event);
@@ -169,7 +169,7 @@ private:
         bool            m_reading;
 
         // the converted selection data
-        String*        m_data;
+        std::string* m_data;
 
         // the actual type of the data.  if this is None then the
         // selection owner cannot convert to the requested type.
@@ -224,8 +224,8 @@ private:
     class Reply {
     public:
         Reply(Window, Atom target, ::Time);
-        Reply(Window, Atom target, ::Time, Atom property,
-                            const String& data, Atom type, int format);
+        Reply(Window, Atom target, ::Time, Atom property, const std::string& data,
+              Atom type, int format);
 
     public:
         // information about the request
@@ -241,7 +241,7 @@ private:
         bool            m_done;
 
         // the data to send and its type and format
-        String            m_data;
+        std::string m_data;
         Atom            m_type;
         int                m_format;
 
@@ -254,8 +254,7 @@ private:
 
     // ICCCM interoperability methods
     void                icccmFillCache();
-    bool                icccmGetSelection(Atom target,
-                            Atom* actualTarget, String* data) const;
+    bool icccmGetSelection(Atom target, Atom* actualTarget, std::string* data) const;
     Time                icccmGetTime() const;
 
     // motif interoperability methods
@@ -263,8 +262,7 @@ private:
     void                motifUnlockClipboard() const;
     bool                motifOwnsClipboard() const;
     void                motifFillCache();
-    bool                motifGetSelection(const MotifClipFormat*,
-                            Atom* actualTarget, String* data) const;
+    bool motifGetSelection(const MotifClipFormat*, Atom* actualTarget, std::string* data) const;
     Time                motifGetTime() const;
 
     // reply methods
@@ -281,8 +279,8 @@ private:
     bool                wasOwnedAtTime(::Time) const;
 
     // data conversion methods
-    Atom                getTargetsData(String&, int* format) const;
-    Atom                getTimestampData(String&, int* format) const;
+    Atom getTargetsData(std::string&, int* format) const;
+    Atom getTimestampData(std::string&, int* format) const;
 
 private:
     typedef std::vector<IXWindowsClipboardConverter*> ConverterList;
@@ -306,7 +304,7 @@ private:
     bool                m_cached;
     Time                m_cacheTime;
     bool                m_added[kNumFormats];
-    String                m_data[kNumFormats];
+    std::string m_data[kNumFormats];
 
     // conversion request replies
     ReplyMap            m_replies;
@@ -368,14 +366,14 @@ public:
     getFormat().  The return data will be in the X selection
     format returned by getAtom().
     */
-    virtual String        fromIClipboard(const String&) const = 0;
+    virtual std::string fromIClipboard(const std::string&) const = 0;
 
     //! Convert to IClipboard format
     /*!
     Convert from the X selection format to the IClipboard format
     (i.e., the reverse of fromIClipboard()).
     */
-    virtual String        toIClipboard(const String&) const = 0;
+    virtual std::string toIClipboard(const std::string&) const = 0;
 
     //@}
 };

--- a/src/lib/platform/XWindowsClipboardAnyBitmapConverter.cpp
+++ b/src/lib/platform/XWindowsClipboardAnyBitmapConverter.cpp
@@ -122,8 +122,7 @@ XWindowsClipboardAnyBitmapConverter::getDataSize() const
     return 8;
 }
 
-String
-XWindowsClipboardAnyBitmapConverter::fromIClipboard(const String& bmp) const
+std::string XWindowsClipboardAnyBitmapConverter::fromIClipboard(const std::string& bmp) const
 {
     // fill BMP info header with native-endian data
     CBMPInfoHeader infoHeader;
@@ -145,7 +144,7 @@ XWindowsClipboardAnyBitmapConverter::fromIClipboard(const String& bmp) const
         infoHeader.biWidth == 0 || infoHeader.biHeight == 0 ||
         infoHeader.biPlanes != 0 || infoHeader.biCompression != 0 ||
         (infoHeader.biBitCount != 24 && infoHeader.biBitCount != 32)) {
-        return String();
+        return {};
     }
 
     // convert to image format
@@ -160,14 +159,13 @@ XWindowsClipboardAnyBitmapConverter::fromIClipboard(const String& bmp) const
     }
 }
 
-String
-XWindowsClipboardAnyBitmapConverter::toIClipboard(const String& image) const
+std::string XWindowsClipboardAnyBitmapConverter::toIClipboard(const std::string& image) const
 {
     // convert to raw BMP data
     UInt32 w, h, depth;
-    String rawBMP = doToIClipboard(image, w, h, depth);
+    std::string rawBMP = doToIClipboard(image, w, h, depth);
     if (rawBMP.empty() || w == 0 || h == 0 || (depth != 24 && depth != 32)) {
-        return String();
+        return {};
     }
 
     // fill BMP info header with little-endian data
@@ -186,6 +184,6 @@ XWindowsClipboardAnyBitmapConverter::toIClipboard(const String& image) const
     toLE(dst, static_cast<UInt32>(0));
 
     // construct image
-    return String(reinterpret_cast<const char*>(infoHeader),
-                            sizeof(infoHeader)) + rawBMP;
+    return std::string(reinterpret_cast<const char*>(infoHeader),
+                       sizeof(infoHeader)) + rawBMP;
 }

--- a/src/lib/platform/XWindowsClipboardAnyBitmapConverter.h
+++ b/src/lib/platform/XWindowsClipboardAnyBitmapConverter.h
@@ -32,29 +32,27 @@ public:
                         getFormat() const;
     virtual Atom        getAtom() const = 0;
     virtual int            getDataSize() const;
-    virtual String        fromIClipboard(const String&) const;
-    virtual String        toIClipboard(const String&) const;
+    virtual std::string fromIClipboard(const std::string&) const;
+    virtual std::string toIClipboard(const std::string&) const;
 
 protected:
     //! Convert from IClipboard format
     /*!
     Convert raw BGR pixel data to another image format.
     */
-    virtual String        doBGRFromIClipboard(const UInt8* bgrData,
-                            UInt32 w, UInt32 h) const = 0;
+    virtual std::string doBGRFromIClipboard(const UInt8* bgrData, UInt32 w, UInt32 h) const = 0;
 
     //! Convert from IClipboard format
     /*!
     Convert raw BGRA pixel data to another image format.
     */
-    virtual String        doBGRAFromIClipboard(const UInt8* bgrData,
-                            UInt32 w, UInt32 h) const = 0;
+    virtual std::string doBGRAFromIClipboard(const UInt8* bgrData, UInt32 w, UInt32 h) const = 0;
 
     //! Convert to IClipboard format
     /*!
     Convert an image into raw BGR or BGRA image data and store the
     width, height, and image depth (24 or 32).
     */
-    virtual String        doToIClipboard(const String&,
-                            UInt32& w, UInt32& h, UInt32& depth) const = 0;
+    virtual std::string doToIClipboard(const std::string&, UInt32& w, UInt32& h,
+                                       UInt32& depth) const = 0;
 };

--- a/src/lib/platform/XWindowsClipboardBMPConverter.cpp
+++ b/src/lib/platform/XWindowsClipboardBMPConverter.cpp
@@ -101,8 +101,7 @@ XWindowsClipboardBMPConverter::getDataSize() const
     return 8;
 }
 
-String
-XWindowsClipboardBMPConverter::fromIClipboard(const String& bmp) const
+std::string XWindowsClipboardBMPConverter::fromIClipboard(const std::string& bmp) const
 {
     // create BMP image
     UInt8 header[14];
@@ -113,21 +112,20 @@ XWindowsClipboardBMPConverter::fromIClipboard(const String& bmp) const
     toLE(dst, static_cast<UInt16>(0));
     toLE(dst, static_cast<UInt16>(0));
     toLE(dst, static_cast<UInt32>(14 + 40));
-    return String(reinterpret_cast<const char*>(header), 14) + bmp;
+    return std::string(reinterpret_cast<const char*>(header), 14) + bmp;
 }
 
-String
-XWindowsClipboardBMPConverter::toIClipboard(const String& bmp) const
+std::string XWindowsClipboardBMPConverter::toIClipboard(const std::string& bmp) const
 {
     // make sure data is big enough for a BMP file
     if (bmp.size() <= 14 + 40) {
-        return String();
+        return {};
     }
 
     // check BMP file header
     const UInt8* rawBMPHeader = reinterpret_cast<const UInt8*>(bmp.data());
     if (rawBMPHeader[0] != 'B' || rawBMPHeader[1] != 'M') {
-        return String();
+        return {};
     }
 
     // get offset to image data

--- a/src/lib/platform/XWindowsClipboardBMPConverter.h
+++ b/src/lib/platform/XWindowsClipboardBMPConverter.h
@@ -32,8 +32,8 @@ public:
                         getFormat() const;
     virtual Atom        getAtom() const;
     virtual int            getDataSize() const;
-    virtual String        fromIClipboard(const String&) const;
-    virtual String        toIClipboard(const String&) const;
+    virtual std::string fromIClipboard(const std::string&) const;
+    virtual std::string toIClipboard(const std::string&) const;
 
 private:
     Atom                m_atom;

--- a/src/lib/platform/XWindowsClipboardHTMLConverter.cpp
+++ b/src/lib/platform/XWindowsClipboardHTMLConverter.cpp
@@ -54,14 +54,12 @@ XWindowsClipboardHTMLConverter::getDataSize() const
     return 8;
 }
 
-String
-XWindowsClipboardHTMLConverter::fromIClipboard(const String& data) const
+std::string XWindowsClipboardHTMLConverter::fromIClipboard(const std::string& data) const
 {
     return Unicode::UTF8ToUTF16(data);
 }
 
-String
-XWindowsClipboardHTMLConverter::toIClipboard(const String& data) const
+std::string XWindowsClipboardHTMLConverter::toIClipboard(const std::string& data) const
 {
     return Unicode::UTF16ToUTF8(data);
 }

--- a/src/lib/platform/XWindowsClipboardHTMLConverter.h
+++ b/src/lib/platform/XWindowsClipboardHTMLConverter.h
@@ -34,8 +34,8 @@ public:
                         getFormat() const;
     virtual Atom        getAtom() const;
     virtual int            getDataSize() const;
-    virtual String        fromIClipboard(const String&) const;
-    virtual String        toIClipboard(const String&) const;
+    virtual std::string fromIClipboard(const std::string&) const;
+    virtual std::string toIClipboard(const std::string&) const;
 
 private:
     Atom                m_atom;

--- a/src/lib/platform/XWindowsClipboardTextConverter.cpp
+++ b/src/lib/platform/XWindowsClipboardTextConverter.cpp
@@ -54,18 +54,16 @@ XWindowsClipboardTextConverter::getDataSize() const
     return 8;
 }
 
-String
-XWindowsClipboardTextConverter::fromIClipboard(const String& data) const
+std::string XWindowsClipboardTextConverter::fromIClipboard(const std::string& data) const
 {
     return Unicode::UTF8ToText(data);
 }
 
-String
-XWindowsClipboardTextConverter::toIClipboard(const String& data) const
+std::string XWindowsClipboardTextConverter::toIClipboard(const std::string& data) const
 {
     // convert to UTF-8
     bool errors;
-    String utf8 = Unicode::textToUTF8(data, &errors);
+    std::string utf8 = Unicode::textToUTF8(data, &errors);
 
     // if there were decoding errors then, to support old applications
     // that don't understand UTF-8 but can report the exact binary

--- a/src/lib/platform/XWindowsClipboardTextConverter.h
+++ b/src/lib/platform/XWindowsClipboardTextConverter.h
@@ -34,8 +34,8 @@ public:
                         getFormat() const;
     virtual Atom        getAtom() const;
     virtual int            getDataSize() const;
-    virtual String        fromIClipboard(const String&) const;
-    virtual String        toIClipboard(const String&) const;
+    virtual std::string fromIClipboard(const std::string&) const;
+    virtual std::string toIClipboard(const std::string&) const;
 
 private:
     Atom                m_atom;

--- a/src/lib/platform/XWindowsClipboardUCS2Converter.cpp
+++ b/src/lib/platform/XWindowsClipboardUCS2Converter.cpp
@@ -54,14 +54,12 @@ XWindowsClipboardUCS2Converter::getDataSize() const
     return 16;
 }
 
-String
-XWindowsClipboardUCS2Converter::fromIClipboard(const String& data) const
+std::string XWindowsClipboardUCS2Converter::fromIClipboard(const std::string& data) const
 {
     return Unicode::UTF8ToUCS2(data);
 }
 
-String
-XWindowsClipboardUCS2Converter::toIClipboard(const String& data) const
+std::string XWindowsClipboardUCS2Converter::toIClipboard(const std::string& data) const
 {
     return Unicode::UCS2ToUTF8(data);
 }

--- a/src/lib/platform/XWindowsClipboardUCS2Converter.h
+++ b/src/lib/platform/XWindowsClipboardUCS2Converter.h
@@ -34,8 +34,8 @@ public:
                         getFormat() const;
     virtual Atom        getAtom() const;
     virtual int            getDataSize() const;
-    virtual String        fromIClipboard(const String&) const;
-    virtual String        toIClipboard(const String&) const;
+    virtual std::string fromIClipboard(const std::string&) const;
+    virtual std::string toIClipboard(const std::string&) const;
 
 private:
     Atom                m_atom;

--- a/src/lib/platform/XWindowsClipboardUTF8Converter.cpp
+++ b/src/lib/platform/XWindowsClipboardUTF8Converter.cpp
@@ -52,14 +52,12 @@ XWindowsClipboardUTF8Converter::getDataSize() const
     return 8;
 }
 
-String
-XWindowsClipboardUTF8Converter::fromIClipboard(const String& data) const
+std::string XWindowsClipboardUTF8Converter::fromIClipboard(const std::string& data) const
 {
     return data;
 }
 
-String
-XWindowsClipboardUTF8Converter::toIClipboard(const String& data) const
+std::string XWindowsClipboardUTF8Converter::toIClipboard(const std::string& data) const
 {
     return data;
 }

--- a/src/lib/platform/XWindowsClipboardUTF8Converter.h
+++ b/src/lib/platform/XWindowsClipboardUTF8Converter.h
@@ -34,8 +34,8 @@ public:
                         getFormat() const;
     virtual Atom        getAtom() const;
     virtual int            getDataSize() const;
-    virtual String        fromIClipboard(const String&) const;
-    virtual String        toIClipboard(const String&) const;
+    virtual std::string fromIClipboard(const std::string&) const;
+    virtual std::string toIClipboard(const std::string&) const;
 
 private:
     Atom                m_atom;

--- a/src/lib/platform/XWindowsKeyState.cpp
+++ b/src/lib/platform/XWindowsKeyState.cpp
@@ -20,7 +20,6 @@
 
 #include "platform/XWindowsUtil.h"
 #include "base/Log.h"
-#include "base/String.h"
 #include "common/stdmap.h"
 
 #include <cstddef>

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -30,7 +30,6 @@
 #include "arch/Arch.h"
 #include "base/Log.h"
 #include "base/Stopwatch.h"
-#include "base/String.h"
 #include "base/IEventQueue.h"
 #include "base/TMethodEventJob.h"
 

--- a/src/lib/platform/XWindowsUtil.cpp
+++ b/src/lib/platform/XWindowsUtil.cpp
@@ -1294,7 +1294,7 @@ XWindowsUtil::KeySymMap    XWindowsUtil::s_keySymToUCS4;
 
 bool
 XWindowsUtil::getWindowProperty(Display* display, Window window,
-                Atom property, String* data, Atom* type,
+                Atom property, std::string* data, Atom* type,
                 SInt32* format, bool deleteProperty)
 {
     assert(display != NULL);
@@ -1608,8 +1608,7 @@ XWindowsUtil::getModifierBitForKeySym(KeySym keysym)
     }
 }
 
-String
-XWindowsUtil::atomToString(Display* display, Atom atom)
+std::string XWindowsUtil::atomToString(Display* display, Atom atom)
 {
     if (atom == 0) {
         return "None";
@@ -1622,20 +1621,19 @@ XWindowsUtil::atomToString(Display* display, Atom atom)
         return barrier::string::sprintf("<UNKNOWN> (%d)", (int)atom);
     }
     else {
-        String msg = barrier::string::sprintf("%s (%d)", name, (int)atom);
+        std::string msg = barrier::string::sprintf("%s (%d)", name, (int)atom);
         XFree(name);
         return msg;
     }
 }
 
-String
-XWindowsUtil::atomsToString(Display* display, const Atom* atom, UInt32 num)
+std::string XWindowsUtil::atomsToString(Display* display, const Atom* atom, UInt32 num)
 {
     char** names = new char*[num];
     bool error = false;
     XWindowsUtil::ErrorLock lock(display, &error);
     XGetAtomNames(display, const_cast<Atom*>(atom), (int)num, names);
-    String msg;
+    std::string msg;
     if (error) {
         for (UInt32 i = 0; i < num; ++i) {
             msg += barrier::string::sprintf("<UNKNOWN> (%d), ", (int)atom[i]);
@@ -1654,8 +1652,7 @@ XWindowsUtil::atomsToString(Display* display, const Atom* atom, UInt32 num)
     return msg;
 }
 
-void
-XWindowsUtil::convertAtomProperty(String& data)
+void XWindowsUtil::convertAtomProperty(std::string& data)
 {
     // as best i can tell, 64-bit systems don't pack Atoms into properties
     // as 32-bit numbers but rather as the 64-bit numbers they are.  that
@@ -1669,22 +1666,19 @@ XWindowsUtil::convertAtomProperty(String& data)
     }
 }
 
-void
-XWindowsUtil::appendAtomData(String& data, Atom atom)
+void XWindowsUtil::appendAtomData(std::string& data, Atom atom)
 {
     data.append(reinterpret_cast<char*>(&atom), sizeof(Atom));
 }
 
-void
-XWindowsUtil::replaceAtomData(String& data, UInt32 index, Atom atom)
+void XWindowsUtil::replaceAtomData(std::string& data, UInt32 index, Atom atom)
 {
     data.replace(index * sizeof(Atom), sizeof(Atom),
                                 reinterpret_cast<const char*>(&atom),
                                 sizeof(Atom));
 }
 
-void
-XWindowsUtil::appendTimeData(String& data, Time time)
+void XWindowsUtil::appendTimeData(std::string& data, Time time)
 {
     data.append(reinterpret_cast<char*>(&time), sizeof(Time));
 }

--- a/src/lib/platform/XWindowsUtil.h
+++ b/src/lib/platform/XWindowsUtil.h
@@ -18,7 +18,6 @@
 
 #pragma once
 
-#include "base/String.h"
 #include "base/EventTypes.h"
 #include "common/stdmap.h"
 #include "common/stdvector.h"
@@ -28,6 +27,8 @@
 #else
 #    include <X11/Xlib.h>
 #endif
+
+#include <string>
 
 //! X11 utility functions
 class XWindowsUtil {
@@ -42,10 +43,9 @@ public:
     if \c format is not NULL.  If \c deleteProperty is true then the
     property is deleted after being read.
     */
-    static bool            getWindowProperty(Display*,
-                            Window window, Atom property,
-                            String* data, Atom* type,
-                            SInt32* format, bool deleteProperty);
+    static bool getWindowProperty(Display*, Window window, Atom property,
+                                  std::string* data, Atom* type,
+                                  SInt32* format, bool deleteProperty);
 
     //! Set property
     /*!
@@ -81,44 +81,42 @@ public:
     /*!
     Converts \p atom to its string representation.
     */
-    static String        atomToString(Display*, Atom atom);
+    static std::string atomToString(Display*, Atom atom);
 
     //! Convert several Atoms to a string
     /*!
     Converts each atom in \p atoms to its string representation and
     concatenates the results.
     */
-    static String        atomsToString(Display* display,
-                            const Atom* atom, UInt32 num);
+    static std::string atomsToString(Display* display, const Atom* atom, UInt32 num);
 
     //! Prepare a property of atoms for use
     /*!
     64-bit systems may need to modify a property's data if it's a
     list of Atoms before using it.
     */
-    static void            convertAtomProperty(String& data);
+    static void convertAtomProperty(std::string& data);
 
     //! Append an Atom to property data
     /*!
     Converts \p atom to a 32-bit on-the-wire format and appends it to
     \p data.
     */
-    static void            appendAtomData(String& data, Atom atom);
+    static void appendAtomData(std::string& data, Atom atom);
 
     //! Replace an Atom in property data
     /*!
     Converts \p atom to a 32-bit on-the-wire format and replaces the atom
     at index \p index in \p data.
     */
-    static void            replaceAtomData(String& data,
-                            UInt32 index, Atom atom);
+    static void replaceAtomData(std::string& data, UInt32 index, Atom atom);
 
     //! Append an Time to property data
     /*!
     Converts \p time to a 32-bit on-the-wire format and appends it to
     \p data.
     */
-    static void            appendTimeData(String& data, Time time);
+    static void appendTimeData(std::string& data, Time time);
 
     //! X11 error handler
     /*!


### PR DESCRIPTION
Having a `String` typedef that points to `std::string` does not serve any benefit and is just confusing. This PR should not result in any functionality changes, I would expect the produced binary to be exactly the same.

This PR also fixes a build problem on master due to missing include which got introduced due to interaction of all of these PRs that have been submitted.