### PR TITLE
Rename TEST_ENV macro to BARRIER_TEST_ENV

### DIFF
--- a/src/lib/barrier/KeyMap.h
+++ b/src/lib/barrier/KeyMap.h
@@ -24,7 +24,7 @@
 #include "common/stdset.h"
 #include "common/stdvector.h"
 
-#ifdef TEST_ENV
+#ifdef BARRIER_TEST_ENV
 #include <gtest/gtest_prod.h>
 #endif
 
@@ -329,7 +329,7 @@ public:
     //@}
 
 private:
-#ifdef TEST_ENV
+#ifdef BARRIER_TEST_ENV
     FRIEND_TEST(KeyMapTests,
                 findBestKey_requiredDown_matchExactFirstItem);
     FRIEND_TEST(KeyMapTests,

--- a/src/lib/barrier/Screen.h
+++ b/src/lib/barrier/Screen.h
@@ -42,7 +42,7 @@ public:
     Screen(IPlatformScreen* platformScreen, IEventQueue* events);
     virtual ~Screen();
 
-#ifdef TEST_ENV
+#ifdef BARRIER_TEST_ENV
     Screen() : m_mock(true) { }
 #endif
 

--- a/src/lib/client/ServerProxy.h
+++ b/src/lib/client/ServerProxy.h
@@ -59,7 +59,7 @@ public:
     // sending dragging information to server
     void                sendDragInfo(UInt32 fileCount, const char* info, size_t size);
     
-#ifdef TEST_ENV
+#ifdef BARRIER_TEST_ENV
     void                handleDataForTest() { handleData(Event(), NULL); }
 #endif
 

--- a/src/lib/ipc/IpcServer.h
+++ b/src/lib/ipc/IpcServer.h
@@ -82,7 +82,7 @@ private:
     ClientList            m_clients;
     mutable std::mutex m_clientsMutex;
 
-#ifdef TEST_ENV
+#ifdef BARRIER_TEST_ENV
 public:
     IpcServer() :
         m_mock(true),

--- a/src/lib/platform/XWindowsKeyState.h
+++ b/src/lib/platform/XWindowsKeyState.h
@@ -136,7 +136,7 @@ private:
         bool            m_lock;
     };
 
-#ifdef TEST_ENV
+#ifdef BARRIER_TEST_ENV
 public: // yuck
 #endif
     typedef std::vector<KeyModifierMask> KeyModifierMaskList;
@@ -169,7 +169,7 @@ private:
     // autorepeat state
     XKeyboardState        m_keyboardState;
 
-#ifdef TEST_ENV
+#ifdef BARRIER_TEST_ENV
 public:
     SInt32                  group() const { return m_group; }
     void                    group(const SInt32& group) { m_group = group; }

--- a/src/lib/server/Config.h
+++ b/src/lib/server/Config.h
@@ -174,7 +174,7 @@ public:
     Config(IEventQueue* events);
     virtual ~Config();
 
-#ifdef TEST_ENV
+#ifdef BARRIER_TEST_ENV
     Config() : m_inputFilter(NULL) { }
 #endif
 

--- a/src/lib/server/InputFilter.h
+++ b/src/lib/server/InputFilter.h
@@ -333,7 +333,7 @@ public:
     InputFilter(const InputFilter&);
     virtual ~InputFilter();
 
-#ifdef TEST_ENV
+#ifdef BARRIER_TEST_ENV
     InputFilter() : m_primaryClient(NULL) { }
 #endif
 

--- a/src/lib/server/PrimaryClient.h
+++ b/src/lib/server/PrimaryClient.h
@@ -37,7 +37,7 @@ public:
     PrimaryClient(const std::string& name, barrier::Screen* screen);
     ~PrimaryClient();
 
-#ifdef TEST_ENV
+#ifdef BARRIER_TEST_ENV
     PrimaryClient() : BaseClientProxy("") { }
 #endif
 

--- a/src/lib/server/Server.h
+++ b/src/lib/server/Server.h
@@ -110,7 +110,7 @@ public:
         barrier::Screen* screen, IEventQueue* events, ServerArgs const& args);
     ~Server();
 
-#ifdef TEST_ENV
+#ifdef BARRIER_TEST_ENV
     Server() : m_mock(true), m_config(NULL) { }
     void setActive(BaseClientProxy* active) {    m_active = active; }
 #endif

--- a/src/test/integtests/ipc/IpcTests.cpp
+++ b/src/test/integtests/ipc/IpcTests.cpp
@@ -19,7 +19,7 @@
 // TODO: fix, tests failing intermittently on mac.
 #ifndef WINAPI_CARBON
 
-#define TEST_ENV
+#define BARRIER_TEST_ENV
 
 #include "test/global/TestEventQueue.h"
 #include "ipc/IpcServer.h"

--- a/src/test/integtests/net/NetworkTests.cpp
+++ b/src/test/integtests/net/NetworkTests.cpp
@@ -18,7 +18,7 @@
 // TODO: fix, tests failing intermittently on mac.
 #ifndef WINAPI_CARBON
 
-#define TEST_ENV
+#define BARRIER_TEST_ENV
 
 #include "test/mock/server/MockConfig.h"
 #include "test/mock/server/MockPrimaryClient.h"

--- a/src/test/integtests/platform/MSWindowsKeyStateTests.cpp
+++ b/src/test/integtests/platform/MSWindowsKeyStateTests.cpp
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define TEST_ENV
+#define BARRIER_TEST_ENV
 
 #include "test/mock/barrier/MockEventQueue.h"
 #include "test/mock/barrier/MockKeyMap.h"

--- a/src/test/integtests/platform/XWindowsKeyStateTests.cpp
+++ b/src/test/integtests/platform/XWindowsKeyStateTests.cpp
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define TEST_ENV
+#define BARRIER_TEST_ENV
 
 #include "test/mock/barrier/MockKeyMap.h"
 #include "test/mock/barrier/MockEventQueue.h"

--- a/src/test/mock/barrier/MockApp.h
+++ b/src/test/mock/barrier/MockApp.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#define TEST_ENV
+#define BARRIER_TEST_ENV
 
 #include "barrier/App.h"
 

--- a/src/test/mock/barrier/MockArgParser.h
+++ b/src/test/mock/barrier/MockArgParser.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#define TEST_ENV
+#define BARRIER_TEST_ENV
 
 #include "barrier/ArgParser.h"
 

--- a/src/test/mock/barrier/MockScreen.h
+++ b/src/test/mock/barrier/MockScreen.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#define TEST_ENV
+#define BARRIER_TEST_ENV
 
 #include "barrier/Screen.h"
 

--- a/src/test/mock/server/MockConfig.h
+++ b/src/test/mock/server/MockConfig.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#define TEST_ENV
+#define BARRIER_TEST_ENV
 
 #include "server/Config.h"
 

--- a/src/test/mock/server/MockInputFilter.h
+++ b/src/test/mock/server/MockInputFilter.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#define TEST_ENV
+#define BARRIER_TEST_ENV
 
 #include "server/InputFilter.h"
 

--- a/src/test/mock/server/MockPrimaryClient.h
+++ b/src/test/mock/server/MockPrimaryClient.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#define TEST_ENV
+#define BARRIER_TEST_ENV
 
 #include "server/PrimaryClient.h"
 #include "base/String.h"

--- a/src/test/mock/server/MockServer.h
+++ b/src/test/mock/server/MockServer.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#define TEST_ENV
+#define BARRIER_TEST_ENV
 
 #include "server/Server.h"
 

--- a/src/test/unittests/barrier/KeyMapTests.cpp
+++ b/src/test/unittests/barrier/KeyMapTests.cpp
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define TEST_ENV
+#define BARRIER_TEST_ENV
 
 #include "barrier/KeyMap.h"
 

--- a/src/test/unittests/ipc/IpcLogOutputterTests.cpp
+++ b/src/test/unittests/ipc/IpcLogOutputterTests.cpp
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define TEST_ENV
+#define BARRIER_TEST_ENV
 
 #include "test/mock/ipc/MockIpcServer.h"
 


### PR DESCRIPTION
As requested in #846.