### PR TITLE
Use better openssl message digest algorithm

### DIFF
--- a/res/openssl/barrier.conf
+++ b/res/openssl/barrier.conf
@@ -15,7 +15,7 @@ new_certs_dir = $dir/certs
 certificate = $dir/cacert.pem
 private_key = $dir/private/cakey.pem
 default_days = 365
-default_md = md5
+default_md = default
 preserve = no
 email_in_dn = no
 nameopt = default_ca
@@ -33,7 +33,7 @@ emailAddress = optional
 [req]
 default_bits = 2048 # Size of keys
 default_keyfile = key.pem # name of generated keys
-default_md = md5 # message digest algorithm
+default_md = default # message digest algorithm
 string_mask = nombstr # permitted characters
 distinguished_name = req_distinguished_name
 req_extensions = v3_req

--- a/src/gui/src/SslCertificate.cpp
+++ b/src/gui/src/SslCertificate.cpp
@@ -153,7 +153,7 @@ void SslCertificate::generateFingerprint(const QString& certificateFilename)
     QStringList arguments;
     arguments.append("x509");
     arguments.append("-fingerprint");
-    arguments.append("-sha1");
+    arguments.append("-sha256");
     arguments.append("-noout");
     arguments.append("-in");
     arguments.append(certificateFilename);

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -685,7 +685,7 @@ SecureSocket::verifyCertFingerprint()
     EVP_MD* tempDigest;
     unsigned char tempFingerprint[EVP_MAX_MD_SIZE];
     unsigned int tempFingerprintLen;
-    tempDigest = (EVP_MD*)EVP_sha1();
+    tempDigest = (EVP_MD*)EVP_sha256();
     int digestResult = X509_digest(cert, tempDigest, tempFingerprint, &tempFingerprintLen);
 
     if (digestResult <= 0) {


### PR DESCRIPTION
Fixes #203.

Using a default algorithm instead of hardcoding something like sha256 allows us to seamlessly integrate any future changes of recommended algorithms without any work needed by us.