### PR TITLE
Improvements to custom profile dir option

### DIFF
--- a/src/lib/barrier/App.h
+++ b/src/lib/barrier/App.h
@@ -166,8 +166,8 @@ private:
     "  -l  --log <file>         write log messages to file.\n" \
     "      --no-tray            disable the system tray icon.\n" \
     "      --enable-drag-drop   enable file drag & drop.\n" \
-    "      --enable-crypto      enable the crypto (ssl) plugin.\n"
-
+    "      --enable-crypto      enable the crypto (ssl) plugin.\n" \
+    "      --profile-dir <path> use named profile directory instead.\n"
 #define HELP_COMMON_INFO_2 \
     "  -h, --help               display this help and exit.\n" \
     "      --version            display version information and exit.\n"

--- a/src/lib/barrier/ServerApp.cpp
+++ b/src/lib/barrier/ServerApp.cpp
@@ -128,6 +128,12 @@ ServerApp::help()
 #  define WINAPI_INFO ""
 #endif
 
+    // refer to custom profile directory even if not saved yet
+    String profilePath = argsBase().m_profileDirectory;
+    if (profilePath.empty()) {
+        profilePath = DataDirectories::profile();
+    }
+
     std::ostringstream buffer;
     buffer << "Start the barrier server component." << std::endl
            << std::endl
@@ -150,7 +156,7 @@ ServerApp::help()
            << std::endl
            << "If no configuration file pathname is provided then the first of the" << std::endl
            << "following to load successfully sets the configuration:" << std::endl
-           << "  " << PathUtilities::concat(DataDirectories::profile(), USR_CONFIG_NAME) << std::endl
+           << "  " << PathUtilities::concat(profilePath, USR_CONFIG_NAME) << std::endl
            << "  " << PathUtilities::concat(DataDirectories::systemconfig(), SYS_CONFIG_NAME) << std::endl;
 
     LOG((CLOG_PRINT "%s", buffer.str().c_str()));

--- a/src/lib/platform/MSWindowsHook.cpp
+++ b/src/lib/platform/MSWindowsHook.cpp
@@ -56,14 +56,13 @@ static BYTE                g_deadKeyState[256] = { 0 };
 static BYTE                g_keyState[256] = { 0 };
 static bool                g_fakeServerInput = false;
 static std::vector<DWORD> g_immuneKeys;
-
-static const std::string ImmuneKeysPath = DataDirectories::profile() + "\\ImmuneKeys.txt";
+static std::string g_immuneKeysPath;
 
 static std::vector<DWORD> immune_keys_list()
 {
     std::vector<DWORD> keys;
     std::string badLine;
-    if (!ImmuneKeysReader::get_list(ImmuneKeysPath.c_str(), keys, badLine))
+    if (!ImmuneKeysReader::get_list(g_immuneKeysPath.c_str(), keys, badLine))
         LOG((CLOG_ERR "Reading immune keys stopped at: %s", badLine.c_str()));
     return keys;
 }
@@ -575,8 +574,9 @@ MSWindowsHook::install()
     g_fakeServerInput = false;
 
     // setup immune keys
+    g_immuneKeysPath = DataDirectories::profile() + "\\ImmuneKeys.txt";
     g_immuneKeys = immune_keys_list();
-    LOG((CLOG_DEBUG "Found %u immune keys in %s", g_immuneKeys.size(), ImmuneKeysPath.c_str()));
+    LOG((CLOG_DEBUG "Found %u immune keys in %s", g_immuneKeys.size(), g_immuneKeysPath.c_str()));
 
 #if NO_GRAB_KEYBOARD
     // we only need the mouse hook


### PR DESCRIPTION
Included --profile-dir in help text, output from `barriers --help` and `barrierc --help`.
If `--profile-dir <path>` is included first, then the given path will be used in the help text describing default path to configuration file.

Also fixed an issue where the full path to ImmuneKeys.txt were stored in a global variable before considering `--profile-dir` argument, so it would always be loaded from default `%LocalAppData%\Barrier` directory.

Related to https://github.com/debauchee/barrier/issues/961#issuecomment-739028515