### PR TITLE
Revert "Make connection message a NOTE for consistency"

### DIFF
--- a/src/lib/barrier/ClientApp.cpp
+++ b/src/lib/barrier/ClientApp.cpp
@@ -282,7 +282,7 @@ ClientApp::scheduleClientRestart(double retryTime)
 void
 ClientApp::handleClientConnected(const Event&, void*)
 {
-    LOG((CLOG_NOTE "connected to server"));
+    LOG((CLOG_PRINT "connected to server"));
     resetRestartTimeout();
     updateStatus();
 }


### PR DESCRIPTION
Reverts debauchee/barrier#725

We rely on log messages to communicate between GUI and the worker process. See #664.