### PR TITLE
[style](editorconfig): Commit initial EditorConfig config for code style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
Soon to be added: wiki page about expected code style for Barrier.
Also, docs when that's ready.

@p12tic We discussed this in #716 - does this PR look alright to you?

I will be making a wiki page _soon_™️ about guidelines for devs who don't have EditorConfig support as well - you use QtCreator IIRC, so that's with you in mind for example :+1:

Signed-off-by: Dom Rodriguez <shymega@shymega.org.uk>