### PR TITLE
Fix snap build failing to initialize submodules

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -43,6 +43,7 @@ parts:
 
   barrier:
     source: .
+    source-type: git
     plugin: cmake
     configflags:
       - "-DCMAKE_INSTALL_PREFIX=/usr"


### PR DESCRIPTION
Local builds fail to find gtest/gmock. But, I see the snap is still being built and published to `edge`; so I'm not sure this is really needed, and how your builds are working :-)