### PR TITLE
lib/ipc: Introduce writef_void(void*, ...)

### DIFF
--- a/src/lib/barrier/ProtocolUtil.cpp
+++ b/src/lib/barrier/ProtocolUtil.cpp
@@ -80,7 +80,7 @@ ProtocolUtil::vwritef(barrier::IStream* stream,
 
     // fill buffer
     UInt8* buffer = new UInt8[size];
-    writef(buffer, fmt, args);
+    writef_void(buffer, fmt, args);
 
     try {
         // write buffer
@@ -339,7 +339,7 @@ ProtocolUtil::getLength(const char* fmt, va_list args)
 }
 
 void
-ProtocolUtil::writef(void* buffer, const char* fmt, va_list args)
+ProtocolUtil::writef_void(void* buffer, const char* fmt, va_list args)
 {
     UInt8* dst = static_cast<UInt8*>(buffer);
 

--- a/src/lib/barrier/ProtocolUtil.h
+++ b/src/lib/barrier/ProtocolUtil.h
@@ -79,7 +79,7 @@ private:
                             const char* fmt, va_list);
 
     static UInt32        getLength(const char* fmt, va_list);
-    static void            writef(void*, const char* fmt, va_list);
+    static void            writef_void(void*, const char* fmt, va_list);
     static UInt32        eatLength(const char** fmt);
     static void            read(barrier::IStream*, void*, UInt32);
 };


### PR DESCRIPTION
to fix ambiguity with writef(barrier::IStream*, ...).

This fixes the build failure observed on mips*el and riscv64 architectures.

https://bugs.debian.org/970611