### PR TITLE
Fixed gui writing invalid config for hotkeys with multiple actions

### DIFF
--- a/src/gui/src/Hotkey.cpp
+++ b/src/gui/src/Hotkey.cpp
@@ -68,8 +68,20 @@ void Hotkey::saveSettings(QSettings& settings) const
 
 QTextStream& operator<<(QTextStream& outStream, const Hotkey& hotkey)
 {
-    for (int i = 0; i < hotkey.actions().size(); i++)
-        outStream << "\t" << hotkey.text() << " = " << hotkey.actions()[i] << endl;
+    // Don't write config if there are no actions
+    if (hotkey.actions().size() == 0) {
+        return outStream;
+    }
+
+    outStream << "\t" << hotkey.text() << " = ";
+    for (int i = 0; i < hotkey.actions().size(); i++) {
+        outStream << hotkey.actions()[i];
+        if (i != hotkey.actions().size() - 1) {
+            outStream << ", ";
+        }
+    }
+
+    outStream << "\n";
 
     return outStream;
 }

--- a/src/gui/test/HotkeyTests.cpp
+++ b/src/gui/test/HotkeyTests.cpp
@@ -316,5 +316,5 @@ TEST(HotkeyToTexStreamTests, KeysMultipleAction)
         }
     };
     ASSERT_EQ(hotkeyToStringViaTextStream(createHotkey(hotkey)),
-              "\tkeystroke(a+b) = keyDown(z,*)\n\tkeystroke(a+b) = switchToScreen(test_screen)\n");
+              "\tkeystroke(a+b) = keyDown(z,*), switchToScreen(test_screen)\n");
 }


### PR DESCRIPTION
Hotkeys with multiple actions need to be separated by commas, not new lines, otherwise only one of the actions will be performed when the hotkey is pressed.

Works:
```
keystroke(Control+Alt+F11) = switchToScreen(Laptop), lockCursorToScreen(on)
```

Doesn't work:
```
keystroke(Control+Alt+F11) = switchToScreen(Laptop)
keystroke(Control+Alt+F11) = lockCursorToScreen(on)
```