### PR TITLE
Fixed processing of non-ASCII symbols missing in CP_THREAD_ACP but present in current KB layout

### DIFF
--- a/src/lib/platform/MSWindowsKeyState.cpp
+++ b/src/lib/platform/MSWindowsKeyState.cpp
@@ -688,34 +688,17 @@ MSWindowsKeyState::mapKeyFromEvent(WPARAM charAndVirtKey,
 		KeyModifierControl | KeyModifierAlt;
 
 	// extract character, virtual key, and if we didn't use AltGr
-	char c       = (char)((charAndVirtKey & 0xff00u) >> 8);
-	UINT vkCode  = (charAndVirtKey & 0xffu);
-	bool noAltGr = ((charAndVirtKey & 0xff0000u) != 0);
+	WCHAR wc     = (WCHAR)(charAndVirtKey & 0xffffu);
+	UINT vkCode  = ((charAndVirtKey >> 16) & 0xffu);
+	bool noAltGr = ((charAndVirtKey & 0xff000000u) != 0);
 
 	// handle some keys via table lookup
 	KeyID id     = getKeyID(vkCode, (KeyButton)((info >> 16) & 0x1ffu));
 
 	// check if not in table;  map character to key id
-	if (id == kKeyNone && c != 0) {
-		if ((c & 0x80u) == 0) {
-			// ASCII
-			id = static_cast<KeyID>(c) & 0xffu;
-		}
-		else {
-			// character is not really ASCII.  instead it's some
-			// character in the current ANSI code page.  try to
-			// convert that to a Unicode character.  if we fail
-			// then use the single byte character as is.
-			char src = c;
-			wchar_t unicode;
-			if (MultiByteToWideChar(CP_THREAD_ACP, MB_PRECOMPOSED,
-										&src, 1, &unicode, 1) > 0) {
-				id = static_cast<KeyID>(unicode);
-			}
-			else {
-				id = static_cast<KeyID>(c) & 0xffu;
-			}
-		}
+	if (id == kKeyNone && wc != 0) {
+		// UTF16
+		id = static_cast<KeyID>(wc) & 0xffffu;
 	}
 
 	// set modifier mask


### PR DESCRIPTION
Hi there, my name is Eugene Golushkov, I had problems with Barrier and being the programmer decided to contribute fix.

I'm Ukrainian, this language uses https://en.wikipedia.org/wiki/Cyrillic_script, Unicode range 0x400 - 0x4FF, Windows cp1251

 My setup consists of 
1. Windows 10 PC, Barrier Server, ENG + UKR keyboard layouts.
2. macOS Catalina, Barrier Client, ENG + UKR keyboard layouts.
3. Windows 10 Tablet, Barrier Client, ENG + UKR keyboard layouts.

Problem description:
When current keyboard layout is ENG everything works like a charm. But if I move mouse cursor to clients (2),(3) having UKR keyboard layout selected on win server (1), then win client (3) ignores key strokes, and macos client (2) enters Latin characters with diacritics instead.

Expected result:
1. Produce Cyrillic characters on clients if possible
2. Or fallback to English characters
3. But never produce Latin characters with diacritics that are absent in both English and Ukrainian

Solution:
I enabled Debug1 log level on macos client (2) and pressed 'A' key that is near CapsLock, in ENG KB layout. Got expected log:
DEBUG1: recv key down id=0x00000061, mask=0x2000, button=0x001e
then I switched to UKR layout on (1) and pressed the same physical key, that was expected to produce U+0444 CYRILLIC SMALL LETTER EF, but got such log:
DEBUG1: recv key down id=0x000000f4, mask=0x2000, button=0x001e
where 0xF4 is code for CYRILLIC SMALL LETTER EF in Windows ANSI codepage cp1251.

It became obvious that Barrier was not able to restore unicode char from ANSI, probably because CP_THREAD_ACP that it tried to use for this purpose is not in any way connected to current HKL. This was even as (1) had "Current language for non-Unicode programs" = Ukrainian. The fix was easy - keyboard driver already produces UTF16 chars that could be obtained by ToUnicode function. ToAscii is actually just simple wrapper around ToUnicode that further converts UTF16 chars to ANSI, and by avoiding this unnecessary step we will fix the problem. Barrier inter-machine protocol is Unicode based (KeyID).

Results:
1. I built Barrier with fix, without GUI and installer, and substituted binaries into existing Barrier setup. Everything still works on clients (2), (3) with ENG keyboard layout selected on win server (1)
2. windows client (3) that previously ignored keystrokes - now enters Cyrillic characters with UKR keyboard layout selected on win server (1), and language indicator on (3) synchronizes with language indicator on (1) after the first pressed key.
3. macos client that previously entered Latin characters with diacritics - now see in log proper key down id 0x00000444, but entered proper English chars - there are still space for improvement, quite possibly I will look there later.