### PR TITLE
Issue 746: escape the comma in KeySequence

### DIFF
--- a/src/gui/src/KeySequence.cpp
+++ b/src/gui/src/KeySequence.cpp
@@ -211,6 +211,10 @@ QString KeySequence::keyToString(int key)
     // treat key pad like normal keys (FIXME: we should have another lookup table for keypad keys instead)
      key &= ~Qt::KeypadModifier;
 
+    //escape comma
+    if (key == ',')
+      return QString("\\u%1").arg(QChar(key).toLower().unicode(), 4, 16, QChar('0'));
+
     // a printable 7 bit character?
      if (key < 0x80 && key != Qt::Key_Space)
          return QChar(key & 0x7f).toLower();


### PR DESCRIPTION
This PR fixes [issue #746](https://github.com/debauchee/barrier/issues/746).  `QSettings` seems to use the comma as a list separator. Because of this, `KeySequence` with a comma in it is saved fine to the settings file but cannot read back. The solution is to escape the comma.