### PR TITLE
Enhancement: Read theme's panel icons.

### DIFF
--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -80,6 +80,14 @@ static const char* barrierIconFiles[] =
 #endif
 };
 
+static const char* barrierIconNames[] =
+{
+    "barrier-disconnected",
+    "barrier-disconnected",
+    "barrier-connected",
+    "barrier-transfering"
+};
+
 static const char* barrierLargeIcon = ":/res/icons/256x256/barrier.ico";
 
 MainWindow::MainWindow(QSettings& settings, AppConfig& appConfig) :
@@ -296,7 +304,7 @@ void MainWindow::saveSettings()
 void MainWindow::setIcon(qBarrierState state)
 {
     if (m_pTrayIcon) {
-        QIcon icon = QIcon(barrierIconFiles[state]);
+        QIcon icon = QIcon::fromTheme(barrierIconNames[state], QIcon(barrierIconFiles[state]));
 #if defined(Q_OS_MAC)
         icon.setIsMask(true);
 #endif


### PR DESCRIPTION
I think this should fix issue  #471 (Because I'm using i3wm now, and it worked for me).

In order to use custom icons, the theme should have these icons: _barrier-disconnected_, _barrier-connected_ and _barrier-transfering_. And barrier will use the default tray icons if there is not these icons in the using icon theme.