### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Please fill in this template as much as you can, to help us, help you.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+Please do not link to image hosting sites, as these can be ephemeral. Instead, attach them to the issue. 
+
+**Desktop (please complete the following information):**
+
+ - OS: [e.g. Windows]
+- Barrier version [e.g 2.3.3]
+
+**Additional context**
+
+Add any other context about the problem here.


### PR DESCRIPTION
Our current templates do not use the latest GitHub templates, so this updates them. I have adjusted and removed some wording to make the template simpler, as I have found some users neglect to fill in the template, or partially fill it in. I hope this helps with the bug reporting process.