### PR TITLE
Added special hotkey config rules for comma and semicolon

### DIFF
--- a/src/gui/src/KeySequence.cpp
+++ b/src/gui/src/KeySequence.cpp
@@ -55,6 +55,8 @@ static const struct
     { Qt::Key_Help,         "Help" },
     { Qt::Key_Enter,        "KP_Enter" },
     { Qt::Key_Clear,        "Clear" },
+    { Qt::Key_Comma,        "Comma" },
+    { Qt::Key_Semicolon,    "Semicolon" },
 
     { Qt::Key_Back,         "WWWBack" },
     { Qt::Key_Forward,      "WWWForward" },
@@ -211,22 +213,21 @@ QString KeySequence::keyToString(int key)
     // treat key pad like normal keys (FIXME: we should have another lookup table for keypad keys instead)
      key &= ~Qt::KeypadModifier;
 
+    // a special key?
+    int i = 0;
+    while (keyname[i].name) {
+        if (key == keyname[i].key)
+            return QString::fromUtf8(keyname[i].name);
+        i++;
+    }
+
     // a printable 7 bit character?
-     if (key < 0x80 && key != Qt::Key_Space)
+     if (key < 0x80)
          return QChar(key & 0x7f).toLower();
 
     // a function key?
     if (key >= Qt::Key_F1 && key <= Qt::Key_F35)
         return QString::fromUtf8("F%1").arg(key - Qt::Key_F1 + 1);
-
-    // a special key?
-    int i=0;
-    while (keyname[i].name)
-    {
-        if (key == keyname[i].key)
-            return QString::fromUtf8(keyname[i].name);
-        i++;
-    }
 
     // representable in ucs2?
     if (key < 0x10000)

--- a/src/gui/test/HotkeyTests.cpp
+++ b/src/gui/test/HotkeyTests.cpp
@@ -300,7 +300,7 @@ TEST(HotkeyToTexStreamTests, KeysCommaSingleAction)
         }
     };
     ASSERT_EQ(hotkeyToStringViaTextStream(createHotkey(hotkey)),
-              "\tkeystroke(a+,+b) = keyDown(z,*)\n");
+              "\tkeystroke(a+Comma+b) = keyDown(z,*)\n");
 }
 
 TEST(HotkeyToTexStreamTests, KeysMultipleAction)

--- a/src/gui/test/KeySequenceTests.cpp
+++ b/src/gui/test/KeySequenceTests.cpp
@@ -133,9 +133,9 @@ TEST(KeySequenceTests, ToString)
     ASSERT_EQ(keySequenceToString({{Qt::Key_A, 0}, {Qt::Key_B, 0}}),
               "a+b");
     ASSERT_EQ(keySequenceToString({{Qt::Key_A, 0}, {Qt::Key_Comma, 0}, {Qt::Key_B, 0}}),
-              "a+,+b");
+              "a+Comma+b");
     ASSERT_EQ(keySequenceToString({{Qt::Key_A, 0}, {Qt::Key_Semicolon, 0}, {Qt::Key_B, 0}}),
-              "a+;+b");
+              "a+Semicolon+b");
     ASSERT_EQ(keySequenceToString({{Qt::Key_A, 0}, {Qt::Key_Shift, Qt::ShiftModifier},
                                    {Qt::Key_0, Qt::ShiftModifier}}),
               "a+Shift+0");


### PR DESCRIPTION
The config parser interprets commas and semicolons as syntax. This PR adds commas and semicolons to the special keys list so that ',' becomes "Comma" and ';' becomes "Semicolon". This allows hotkeys to contain commas and semicolons.

Fixes issue #778 

**Edited for additional comments on changes on [line 215](https://github.com/debauchee/barrier/pull/916/files#diff-b3f12433f5e2de847168c791983976886341f69b1b1ffc763ee378b60fc4363aL215):**
I had to reorder how `KeySequence::keyToString()` decides how to serialize a key so that it will prioritize checking the special keys list before checking for 7-bit printable characters. This made excluding a space character (`key != Qt::Key_Space`) from the 7-bit printable character check (`if (key < 0x80 && key != Qt::Key_Space)`) redundant because `Qt::Key_Space` is already in the special keys list and will already be substituted for `"Space"`.