### PR TITLE
GUI status log comments

### DIFF
--- a/src/lib/barrier/ClientApp.cpp
+++ b/src/lib/barrier/ClientApp.cpp
@@ -282,6 +282,8 @@ ClientApp::scheduleClientRestart(double retryTime)
 void
 ClientApp::handleClientConnected(const Event&, void*)
 {
+    // using CLOG_PRINT here allows the GUI to see that the client is connected
+    // regardless of which log level is set
     LOG((CLOG_PRINT "connected to server"));
     resetRestartTimeout();
     updateStatus();

--- a/src/lib/barrier/ServerApp.cpp
+++ b/src/lib/barrier/ServerApp.cpp
@@ -555,6 +555,9 @@ ServerApp::startServer()
         m_server->setListener(listener);
         m_listener = listener;
         updateStatus();
+
+        // using CLOG_PRINT here allows the GUI to see that the server is started
+        // regardless of which log level is set
         LOG((CLOG_PRINT "started server (%s), waiting for clients", family));
         m_serverState = kStarted;
         return true;

--- a/src/lib/barrier/win32/DaemonApp.cpp
+++ b/src/lib/barrier/win32/DaemonApp.cpp
@@ -353,6 +353,9 @@ DaemonApp::handleIpcMessage(const Event& e, void*)
             LOG((CLOG_DEBUG "ipc hello, type=%s", type.c_str()));
 
             const char * serverstatus = m_watchdog->isProcessActive() ? "active" : "not active";
+
+            // using CLOG_PRINT here allows the GUI to see that the server status
+            // regardless of which log level is set
             LOG((CLOG_PRINT "server status: %s", serverstatus));
 
             m_ipcLogOutputter->notifyBuffer();


### PR DESCRIPTION
This adds comments explaining the reason for using CLOG_PRINT for certain status messages. It also reverts #725 which reintroduces issues #652 and #516.

@p12tic This also covers #738 if you want to close that, sorry I didn't include these comments in the first place.