### PR TITLE
Shorten snap version on tagged revisions

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: barrier
 base: core18
 version: master
-version-script: git describe --tags --long | sed "s/^v//"
+version-script: git describe --tags | sed "s/^v//"
 adopt-info: appstream-flathub
 grade: stable # must be 'stable' to release into candidate/stable channels
 confinement: strict # use 'strict' once you have the right plugs and slots


### PR DESCRIPTION
Hi! Congrats on the new release. Are there plans to release the snap for v2.3.3? Afaict, CI is pushing builds to `edge`, so it's just a matter of promoting the latest build to `stable` (maybe `candidate` first?).

Confusingly, the latest build on `edge` currently has version `2.3.2-122-g3395cca9` instead of just `v2.3.3`; not sure why it didn't catch the new tag. Maybe it was tagged *after* the snap was built? In any case, even if it had worked, the resulting snap version would've been `2.3.3-0-g3395cca9`. This branch should improve that and make the next tagged release shorter.

If you merge this, the resulting snap build on `edge` should have version `2.3.3-1-g12345678`. Maybe then it can just be promoted to `candidate` and/or `stable`?