### PR TITLE
Make connection message a NOTE for consistency

### DIFF
--- a/src/lib/barrier/ClientApp.cpp
+++ b/src/lib/barrier/ClientApp.cpp
@@ -282,7 +282,7 @@ ClientApp::scheduleClientRestart(double retryTime)
 void
 ClientApp::handleClientConnected(const Event&, void*)
 {
-    LOG((CLOG_PRINT "connected to server"));
+    LOG((CLOG_NOTE "connected to server"));
     resetRestartTimeout();
     updateStatus();
 }


### PR DESCRIPTION
When disconnected a NOTE log entry is made in the log, when connected it just prints which seems inconsistent to me:

```
[2020-06-01T11:50:55] INFO: AES256-GCM-SHA384       TLSv1.2 Kx=RSA      Au=RSA  Enc=AESGCM(256) Mac=AEAD

	/home/jonathan/barrier/src/lib/net/SecureSocket.cpp,872
connected to server
[2020-06-01T11:52:43] INFO: entering screen
```
vs.
```
[2020-06-01T11:59:01] NOTE: disconnected from server
	/home/jonathan/barrier/src/lib/barrier/ClientApp.cpp,315
```
Since everything else logs with a timestamp I suggest changing this to NOTE as well for connection events being logged.