### PR TITLE
ui: Settings: Explain what "double tap" means

### DIFF
--- a/src/gui/src/ServerConfigDialogBase.ui
+++ b/src/gui/src/ServerConfigDialogBase.ui
@@ -334,53 +334,67 @@ Double click on a screen to edit its settings.</string>
            </layout>
           </item>
           <item>
-           <layout class="QHBoxLayout">
+           <layout class="QVBoxLayout">
             <item>
-             <widget class="QCheckBox" name="m_pCheckBoxSwitchDoubleTap">
-              <property name="enabled">
+             <layout class="QHBoxLayout">
+              <item>
+               <widget class="QCheckBox" name="m_pCheckBoxSwitchDoubleTap">
+                <property name="enabled">
+                 <bool>true</bool>
+                </property>
+                <property name="text">
+                 <string>Switch on double &amp;tap within</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer>
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QSpinBox" name="m_pSpinBoxSwitchDoubleTap">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="minimum">
+                 <number>10</number>
+                </property>
+                <property name="maximum">
+                 <number>10000</number>
+                </property>
+                <property name="singleStep">
+                 <number>10</number>
+                </property>
+                <property name="value">
+                 <number>250</number>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="m_pLabel_15">
+                <property name="text">
+                 <string>ms</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <widget class="QLabel" name="label_4">
+              <property name="text">
+               <string>Bump against the screen edge with the mouse pointer twice in quick succession.</string>
+              </property>
+              <property name="wordWrap">
                <bool>true</bool>
-              </property>
-              <property name="text">
-               <string>Switch on double &amp;tap within</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer>
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QSpinBox" name="m_pSpinBoxSwitchDoubleTap">
-              <property name="enabled">
-               <bool>false</bool>
-              </property>
-              <property name="minimum">
-               <number>10</number>
-              </property>
-              <property name="maximum">
-               <number>10000</number>
-              </property>
-              <property name="singleStep">
-               <number>10</number>
-              </property>
-              <property name="value">
-               <number>250</number>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLabel" name="m_pLabel_15">
-              <property name="text">
-               <string>ms</string>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
It took me half an hour, and a look at the code, to figure out what "double tap" means. I thought it meant "click", so I tried clicking around on the screen edge but it wouldn't do anything. I think it's a bad translation; probably a better English word for the motion would be "bump" or "edge bump".

In any case, a detailed explanation is better. So this PR adds a label

> Bump against the screen edge with the mouse pointer twice in quick succession.

Screenshot of what it looks like with my change:

![image](https://user-images.githubusercontent.com/399535/84600790-3fee9700-ae7c-11ea-95a6-1f4756db5702.png)

---

I think this way of explaining it is better than a tool-tip or Qt's `What's This` functionality because most people don't know that those exist. An alternative would be to rename the setting from "tap" to "bump" (thus also changing the mnemonic key) and write on the settings screen something like "you can right-click each setting for a description of what it does" so that `What's this` is more discoverable, but I'd only do that after explaining the other settings as well, and that is more involved than this quick fix, which I think should be landed first.