### PR TITLE
Cleanup obsolete options in help text

### DIFF
--- a/src/lib/barrier/App.h
+++ b/src/lib/barrier/App.h
@@ -191,12 +191,11 @@ private:
 
 // windows args
 #  define HELP_SYS_ARGS \
-    " [--service <action>] [--relaunch] [--exit-pause]"
+    " [--exit-pause]"
 #  define HELP_SYS_INFO \
     "      --service <action>   manage the windows service, valid options are:\n" \
     "                             install/uninstall/start/stop\n" \
-    "      --relaunch           persistently relaunches process in current user \n" \
-    "                             session (useful for vista and upward).\n" \
+    "                             (obsolete, use barrierd instead)\n" \
     "      --exit-pause         wait for key press on exit, can be useful for\n" \
     "                             reading error messages that occur on exit.\n"
 #endif


### PR DESCRIPTION
Remove from help text unsupported --relaunch option and note --service option is obsolete on windows