### PR TITLE
Add key mappings for `Kana`, `Eisu_toggle` and `Muhenkan`

### DIFF
--- a/src/lib/platform/MSWindowsKeyState.cpp
+++ b/src/lib/platform/MSWindowsKeyState.cpp
@@ -69,7 +69,7 @@ const KeyID				MSWindowsKeyState::s_virtualKey[] =
 	/* 0x01a */ { kKeyNone },		// undefined
 	/* 0x01b */ { kKeyEscape },		// VK_ESCAPE
 	/* 0x01c */ { kKeyHenkan },		// VK_CONVERT		
-	/* 0x01d */ { kKeyNone },		// VK_NONCONVERT	
+	/* 0x01d */ { kKeyMuhenkan },	// VK_NONCONVERT	
 	/* 0x01e */ { kKeyNone },		// VK_ACCEPT		
 	/* 0x01f */ { kKeyNone },		// VK_MODECHANGE	
 	/* 0x020 */ { kKeyNone },		// VK_SPACE

--- a/src/lib/platform/OSXKeyState.cpp
+++ b/src/lib/platform/OSXKeyState.cpp
@@ -123,6 +123,10 @@ static const KeyEntry    s_controlKeys[] = {
     { kKeyLaunchpad, s_launchpadVK },
     { kKeyBrightnessUp,  s_brightnessUp },
     { kKeyBrightnessDown, s_brightnessDown }
+
+    // JIS keyboards only
+    { kKeyEisuToggle, kVK_JIS_Eisu },
+    { kKeyKana, kVK_JIS_Kana }
 };
 
 


### PR DESCRIPTION
This request is a continuation of #818 to share Japanese keyboards with Windows and mac computers while keeping Japanese input functionalities.

Windows and mac provide similar but different keys to enable and disable Japanese input methods:
- Disable Japanese input method: `Muhenkan` (Windows) <-> `Eisu_toggle` (mac)
- Enable Japanese input method: `Henkan` (Windows) <-> `Kana` (mac)

Making a mapping of these keys is important to share the Japanese keyboards but unfortunately some of these keys are not recognized by barrier.

The request #818 added key entries for `Eisu_toggle` and `Muhenkan` to the barrier internal key representation.
This request adds a mapping between the internal representation with OS-specific key representation.

I confirmed that this request makes barrier aware of `Kana`, `Eisu_toggle`, `Henkan` and `Muhenkan` keys in the `section: options` section in the setting file.

After merging this request, we can smoothly share Japanese keyboards between Windows and mac computers by adding the following settings (in the case of Windows server):

```
section: options
        ...
	keystroke(Henkan) = ;keystroke(Kana,client)
	keystroke(Muhenkan) = ;keystroke(EisuToggle,client)
end
```

Note that GUI hotkey editor does not recognize these Japanese IME keys and therefore we have to edit the configuration file directly. Fixing it is out of scope of this request.