### PR TITLE
Remove trailing whitespaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,7 +320,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 elseif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     find_program(BREW_PROGRAM "brew")
     find_program(PORT_PROGRAM "port")
-    
+
     if (IS_DIRECTORY /opt/local AND PORT_PROGRAM)
         # macports
         set (OPENSSL_ROOT /opt/local)
@@ -421,7 +421,7 @@ endif()
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     configure_files (${CMAKE_CURRENT_SOURCE_DIR}/dist/rpm ${CMAKE_BINARY_DIR}/rpm)
     install(FILES res/barrier.svg DESTINATION share/icons/hicolor/scalable/apps)
-    if("${VERSION_MAJOR}" STREQUAL "2") 
+    if("${VERSION_MAJOR}" STREQUAL "2")
         install(FILES res/barrier2.desktop DESTINATION share/applications)
     else()
         install(FILES res/barrier.desktop DESTINATION share/applications)

--- a/ext/openssl/windows/x64/include/openssl/opensslconf.h
+++ b/ext/openssl/windows/x64/include/openssl/opensslconf.h
@@ -233,7 +233,7 @@ extern "C" {
    even newer MIPS CPU's, but at the moment one size fits all for
    optimization options.  Older Sparc's work better with only UNROLL, but
    there's no way to tell at compile time what it is you're running on */
- 
+
 #if defined( __sun ) || defined ( sun )		/* Newer Sparc's */
 #  define DES_PTR
 #  define DES_RISC1

--- a/ext/openssl/windows/x86/include/openssl/opensslconf.h
+++ b/ext/openssl/windows/x86/include/openssl/opensslconf.h
@@ -233,7 +233,7 @@ extern "C" {
    even newer MIPS CPU's, but at the moment one size fits all for
    optimization options.  Older Sparc's work better with only UNROLL, but
    there's no way to tell at compile time what it is you're running on */
- 
+
 #if defined( __sun ) || defined ( sun )		/* Newer Sparc's */
 #  define DES_PTR
 #  define DES_RISC1

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,11 +1,11 @@
 # barrier -- mouse and keyboard sharing utility
 # Copyright (C) 2012-2016 Symless Ltd.
 # Copyright (C) 2011 Nick Bolton
-# 
+#
 # This package is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # found in the file LICENSE that should have accompanied this file.
-# 
+#
 # This package is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -1,11 +1,11 @@
 # barrier -- mouse and keyboard sharing utility
 # Copyright (C) 2012-2016 Symless Ltd.
 # Copyright (C) 2011 Nick Bolton
-# 
+#
 # This package is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # found in the file LICENSE that should have accompanied this file.
-# 
+#
 # This package is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/cmd/barrierc/CMakeLists.txt
+++ b/src/cmd/barrierc/CMakeLists.txt
@@ -1,11 +1,11 @@
 # barrier -- mouse and keyboard sharing utility
 # Copyright (C) 2012-2016 Symless Ltd.
 # Copyright (C) 2009 Nick Bolton
-# 
+#
 # This package is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # found in the file LICENSE that should have accompanied this file.
-# 
+#
 # This package is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/cmd/barrierc/MSWindowsClientTaskBarReceiver.cpp
+++ b/src/cmd/barrierc/MSWindowsClientTaskBarReceiver.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2003 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/cmd/barrierc/MSWindowsClientTaskBarReceiver.h
+++ b/src/cmd/barrierc/MSWindowsClientTaskBarReceiver.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2003 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/cmd/barrierc/OSXClientTaskBarReceiver.cpp
+++ b/src/cmd/barrierc/OSXClientTaskBarReceiver.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/cmd/barrierc/OSXClientTaskBarReceiver.h
+++ b/src/cmd/barrierc/OSXClientTaskBarReceiver.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/cmd/barrierc/XWindowsClientTaskBarReceiver.cpp
+++ b/src/cmd/barrierc/XWindowsClientTaskBarReceiver.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2003 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/cmd/barrierc/XWindowsClientTaskBarReceiver.h
+++ b/src/cmd/barrierc/XWindowsClientTaskBarReceiver.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2003 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/cmd/barrierc/barrierc.cpp
+++ b/src/cmd/barrierc/barrierc.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -32,13 +32,13 @@
 #endif
 
 int
-main(int argc, char** argv) 
+main(int argc, char** argv)
 {
 #if SYSAPI_WIN32
     // record window instance for tray icon, etc
     ArchMiscWindows::setInstanceWin32(GetModuleHandle(NULL));
 #endif
-    
+
     Arch arch;
     arch.init();
 

--- a/src/cmd/barrierc/resource.h
+++ b/src/cmd/barrierc/resource.h
@@ -26,7 +26,7 @@
 #define IDC_TASKBAR_LOG_LEVEL_DEBUG2    40015
 
 // Next default values for new objects
-// 
+//
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        109

--- a/src/cmd/barrierd/barrierd.cpp
+++ b/src/cmd/barrierd/barrierd.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2012 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/cmd/barriers/CMakeLists.txt
+++ b/src/cmd/barriers/CMakeLists.txt
@@ -1,11 +1,11 @@
 # barrier -- mouse and keyboard sharing utility
 # Copyright (C) 2012-2016 Symless Ltd.
 # Copyright (C) 2009 Nick Bolton
-# 
+#
 # This package is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # found in the file LICENSE that should have accompanied this file.
-# 
+#
 # This package is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/cmd/barriers/MSWindowsServerTaskBarReceiver.cpp
+++ b/src/cmd/barriers/MSWindowsServerTaskBarReceiver.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2003 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/cmd/barriers/MSWindowsServerTaskBarReceiver.h
+++ b/src/cmd/barriers/MSWindowsServerTaskBarReceiver.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2003 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/cmd/barriers/OSXServerTaskBarReceiver.cpp
+++ b/src/cmd/barriers/OSXServerTaskBarReceiver.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/cmd/barriers/OSXServerTaskBarReceiver.h
+++ b/src/cmd/barriers/OSXServerTaskBarReceiver.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/cmd/barriers/XWindowsServerTaskBarReceiver.cpp
+++ b/src/cmd/barriers/XWindowsServerTaskBarReceiver.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2003 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/cmd/barriers/XWindowsServerTaskBarReceiver.h
+++ b/src/cmd/barriers/XWindowsServerTaskBarReceiver.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2003 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/cmd/barriers/barriers.cpp
+++ b/src/cmd/barriers/barriers.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -32,7 +32,7 @@
 #endif
 
 int
-main(int argc, char** argv) 
+main(int argc, char** argv)
 {
 #if SYSAPI_WIN32
     // record window instance for tray icon, etc
@@ -45,7 +45,7 @@ main(int argc, char** argv)
     */
     setenv("OS_ACTIVITY_DT_MODE", "NO", true);
 #endif
-    
+
     Arch arch;
     arch.init();
 

--- a/src/cmd/barriers/resource.h
+++ b/src/cmd/barriers/resource.h
@@ -31,7 +31,7 @@
 #define ID_BARRIER_RESETSERVER          40017
 
 // Next default values for new objects
-// 
+//
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        109

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -28,7 +28,7 @@ target_compile_definitions (barrier PRIVATE -DBARRIER_REVISION="${BARRIER_REVISI
 
 if (WIN32)
     include_directories ($ENV{BONJOUR_SDK_HOME}/Include)
-    find_library (DNSSD_LIB dnssd.lib 
+    find_library (DNSSD_LIB dnssd.lib
                   HINTS ENV BONJOUR_SDK_HOME
                   PATH_SUFFIXES "Lib/x64")
     set_target_properties (barrier PROPERTIES LINK_FLAGS "/NODEFAULTLIB:LIBCMT")

--- a/src/gui/src/AboutDialog.cpp
+++ b/src/gui/src/AboutDialog.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/AboutDialog.h
+++ b/src/gui/src/AboutDialog.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/Action.cpp
+++ b/src/gui/src/Action.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/Action.h
+++ b/src/gui/src/Action.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/ActionDialog.cpp
+++ b/src/gui/src/ActionDialog.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/ActionDialog.h
+++ b/src/gui/src/ActionDialog.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/BaseConfig.cpp
+++ b/src/gui/src/BaseConfig.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/BaseConfig.h
+++ b/src/gui/src/BaseConfig.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/Hotkey.cpp
+++ b/src/gui/src/Hotkey.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/Hotkey.h
+++ b/src/gui/src/Hotkey.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/HotkeyDialog.cpp
+++ b/src/gui/src/HotkeyDialog.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/HotkeyDialog.h
+++ b/src/gui/src/HotkeyDialog.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/KeySequence.cpp
+++ b/src/gui/src/KeySequence.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/KeySequence.h
+++ b/src/gui/src/KeySequence.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/KeySequenceWidget.cpp
+++ b/src/gui/src/KeySequenceWidget.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/KeySequenceWidget.h
+++ b/src/gui/src/KeySequenceWidget.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/NewScreenWidget.cpp
+++ b/src/gui/src/NewScreenWidget.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/NewScreenWidget.h
+++ b/src/gui/src/NewScreenWidget.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/QBarrierApplication.cpp
+++ b/src/gui/src/QBarrierApplication.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/QBarrierApplication.h
+++ b/src/gui/src/QBarrierApplication.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/Screen.cpp
+++ b/src/gui/src/Screen.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/Screen.h
+++ b/src/gui/src/Screen.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/ScreenSettingsDialog.cpp
+++ b/src/gui/src/ScreenSettingsDialog.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/ScreenSettingsDialog.h
+++ b/src/gui/src/ScreenSettingsDialog.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/ScreenSetupModel.cpp
+++ b/src/gui/src/ScreenSetupModel.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/ScreenSetupModel.h
+++ b/src/gui/src/ScreenSetupModel.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/ScreenSetupView.cpp
+++ b/src/gui/src/ScreenSetupView.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/ScreenSetupView.h
+++ b/src/gui/src/ScreenSetupView.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/ServerConfig.cpp
+++ b/src/gui/src/ServerConfig.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/ServerConfig.h
+++ b/src/gui/src/ServerConfig.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/ServerConfigDialog.cpp
+++ b/src/gui/src/ServerConfigDialog.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/ServerConfigDialog.h
+++ b/src/gui/src/ServerConfigDialog.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/SettingsDialog.cpp
+++ b/src/gui/src/SettingsDialog.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/SettingsDialog.h
+++ b/src/gui/src/SettingsDialog.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/SetupWizard.cpp
+++ b/src/gui/src/SetupWizard.cpp
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
- 
+
 #include "SetupWizard.h"
 #include "MainWindow.h"
 #include "QBarrierApplication.h"
@@ -58,7 +58,7 @@ SetupWizard::~SetupWizard()
 }
 
 bool SetupWizard::validateCurrentPage()
-{    
+{
     QMessageBox message;
     message.setWindowTitle(tr("Setup Barrier"));
     message.setIcon(QMessageBox::Information);

--- a/src/gui/src/SetupWizard.h
+++ b/src/gui/src/SetupWizard.h
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/TrashScreenWidget.cpp
+++ b/src/gui/src/TrashScreenWidget.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/gui/src/TrashScreenWidget.h
+++ b/src/gui/src/TrashScreenWidget.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2008 Volker Lanz (vl@fidra.de)
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -1,11 +1,11 @@
 # barrier -- mouse and keyboard sharing utility
 # Copyright (C) 2012-2016 Symless Ltd.
 # Copyright (C) 2009 Nick Bolton
-# 
+#
 # This package is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # found in the file LICENSE that should have accompanied this file.
-# 
+#
 # This package is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/Arch.cpp
+++ b/src/lib/arch/Arch.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/Arch.h
+++ b/src/lib/arch/Arch.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/ArchConsoleStd.cpp
+++ b/src/lib/arch/ArchConsoleStd.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/ArchConsoleStd.h
+++ b/src/lib/arch/ArchConsoleStd.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/ArchDaemonNone.cpp
+++ b/src/lib/arch/ArchDaemonNone.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/ArchDaemonNone.h
+++ b/src/lib/arch/ArchDaemonNone.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/CMakeLists.txt
+++ b/src/lib/arch/CMakeLists.txt
@@ -1,11 +1,11 @@
 # barrier -- mouse and keyboard sharing utility
 # Copyright (C) 2012-2016 Symless Ltd.
 # Copyright (C) 2009 Nick Bolton
-# 
+#
 # This package is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # found in the file LICENSE that should have accompanied this file.
-# 
+#
 # This package is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/IArchConsole.h
+++ b/src/lib/arch/IArchConsole.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/IArchDaemon.h
+++ b/src/lib/arch/IArchDaemon.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -64,7 +64,7 @@ public:
     Installs the default daemon.
     */
     virtual void        installDaemon() = 0;
-    
+
     //! Uninstall daemon
     /*!
     Uninstalls the default daemon.
@@ -76,7 +76,7 @@ public:
     Daemonize.  Throw XArchDaemonFailed on error.  \c name is the name
     of the daemon.  Once daemonized, \c func is invoked and daemonize
     returns when and what it does.
-    
+
     Exactly what happens when daemonizing depends on the platform.
     <ul>
     <li>unix:

--- a/src/lib/arch/IArchLog.h
+++ b/src/lib/arch/IArchLog.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/IArchMultithread.h
+++ b/src/lib/arch/IArchMultithread.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -20,7 +20,7 @@
 
 #include "common/IInterface.h"
 
-/*!      
+/*!
 \class ArchCondImpl
 \brief Internal condition variable data.
 An architecture dependent type holding the necessary data for a
@@ -28,35 +28,35 @@ condition variable.
 */
 class ArchCondImpl;
 
-/*!      
+/*!
 \var ArchCond
 \brief Opaque condition variable type.
 An opaque type representing a condition variable.
 */
 typedef ArchCondImpl* ArchCond;
 
-/*!      
+/*!
 \class ArchMutexImpl
 \brief Internal mutex data.
 An architecture dependent type holding the necessary data for a mutex.
 */
 class ArchMutexImpl;
 
-/*!      
+/*!
 \var ArchMutex
 \brief Opaque mutex type.
 An opaque type representing a mutex.
 */
 typedef ArchMutexImpl* ArchMutex;
 
-/*!      
+/*!
 \class ArchThreadImpl
 \brief Internal thread data.
 An architecture dependent type holding the necessary data for a thread.
 */
 class ArchThreadImpl;
 
-/*!      
+/*!
 \var ArchThread
 \brief Opaque thread type.
 An opaque type representing a thread.

--- a/src/lib/arch/IArchNetwork.h
+++ b/src/lib/arch/IArchNetwork.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -24,21 +24,21 @@
 class ArchThreadImpl;
 typedef ArchThreadImpl* ArchThread;
 
-/*!      
+/*!
 \class ArchSocketImpl
 \brief Internal socket data.
 An architecture dependent type holding the necessary data for a socket.
 */
 class ArchSocketImpl;
 
-/*!      
+/*!
 \var ArchSocket
 \brief Opaque socket type.
 An opaque type representing a socket.
 */
 typedef ArchSocketImpl* ArchSocket;
 
-/*!      
+/*!
 \class ArchNetAddressImpl
 \brief Internal network address data.
 An architecture dependent type holding the necessary data for a network
@@ -46,7 +46,7 @@ address.
 */
 class ArchNetAddressImpl;
 
-/*!      
+/*!
 \var ArchNetAddress
 \brief Opaque network address type.
 An opaque type representing a network address.

--- a/src/lib/arch/IArchSleep.h
+++ b/src/lib/arch/IArchSleep.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/IArchString.cpp
+++ b/src/lib/arch/IArchString.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2011 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/IArchString.h
+++ b/src/lib/arch/IArchString.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/IArchSystem.h
+++ b/src/lib/arch/IArchSystem.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/IArchTaskBar.h
+++ b/src/lib/arch/IArchTaskBar.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2003 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/IArchTaskBarReceiver.h
+++ b/src/lib/arch/IArchTaskBarReceiver.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2003 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/IArchTime.h
+++ b/src/lib/arch/IArchTime.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/XArch.h
+++ b/src/lib/arch/XArch.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -57,7 +57,7 @@ class XArchEval {
 public:
     XArchEval() { }
     virtual ~XArchEval() noexcept { }
-    
+
     virtual std::string    eval() const = 0;
 };
 

--- a/src/lib/arch/multibyte.h
+++ b/src/lib/arch/multibyte.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/unix/ArchConsoleUnix.cpp
+++ b/src/lib/arch/unix/ArchConsoleUnix.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/unix/ArchConsoleUnix.h
+++ b/src/lib/arch/unix/ArchConsoleUnix.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/unix/ArchDaemonUnix.cpp
+++ b/src/lib/arch/unix/ArchDaemonUnix.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -53,9 +53,9 @@ execSelfNonDaemonized()
 {
     extern char** NXArgv;
     char** selfArgv = NXArgv;
-    
+
     setenv("_BARRIER_DAEMONIZED", "", 1);
-    
+
     execvp(selfArgv[0], selfArgv);
     return 0;
 }
@@ -73,7 +73,7 @@ ArchDaemonUnix::daemonize(const char* name, DaemonFunc func)
     if (alreadyDaemonized())
         return func(1, &name);
 #endif
-    
+
     // fork so shell thinks we're done and so we're not a process
     // group leader
     switch (fork()) {
@@ -92,7 +92,7 @@ ArchDaemonUnix::daemonize(const char* name, DaemonFunc func)
 
     // become leader of a new session
     setsid();
-    
+
 #ifndef __APPLE__
     // NB: don't run chdir on apple; causes strange behaviour.
     // chdir to root so we don't keep mounted filesystems points busy
@@ -115,18 +115,18 @@ ArchDaemonUnix::daemonize(const char* name, DaemonFunc func)
     // of standard I/O safely goes in the bit bucket.
     open("/dev/null", O_RDONLY);
     open("/dev/null", O_RDWR);
-    
+
     int dupErr = dup(1);
 
     if (dupErr < 0) {
         // NB: file logging actually isn't working at this point!
         LOG((CLOG_ERR "dup error: %i", dupErr));
     }
-    
+
 #ifdef __APPLE__
     return execSelfNonDaemonized();
 #endif
-    
+
     // invoke function
     return func(1, &name);
 }

--- a/src/lib/arch/unix/ArchDaemonUnix.h
+++ b/src/lib/arch/unix/ArchDaemonUnix.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/unix/ArchInternetUnix.cpp
+++ b/src/lib/arch/unix/ArchInternetUnix.cpp
@@ -94,16 +94,16 @@ std::string CurlFacade::get(const std::string& url)
     userAgent << "Barrier ";
     userAgent << kVersion;
     curl_easy_setopt(m_curl, CURLOPT_USERAGENT, userAgent.str().c_str());
-    
+
     std::string result;
     curl_easy_setopt(m_curl, CURLOPT_WRITEDATA, &result);
-            
+
     CURLcode code = curl_easy_perform(m_curl);
     if (code != CURLE_OK) {
         LOG((CLOG_ERR "curl perform error: %s", curl_easy_strerror(code)));
         throw XArch("CURL perform failed.");
     }
-    
+
     return result;
 }
 
@@ -114,7 +114,7 @@ std::string CurlFacade::urlEncode(const std::string& url)
     if (resultCStr == NULL) {
         throw XArch("CURL escape failed.");
     }
-    
+
     std::string result(resultCStr);
     curl_free(resultCStr);
 

--- a/src/lib/arch/unix/ArchLogUnix.cpp
+++ b/src/lib/arch/unix/ArchLogUnix.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/unix/ArchLogUnix.h
+++ b/src/lib/arch/unix/ArchLogUnix.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/unix/ArchMultithreadPosix.cpp
+++ b/src/lib/arch/unix/ArchMultithreadPosix.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -549,7 +549,7 @@ ArchMultithreadPosix::setSignalHandler(
 }
 
 void
-ArchMultithreadPosix::raiseSignal(ESignal signal) 
+ArchMultithreadPosix::raiseSignal(ESignal signal)
 {
     std::lock_guard<std::mutex> lock(m_threadMutex);
     if (m_signalFunc[signal] != NULL) {

--- a/src/lib/arch/unix/ArchMultithreadPosix.h
+++ b/src/lib/arch/unix/ArchMultithreadPosix.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/unix/ArchNetworkBSD.cpp
+++ b/src/lib/arch/unix/ArchNetworkBSD.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/unix/ArchNetworkBSD.h
+++ b/src/lib/arch/unix/ArchNetworkBSD.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/unix/ArchSleepUnix.cpp
+++ b/src/lib/arch/unix/ArchSleepUnix.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/unix/ArchSleepUnix.h
+++ b/src/lib/arch/unix/ArchSleepUnix.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/unix/ArchStringUnix.cpp
+++ b/src/lib/arch/unix/ArchStringUnix.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/unix/ArchStringUnix.h
+++ b/src/lib/arch/unix/ArchStringUnix.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/unix/ArchSystemUnix.cpp
+++ b/src/lib/arch/unix/ArchSystemUnix.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/unix/ArchSystemUnix.h
+++ b/src/lib/arch/unix/ArchSystemUnix.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/unix/ArchTaskBarXWindows.cpp
+++ b/src/lib/arch/unix/ArchTaskBarXWindows.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2003 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/unix/ArchTaskBarXWindows.h
+++ b/src/lib/arch/unix/ArchTaskBarXWindows.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2003 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/unix/ArchTimeUnix.cpp
+++ b/src/lib/arch/unix/ArchTimeUnix.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/unix/ArchTimeUnix.h
+++ b/src/lib/arch/unix/ArchTimeUnix.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/unix/XArchUnix.cpp
+++ b/src/lib/arch/unix/XArchUnix.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/unix/XArchUnix.h
+++ b/src/lib/arch/unix/XArchUnix.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/vsnprintf.h
+++ b/src/lib/arch/vsnprintf.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/win32/ArchConsoleWindows.cpp
+++ b/src/lib/arch/win32/ArchConsoleWindows.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/win32/ArchConsoleWindows.h
+++ b/src/lib/arch/win32/ArchConsoleWindows.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/win32/ArchDaemonWindows.cpp
+++ b/src/lib/arch/win32/ArchDaemonWindows.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -441,7 +441,7 @@ ArchDaemonWindows::serviceMain(DWORD argc, LPTSTR* argvIn)
     // create synchronization objects
     m_serviceMutex        = ARCH->newMutex();
     m_serviceCondVar      = ARCH->newCondVar();
-    
+
     // register our service handler function
     m_statusHandle = RegisterServiceCtrlHandler(argv[0],
                                 &ArchDaemonWindows::serviceHandlerEntry);
@@ -667,7 +667,7 @@ ArchDaemonWindows::stop(const char* name)
     // ask the service to stop, asynchronously
     SERVICE_STATUS ss;
     if (!ControlService(service, SERVICE_CONTROL_STOP, &ss)) {
-        DWORD dwErrCode = GetLastError(); 
+        DWORD dwErrCode = GetLastError();
         if (dwErrCode != ERROR_SERVICE_NOT_ACTIVE) {
             throw XArchDaemonFailed(new XArchEvalWindows());
         }
@@ -681,7 +681,7 @@ ArchDaemonWindows::installDaemon()
     if (!isDaemonInstalled(DEFAULT_DAEMON_NAME)) {
         char path[MAX_PATH];
         GetModuleFileName(ArchMiscWindows::instanceWin32(), path, MAX_PATH);
-        
+
         // wrap in quotes so a malicious user can't start \Program.exe as admin.
         std::stringstream ss;
         ss << '"';

--- a/src/lib/arch/win32/ArchDaemonWindows.h
+++ b/src/lib/arch/win32/ArchDaemonWindows.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/win32/ArchInternetWindows.cpp
+++ b/src/lib/arch/win32/ArchInternetWindows.cpp
@@ -121,12 +121,12 @@ std::string WinINetRequest::send()
     openSession();
     connect();
     openRequest();
-    
+
     std::string headers("Content-Type: text/html");
     if (!HttpSendRequest(m_request, headers.c_str(), (DWORD)headers.length(), NULL, NULL)) {
         throw XArch(new XArchEvalWindows());
     }
-    
+
     std::stringstream result;
     CHAR buffer[1025];
     DWORD read = 0;
@@ -170,7 +170,7 @@ WinINetRequest::connect()
         INTERNET_SERVICE_HTTP,
         NULL,
         NULL);
-    
+
     if (m_connect == NULL) {
         throw XArch(new XArchEvalWindows());
     }

--- a/src/lib/arch/win32/ArchLogWindows.cpp
+++ b/src/lib/arch/win32/ArchLogWindows.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/win32/ArchLogWindows.h
+++ b/src/lib/arch/win32/ArchLogWindows.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/win32/ArchMiscWindows.cpp
+++ b/src/lib/arch/win32/ArchMiscWindows.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -429,7 +429,7 @@ ArchMiscWindows::wakeupDisplay()
 }
 
 bool
-ArchMiscWindows::wasLaunchedAsService() 
+ArchMiscWindows::wasLaunchedAsService()
 {
     std::string name;
     if (!getParentProcessName(name)) {
@@ -441,7 +441,7 @@ ArchMiscWindows::wasLaunchedAsService()
 }
 
 bool ArchMiscWindows::getParentProcessName(std::string &name)
-{    
+{
     PROCESSENTRY32 parentEntry;
     if (!getParentProcessEntry(parentEntry)){
         LOG((CLOG_ERR "could not get entry for parent process"));
@@ -452,14 +452,14 @@ bool ArchMiscWindows::getParentProcessName(std::string &name)
     return true;
 }
 
-BOOL WINAPI 
+BOOL WINAPI
 ArchMiscWindows::getSelfProcessEntry(PROCESSENTRY32& entry)
 {
     // get entry from current PID
     return getProcessEntry(entry, GetCurrentProcessId());
 }
 
-BOOL WINAPI 
+BOOL WINAPI
 ArchMiscWindows::getParentProcessEntry(PROCESSENTRY32& entry)
 {
     // get the current process, so we can get parent PID
@@ -472,24 +472,24 @@ ArchMiscWindows::getParentProcessEntry(PROCESSENTRY32& entry)
     return getProcessEntry(entry, selfEntry.th32ParentProcessID);
 }
 
-BOOL WINAPI 
+BOOL WINAPI
 ArchMiscWindows::getProcessEntry(PROCESSENTRY32& entry, DWORD processID)
 {
     // first we need to take a snapshot of the running processes
     HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
     if (snapshot == INVALID_HANDLE_VALUE) {
-        LOG((CLOG_ERR "could not get process snapshot (error: %i)", 
+        LOG((CLOG_ERR "could not get process snapshot (error: %i)",
             GetLastError()));
         return FALSE;
     }
 
     entry.dwSize = sizeof(PROCESSENTRY32);
 
-    // get the first process, and if we can't do that then it's 
+    // get the first process, and if we can't do that then it's
     // unlikely we can go any further
     BOOL gotEntry = Process32First(snapshot, &entry);
     if (!gotEntry) {
-        LOG((CLOG_ERR "could not get first process entry (error: %i)", 
+        LOG((CLOG_ERR "could not get first process entry (error: %i)",
             GetLastError()));
         return FALSE;
     }

--- a/src/lib/arch/win32/ArchMiscWindows.h
+++ b/src/lib/arch/win32/ArchMiscWindows.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -167,7 +167,7 @@ public:
     static HINSTANCE instanceWin32();
 
     static void setInstanceWin32(HINSTANCE instance);
-    
+
     static BOOL WINAPI getProcessEntry(PROCESSENTRY32& entry, DWORD processID);
     static BOOL WINAPI getSelfProcessEntry(PROCESSENTRY32& entry);
     static BOOL WINAPI getParentProcessEntry(PROCESSENTRY32& entry);

--- a/src/lib/arch/win32/ArchMultithreadWindows.cpp
+++ b/src/lib/arch/win32/ArchMultithreadWindows.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/win32/ArchMultithreadWindows.h
+++ b/src/lib/arch/win32/ArchMultithreadWindows.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/win32/ArchNetworkWinsock.cpp
+++ b/src/lib/arch/win32/ArchNetworkWinsock.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/win32/ArchNetworkWinsock.h
+++ b/src/lib/arch/win32/ArchNetworkWinsock.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/win32/ArchSleepWindows.cpp
+++ b/src/lib/arch/win32/ArchSleepWindows.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -57,5 +57,5 @@ ArchSleepWindows::sleep(double timeout)
     else {
         Sleep((DWORD)(1000.0 * timeout));
     }
-    ARCH->testCancelThread();    
+    ARCH->testCancelThread();
 }

--- a/src/lib/arch/win32/ArchSleepWindows.h
+++ b/src/lib/arch/win32/ArchSleepWindows.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/win32/ArchStringWindows.cpp
+++ b/src/lib/arch/win32/ArchStringWindows.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/win32/ArchStringWindows.h
+++ b/src/lib/arch/win32/ArchStringWindows.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/win32/ArchSystemWindows.cpp
+++ b/src/lib/arch/win32/ArchSystemWindows.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/win32/ArchSystemWindows.h
+++ b/src/lib/arch/win32/ArchSystemWindows.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/win32/ArchTaskBarWindows.cpp
+++ b/src/lib/arch/win32/ArchTaskBarWindows.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2003 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/win32/ArchTaskBarWindows.h
+++ b/src/lib/arch/win32/ArchTaskBarWindows.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2003 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -36,7 +36,7 @@ public:
 
     virtual void init();
 
-    //! Add a dialog window 
+    //! Add a dialog window
     /*!
     Tell the task bar event loop about a dialog.  Win32 annoyingly
     requires messages destined for modeless dialog boxes to be

--- a/src/lib/arch/win32/ArchTimeWindows.cpp
+++ b/src/lib/arch/win32/ArchTimeWindows.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/win32/ArchTimeWindows.h
+++ b/src/lib/arch/win32/ArchTimeWindows.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/win32/XArchWindows.cpp
+++ b/src/lib/arch/win32/XArchWindows.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/arch/win32/XArchWindows.h
+++ b/src/lib/arch/win32/XArchWindows.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/App.cpp
+++ b/src/lib/barrier/App.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -86,11 +86,11 @@ App::version()
 
 int
 App::run(int argc, char** argv)
-{    
+{
 #if MAC_OS_X_VERSION_10_7
     // dock hide only supported on lion :(
     ProcessSerialNumber psn = { 0, kCurrentProcess };
-    
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     GetCurrentProcess(&psn);
@@ -101,7 +101,7 @@ App::run(int argc, char** argv)
 
     // install application in to arch
     appUtil().adoptApp(this);
-    
+
     // HACK: fail by default (saves us setting result in each catch)
     int result = kExitFailed;
 
@@ -110,7 +110,7 @@ App::run(int argc, char** argv)
     }
     catch (XExitApp& e) {
         // instead of showing a nasty error, just exit with the error code.
-        // not sure if i like this behaviour, but it's probably better than 
+        // not sure if i like this behaviour, but it's probably better than
         // using the exit(int) function!
         result = e.getCode();
     }
@@ -122,7 +122,7 @@ App::run(int argc, char** argv)
     }
 
     appUtil().beforeAppExit();
-    
+
     return result;
 }
 
@@ -137,7 +137,7 @@ App::daemonMainLoop(int, const char**)
     return mainLoop();
 }
 
-void 
+void
 App::setupFileLogging()
 {
     if (argsBase().m_logFile != NULL) {
@@ -147,23 +147,23 @@ App::setupFileLogging()
     }
 }
 
-void 
+void
 App::loggingFilterWarning()
 {
     if (CLOG->getFilter() > CLOG->getConsoleMaxLevel()) {
         if (argsBase().m_logFile == NULL) {
-            LOG((CLOG_WARN "log messages above %s are NOT sent to console (use file logging)", 
+            LOG((CLOG_WARN "log messages above %s are NOT sent to console (use file logging)",
                 CLOG->getFilterName(CLOG->getConsoleMaxLevel())));
         }
     }
 }
 
-void 
+void
 App::initApp(int argc, const char** argv)
 {
     // parse command line
     parseArgs(argc, argv);
-    
+
     DataDirectories::profile(argsBase().m_profileDirectory);
 
     // set log filter
@@ -173,7 +173,7 @@ App::initApp(int argc, const char** argv)
         m_bye(kExitArgs);
     }
     loggingFilterWarning();
-    
+
     if (argsBase().m_enableDragDrop) {
         LOG((CLOG_INFO "drag and drop enabled"));
     }
@@ -230,11 +230,11 @@ void
 App::runEventsLoop(void*)
 {
     m_events->loop();
-    
+
 #if defined(MAC_OS_X_VERSION_10_7)
-    
+
     stopCocoaLoop();
-    
+
 #endif
 }
 

--- a/src/lib/barrier/App.h
+++ b/src/lib/barrier/App.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -59,7 +59,7 @@ public:
 
     // Parse command line arguments.
     virtual void parseArgs(int argc, const char* const* argv) = 0;
-    
+
     int run(int argc, char** argv);
 
     int daemonMainLoop(int, const char**);
@@ -94,7 +94,7 @@ public:
 
     virtual void setByeFunc(void(*bye)(int)) { m_bye = bye; }
     virtual void bye(int error) { m_bye(error); }
-    
+
     virtual IEventQueue* getEvents() const { return m_events; }
 
     void setSocketMultiplexer(std::unique_ptr<SocketMultiplexer>&& sm) { m_socketMultiplexer = std::move(sm); }
@@ -135,7 +135,7 @@ public:
     virtual void        startNode();
     virtual int            mainLoop();
     virtual int            foregroundStartup(int argc, char** argv);
-    virtual barrier::Screen*    
+    virtual barrier::Screen*
                         createScreen();
     virtual void        loadConfig();
     virtual bool        loadConfig(const String& pathname);

--- a/src/lib/barrier/AppUtil.cpp
+++ b/src/lib/barrier/AppUtil.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -15,11 +15,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
- 
+
 #include "barrier/AppUtil.h"
 
 AppUtil* AppUtil::s_instance = nullptr;
- 
+
 AppUtil::AppUtil() :
 m_app(nullptr)
 {

--- a/src/lib/barrier/AppUtil.h
+++ b/src/lib/barrier/AppUtil.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
- 
+
 #pragma once
 
 #include "barrier/IAppUtil.h"
@@ -33,7 +33,7 @@ public:
     static AppUtil& instance();
     static void exitAppStatic(int code) { instance().exitApp(code); }
     virtual void beforeAppExit() {}
-    
+
 private:
     IApp* m_app;
     static AppUtil* s_instance;

--- a/src/lib/barrier/ArgParser.h
+++ b/src/lib/barrier/ArgParser.h
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2014-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
- 
+
 #pragma once
 
 #include "base/String.h"
@@ -41,21 +41,21 @@ public:
                             const char* name1, const char* name2,
                             int minRequiredParameters = 0);
     static void            splitCommandString(String& command, std::vector<String>& argv);
-    static bool            searchDoubleQuotes(String& command, size_t& left, 
+    static bool            searchDoubleQuotes(String& command, size_t& left,
                             size_t& right, size_t startPos = 0);
     static void            removeDoubleQuotes(String& arg);
     static const char**    getArgv(std::vector<String>& argsArray);
-    static String        assembleCommand(std::vector<String>& argsArray, 
+    static String        assembleCommand(std::vector<String>& argsArray,
                             String ignoreArg = "", int parametersRequired = 0);
 
 private:
     void                updateCommonArgs(const char* const* argv);
     bool                checkUnexpectedArgs();
-    
+
     static ArgsBase&    argsBase() { return *m_argsBase; }
 
 private:
     App*                m_app;
-    
+
     static ArgsBase*    m_argsBase;
 };

--- a/src/lib/barrier/ArgsBase.cpp
+++ b/src/lib/barrier/ArgsBase.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2012 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/ArgsBase.h
+++ b/src/lib/barrier/ArgsBase.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2012 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/CMakeLists.txt
+++ b/src/lib/barrier/CMakeLists.txt
@@ -1,11 +1,11 @@
 # barrier -- mouse and keyboard sharing utility
 # Copyright (C) 2012-2016 Symless Ltd.
 # Copyright (C) 2009 Nick Bolton
-# 
+#
 # This package is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # found in the file LICENSE that should have accompanied this file.
-# 
+#
 # This package is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/Chunk.cpp
+++ b/src/lib/barrier/Chunk.cpp
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2015-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/Chunk.h
+++ b/src/lib/barrier/Chunk.h
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2015-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/ClientApp.cpp
+++ b/src/lib/barrier/ClientApp.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -449,7 +449,7 @@ ClientApp::mainLoop()
 
     // start client, etc
     appUtil().startNode();
-    
+
     // init ipc client after node start, since create a new screen wipes out
     // the event queue (the screen ctors call adoptBuffer).
     if (argsBase().m_enableIpc) {
@@ -460,24 +460,24 @@ ClientApp::mainLoop()
     // later.  the timer installed by startClient() will take care of
     // that.
     DAEMON_RUNNING(true);
-    
+
 #if defined(MAC_OS_X_VERSION_10_7)
-    
+
     Thread thread(
         new TMethodJob<ClientApp>(
             this, &ClientApp::runEventsLoop,
             NULL));
-    
+
     // wait until carbon loop is ready
     OSXScreen* screen = dynamic_cast<OSXScreen*>(
         m_clientScreen->getPlatformScreen());
     screen->waitForCarbonLoop();
-    
+
     runCocoaApp();
 #else
     m_events->loop();
 #endif
-    
+
     DAEMON_RUNNING(false);
 
     // close down
@@ -548,7 +548,7 @@ ClientApp::runInner(int argc, char** argv, ILogOutputter* outputter, StartupFunc
     return result;
 }
 
-void 
+void
 ClientApp::startNode()
 {
     // start the client.  if this return false then we've failed and

--- a/src/lib/barrier/ClientApp.h
+++ b/src/lib/barrier/ClientApp.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -64,7 +64,7 @@ public:
     void handleClientConnected(const Event&, void*);
     void handleClientFailed(const Event& e, void*);
     void handleClientDisconnected(const Event&, void*);
-    Client* openClient(const String& name, const NetworkAddress& address, 
+    Client* openClient(const String& name, const NetworkAddress& address,
                 barrier::Screen* screen);
     void closeClient(Client* client);
     bool startClient();

--- a/src/lib/barrier/ClientArgs.cpp
+++ b/src/lib/barrier/ClientArgs.cpp
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2014-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/ClientArgs.h
+++ b/src/lib/barrier/ClientArgs.h
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2014-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/ClientTaskBarReceiver.cpp
+++ b/src/lib/barrier/ClientTaskBarReceiver.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2003 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/ClientTaskBarReceiver.h
+++ b/src/lib/barrier/ClientTaskBarReceiver.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2003 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/Clipboard.cpp
+++ b/src/lib/barrier/Clipboard.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/Clipboard.h
+++ b/src/lib/barrier/Clipboard.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/ClipboardChunk.cpp
+++ b/src/lib/barrier/ClipboardChunk.cpp
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2015-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -74,7 +74,7 @@ ClipboardChunk::end(ClipboardID id, UInt32 sequence)
 {
     ClipboardChunk* end = new ClipboardChunk(CLIPBOARD_CHUNK_META_SIZE);
     char* chunk = end->m_chunk;
-    
+
     chunk[0] = id;
     std::memcpy (&chunk[1], &sequence, 4);
     chunk[5] = kDataEnd;
@@ -95,7 +95,7 @@ ClipboardChunk::assemble(barrier::IStream* stream,
     if (!ProtocolUtil::readf(stream, kMsgDClipboard + 4, &id, &sequence, &mark, &data)) {
         return kError;
     }
-    
+
     if (mark == kDataStart) {
         s_expectedSize = barrier::string::stringToSizeType(data);
         LOG((CLOG_DEBUG "start receiving clipboard data"));

--- a/src/lib/barrier/ClipboardChunk.h
+++ b/src/lib/barrier/ClipboardChunk.h
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2015-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/DragInformation.cpp
+++ b/src/lib/barrier/DragInformation.cpp
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2013-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -41,7 +41,7 @@ DragInformation::parseDragInfo(DragFileList& dragFileList, UInt32 fileNum, Strin
     if (data.find("/", startPos) != string::npos) {
         slash = "/";
     }
-    
+
     UInt32 index = 0;
     while (index < fileNum) {
         findResult1 = data.find(',', startPos);
@@ -51,7 +51,7 @@ DragInformation::parseDragInfo(DragFileList& dragFileList, UInt32 fileNum, Strin
             //TODO: file number does not match, something goes wrong
             break;
         }
-        
+
         // set filename
         if (findResult1 - findResult2 > 1) {
             String filename = data.substr(findResult2 + 1,
@@ -61,7 +61,7 @@ DragInformation::parseDragInfo(DragFileList& dragFileList, UInt32 fileNum, Strin
             dragFileList.push_back(di);
         }
         startPos = findResult1 + 1;
-        
+
         //set filesize
         findResult2 = data.find(',', startPos);
         if (findResult2 - findResult1 > 1) {
@@ -71,7 +71,7 @@ DragInformation::parseDragInfo(DragFileList& dragFileList, UInt32 fileNum, Strin
             dragFileList.at(index).setFilesize(size);
         }
         startPos = findResult1 + 1;
-        
+
         ++index;
     }
 
@@ -151,8 +151,8 @@ DragInformation::getFileSize(String& filename)
 
     stringstream ss;
     ss << size;
-    
+
     file. close();
-    
+
     return ss.str();
 }

--- a/src/lib/barrier/DragInformation.h
+++ b/src/lib/barrier/DragInformation.h
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2013-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -28,12 +28,12 @@ class DragInformation {
 public:
     DragInformation();
     ~DragInformation() { }
-    
+
     String&            getFilename() { return m_filename; }
     void                setFilename(String& name) { m_filename = name; }
     size_t                getFilesize() { return m_filesize; }
     void                setFilesize(size_t size) { m_filesize = size; }
-    
+
     static void            parseDragInfo(DragFileList& dragFileList, UInt32 fileNum, String data);
     static String        getDragFileExtension(String filename);
     // helper function to setup drag info

--- a/src/lib/barrier/DropHelper.cpp
+++ b/src/lib/barrier/DropHelper.cpp
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2014-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -39,7 +39,7 @@ DropHelper::writeToDir(const String& destination, DragFileList& fileList, String
         if (!file.is_open()) {
             LOG((CLOG_ERR "drop file failed: can not open %s", dropTarget.c_str()));
         }
-        
+
         file.write(data.c_str(), data.size());
         file.close();
 

--- a/src/lib/barrier/DropHelper.h
+++ b/src/lib/barrier/DropHelper.h
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2014-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/FileChunk.cpp
+++ b/src/lib/barrier/FileChunk.cpp
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2015-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/FileChunk.h
+++ b/src/lib/barrier/FileChunk.h
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2015-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/IApp.h
+++ b/src/lib/barrier/IApp.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2012 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/IAppUtil.h
+++ b/src/lib/barrier/IAppUtil.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
- 
+
 #pragma once
 
 #include "common/IInterface.h"

--- a/src/lib/barrier/IClient.h
+++ b/src/lib/barrier/IClient.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/IClipboard.cpp
+++ b/src/lib/barrier/IClipboard.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -66,13 +66,13 @@ IClipboard::unmarshall(IClipboard* clipboard, const String& data, Time time)
 String
 IClipboard::marshall(const IClipboard* clipboard)
 {
-    // return data format: 
+    // return data format:
     // 4 bytes => number of formats included
     // 4 bytes => format enum
     // 4 bytes => clipboard data size n
     // n bytes => clipboard data
     // back to the second 4 bytes if there is another format
-    
+
     assert(clipboard != NULL);
 
     String data;

--- a/src/lib/barrier/IClipboard.h
+++ b/src/lib/barrier/IClipboard.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/IKeyState.cpp
+++ b/src/lib/barrier/IKeyState.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/IKeyState.h
+++ b/src/lib/barrier/IKeyState.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2003 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -122,14 +122,14 @@ public:
     complete and false if normal key processing should continue.
     */
     virtual bool        fakeCtrlAltDel() = 0;
-    
+
     //! Fake a media key
     /*!
      Synthesizes a media key down and up. Only Mac would implement this by
      use cocoa appkit framework.
      */
     virtual bool        fakeMediaKey(KeyID id) = 0;
-    
+
     //@}
     //! @name accessors
     //@{

--- a/src/lib/barrier/INode.h
+++ b/src/lib/barrier/INode.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -21,5 +21,5 @@
 #include "common/IInterface.h"
 
 class INode : IInterface {
-    
+
 };

--- a/src/lib/barrier/IPlatformScreen.cpp
+++ b/src/lib/barrier/IPlatformScreen.cpp
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2016 Symless.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file COPYING that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/IPlatformScreen.h
+++ b/src/lib/barrier/IPlatformScreen.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -197,7 +197,7 @@ public:
     virtual void        fakeDraggingFiles(DragFileList fileList) = 0;
     virtual const String&
                         getDropTarget() const = 0;
-                    
+
 protected:
     //! Handle system event
     /*!

--- a/src/lib/barrier/IPrimaryScreen.cpp
+++ b/src/lib/barrier/IPrimaryScreen.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/IPrimaryScreen.h
+++ b/src/lib/barrier/IPrimaryScreen.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2003 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/IScreen.h
+++ b/src/lib/barrier/IScreen.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2003 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -66,6 +66,6 @@ public:
     Return the current position of the cursor in \c x and \c y.
     */
     virtual void        getCursorPos(SInt32& x, SInt32& y) const = 0;
-    
+
     //@}
 };

--- a/src/lib/barrier/IScreenSaver.h
+++ b/src/lib/barrier/IScreenSaver.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/ISecondaryScreen.h
+++ b/src/lib/barrier/ISecondaryScreen.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2003 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/KeyMap.cpp
+++ b/src/lib/barrier/KeyMap.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2005 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -733,7 +733,7 @@ KeyMap::keyForModifier(KeyButton button, SInt32 group,
     assert(modifierBit >= 0 && modifierBit < kKeyModifierNumBits);
     assert(group >= 0 && group < getNumGroups());
 
-    // find a key that generates the given modifier in the given group 
+    // find a key that generates the given modifier in the given group
     // but doesn't use the given button, presumably because we're trying
     // to generate a KeyID that's only bound the the given button.
     // this is important when a shift button is modified by shift;  we
@@ -989,7 +989,7 @@ KeyMap::addKeystrokes(EKeystroke type, const KeyItem& keyItem,
             }
         }
         break;
-        
+
     case kKeystrokeRelease:
         keystrokes.push_back(Keystroke(button, false, false, data));
         if (keyItem.m_generates != 0 && !keyItem.m_lock) {
@@ -1011,19 +1011,19 @@ KeyMap::addKeystrokes(EKeystroke type, const KeyItem& keyItem,
             }
         }
         break;
-        
+
     case kKeystrokeRepeat:
         keystrokes.push_back(Keystroke(button, false, true, data));
         keystrokes.push_back(Keystroke(button,  true, true, data));
         // no modifier changes on key repeat
         break;
-        
+
     case kKeystrokeClick:
         keystrokes.push_back(Keystroke(button,  true, false, data));
         keystrokes.push_back(Keystroke(button, false, false, data));
         // no modifier changes on key click
         break;
-        
+
     case kKeystrokeModify:
     case kKeystrokeUnmodify:
         if (keyItem.m_lock) {

--- a/src/lib/barrier/KeyMap.h
+++ b/src/lib/barrier/KeyMap.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2005 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -322,7 +322,7 @@ public:
     Converts a string into a modifier mask.  Returns \c true on success
     and \c false if the string cannot be parsed.  The modifiers plus any
     remaining leading and trailing whitespace is stripped from the input
-    string. 
+    string.
     */
     static bool            parseModifiers(String&, KeyModifierMask&);
 
@@ -355,7 +355,7 @@ private:
         kKeystrokeModify,        //!< Synthesize pressing a modifier
         kKeystrokeUnmodify        //!< Synthesize releasing a modifier
     };
-        
+
     // A list of ways to synthesize a KeyID
     typedef std::vector<KeyItemList> KeyEntryList;
 

--- a/src/lib/barrier/KeyState.cpp
+++ b/src/lib/barrier/KeyState.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -529,7 +529,7 @@ KeyState::addActiveModifierCB(KeyID, SInt32 group,
         (keyItem.m_generates & context->m_mask) != 0) {
         context->m_activeModifiers.insert(std::make_pair(
                                 keyItem.m_generates, keyItem));
-    }    
+    }
 }
 
 void
@@ -581,10 +581,10 @@ KeyState::fakeKeyDown(KeyID id, KeyModifierMask mask, KeyButton serverID)
             LOG((CLOG_DEBUG1 "emulating media key"));
             fakeMediaKey(id);
         }
-        
+
         return;
     }
-    
+
     KeyButton localID = (KeyButton)(keyItem->m_button & kButtonMask);
     updateModifierKeyState(localID, oldActiveModifiers, m_activeModifiers);
     if (localID != 0) {

--- a/src/lib/barrier/KeyState.h
+++ b/src/lib/barrier/KeyState.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -74,7 +74,7 @@ public:
     virtual void        fakeAllKeysUp();
     virtual bool        fakeCtrlAltDel() = 0;
     virtual bool        fakeMediaKey(KeyID id);
-    
+
     virtual bool        isKeyDown(KeyButton) const;
     virtual KeyModifierMask
                         getActiveModifiers() const;
@@ -157,7 +157,7 @@ public:
         AddActiveModifierContext& operator=(const AddActiveModifierContext&);
     };
 private:
-    
+
     class ButtonToKeyLess {
     public:
         bool operator()(const barrier::KeyMap::ButtonToKeyMap::value_type& a,

--- a/src/lib/barrier/PacketStreamFilter.cpp
+++ b/src/lib/barrier/PacketStreamFilter.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/PacketStreamFilter.h
+++ b/src/lib/barrier/PacketStreamFilter.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -24,7 +24,7 @@
 
 class IEventQueue;
 
-//! Packetizing stream filter 
+//! Packetizing stream filter
 /*!
 Filters a stream to read and write packets.
 */

--- a/src/lib/barrier/PlatformScreen.cpp
+++ b/src/lib/barrier/PlatformScreen.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/PortableTaskBarReceiver.cpp
+++ b/src/lib/barrier/PortableTaskBarReceiver.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2003 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -111,7 +111,7 @@ PortableTaskBarReceiver::getToolTip() const
     case kNotWorking:
         return barrier::string::sprintf("%s:  %s",
                                 kAppVersion, m_errorMessage.c_str());
-                        
+
     case kNotConnected:
         return barrier::string::sprintf("%s:  Unknown", kAppVersion);
 

--- a/src/lib/barrier/PortableTaskBarReceiver.h
+++ b/src/lib/barrier/PortableTaskBarReceiver.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2003 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/ProtocolUtil.cpp
+++ b/src/lib/barrier/ProtocolUtil.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/ProtocolUtil.h
+++ b/src/lib/barrier/ProtocolUtil.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -38,7 +38,7 @@ public:
     regular characters and format specifiers.  Format specifiers
     begin with \%.  All characters not part of a format specifier
     are regular and are transmitted unchanged.
-    
+
     Format specifiers are:
     - \%\%   -- literal `\%'
     - \%1i  -- converts integer argument to 1 byte integer
@@ -58,7 +58,7 @@ public:
     Read formatted binary data from a buffer.  This performs the
     reverse operation of writef().  Returns true if the entire
     format was successfully parsed, false otherwise.
-    
+
     Format specifiers are:
     - \%\%   -- read (and discard) a literal `\%'
     - \%1i  -- reads a 1 byte integer; argument is a SInt32* or UInt32*

--- a/src/lib/barrier/Screen.cpp
+++ b/src/lib/barrier/Screen.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2003 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -376,7 +376,7 @@ Screen::isLockedToScreen() const
         if (buttonID != kButtonLeft) {
             LOG((CLOG_DEBUG "locked by mouse buttonID: %d", buttonID));
         }
-        
+
         if (m_enableDragDrop) {
             return (buttonID == kButtonLeft) ? false : true;
         }

--- a/src/lib/barrier/Screen.h
+++ b/src/lib/barrier/Screen.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -223,7 +223,7 @@ public:
 
     //! Change dragging status
     void                setDraggingStarted(bool started);
-    
+
     //! Fake a files dragging operation
     void                startDraggingFiles(DragFileList& fileList);
 
@@ -278,7 +278,7 @@ public:
 
     //! Test if file is dragged on primary screen
     bool                isDraggingStarted() const;
-    
+
     //! Test if file is dragged on secondary screen
     bool                isFakeDraggingStarted() const;
 
@@ -299,7 +299,7 @@ public:
     virtual void        getShape(SInt32& x, SInt32& y,
                             SInt32& width, SInt32& height) const;
     virtual void        getCursorPos(SInt32& x, SInt32& y) const;
-    
+
     IPlatformScreen*    getPlatformScreen() { return m_screen; }
 
 protected:

--- a/src/lib/barrier/ServerApp.h
+++ b/src/lib/barrier/ServerApp.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -51,7 +51,7 @@ class ServerApp : public App {
 public:
     ServerApp(IEventQueue* events, CreateTaskBarReceiverFunc createTaskBarReceiver);
     virtual ~ServerApp();
-    
+
     // Parse server specific command line arguments.
     void parseArgs(int argc, const char* const* argv);
 
@@ -104,7 +104,7 @@ public:
     static ServerApp& instance() { return (ServerApp&)App::instance(); }
 
     Server* getServerPtr() { return m_server; }
-    
+
     Server*                m_server;
     EServerState        m_serverState;
     barrier::Screen*    m_serverScreen;

--- a/src/lib/barrier/ServerTaskBarReceiver.cpp
+++ b/src/lib/barrier/ServerTaskBarReceiver.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2003 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -125,7 +125,7 @@ ServerTaskBarReceiver::getToolTip() const
     case kNotWorking:
         return barrier::string::sprintf("%s:  %s",
                                 kAppVersion, m_errorMessage.c_str());
-                        
+
     case kNotConnected:
         return barrier::string::sprintf("%s:  Waiting for clients", kAppVersion);
 

--- a/src/lib/barrier/ServerTaskBarReceiver.h
+++ b/src/lib/barrier/ServerTaskBarReceiver.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2003 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/StreamChunker.cpp
+++ b/src/lib/barrier/StreamChunker.cpp
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2013-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -48,7 +48,7 @@ StreamChunker::sendFile(
                 void* eventTarget)
 {
     s_isChunkingFile = true;
-    
+
     std::fstream file(static_cast<char*>(filename), std::ios::in | std::ios::binary);
 
     if (!file.is_open()) {
@@ -76,9 +76,9 @@ StreamChunker::sendFile(
             LOG((CLOG_DEBUG "file transmission interrupted"));
             break;
         }
-        
+
         events->addEvent(Event(events->forFile().keepAlive(), eventTarget));
-        
+
         // make sure we don't read too much from the mock data.
         if (sentLength + chunkSize > size) {
             chunkSize = size - sentLength;
@@ -106,7 +106,7 @@ StreamChunker::sendFile(
     events->addEvent(Event(events->forFile().fileChunkSending(), eventTarget, end));
 
     file.close();
-    
+
     s_isChunkingFile = false;
 }
 
@@ -122,16 +122,16 @@ StreamChunker::sendClipboard(
     // send first message (data size)
     String dataSize = barrier::string::sizeTypeToString(size);
     ClipboardChunk* sizeMessage = ClipboardChunk::start(id, sequence, dataSize);
-    
+
     events->addEvent(Event(events->forClipboard().clipboardSending(), eventTarget, sizeMessage));
 
     // send clipboard chunk with a fixed size
     size_t sentLength = 0;
     size_t chunkSize = g_chunkSize;
-    
+
     while (true) {
         events->addEvent(Event(events->forFile().keepAlive(), eventTarget));
-        
+
         // make sure we don't read too much from the mock data.
         if (sentLength + chunkSize > size) {
             chunkSize = size - sentLength;
@@ -139,7 +139,7 @@ StreamChunker::sendClipboard(
 
         String chunk(data.substr(sentLength, chunkSize).c_str(), chunkSize);
         ClipboardChunk* dataChunk = ClipboardChunk::data(id, sequence, chunk);
-        
+
         events->addEvent(Event(events->forClipboard().clipboardSending(), eventTarget, dataChunk));
 
         sentLength += chunkSize;
@@ -152,7 +152,7 @@ StreamChunker::sendClipboard(
     ClipboardChunk* end = ClipboardChunk::end(id, sequence);
 
     events->addEvent(Event(events->forClipboard().clipboardSending(), eventTarget, end));
-    
+
     LOG((CLOG_DEBUG "sent clipboard size=%d", sentLength));
 }
 

--- a/src/lib/barrier/StreamChunker.h
+++ b/src/lib/barrier/StreamChunker.h
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2013-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -37,7 +37,7 @@ public:
                             IEventQueue* events,
                             void* eventTarget);
     static void            interruptFile();
-    
+
 private:
     static bool            s_isChunkingFile;
     static bool            s_interruptFile;

--- a/src/lib/barrier/XBarrier.cpp
+++ b/src/lib/barrier/XBarrier.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -118,6 +118,6 @@ int XExitApp::getCode() const noexcept
 String XExitApp::getWhat() const noexcept
 {
     return format(
-        "XExitApp", "exiting with code %{1}", 
+        "XExitApp", "exiting with code %{1}",
         barrier::string::sprintf("%d", m_code).c_str());
 }

--- a/src/lib/barrier/XBarrier.h
+++ b/src/lib/barrier/XBarrier.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -113,8 +113,8 @@ private:
 
 //! Generic exit eception
 /*!
-Thrown when we want to abort, with the opportunity to clean up. This is a 
-little bit of a hack, but it's a better way of exiting, than just calling 
+Thrown when we want to abort, with the opportunity to clean up. This is a
+little bit of a hack, but it's a better way of exiting, than just calling
 exit(int).
 */
 class XExitApp : public XBarrier {
@@ -127,7 +127,7 @@ public:
 
 protected:
     virtual std::string getWhat() const noexcept;
-    
+
 private:
     int    m_code;
 };

--- a/src/lib/barrier/XScreen.cpp
+++ b/src/lib/barrier/XScreen.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/XScreen.h
+++ b/src/lib/barrier/XScreen.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/clipboard_types.h
+++ b/src/lib/barrier/clipboard_types.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/key_types.cpp
+++ b/src/lib/barrier/key_types.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/key_types.h
+++ b/src/lib/barrier/key_types.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -172,7 +172,7 @@ static const KeyID		kKeyKP_Separator= 0xEFAC;	/* separator, often comma */
 static const KeyID		kKeyKP_Subtract	= 0xEFAD;
 static const KeyID		kKeyKP_Decimal	= 0xEFAE;
 static const KeyID		kKeyKP_Divide	= 0xEFAF;
-static const KeyID		kKeyKP_0		= 0xEFB0; 
+static const KeyID		kKeyKP_0		= 0xEFB0;
 static const KeyID		kKeyKP_1		= 0xEFB1;
 static const KeyID		kKeyKP_2		= 0xEFB2;
 static const KeyID		kKeyKP_3		= 0xEFB3;

--- a/src/lib/barrier/mouse_types.h
+++ b/src/lib/barrier/mouse_types.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/option_types.h
+++ b/src/lib/barrier/option_types.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/protocol_types.cpp
+++ b/src/lib/barrier/protocol_types.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/protocol_types.h
+++ b/src/lib/barrier/protocol_types.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/unix/AppUtilUnix.cpp
+++ b/src/lib/barrier/unix/AppUtilUnix.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/barrier/unix/AppUtilUnix.h
+++ b/src/lib/barrier/unix/AppUtilUnix.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -28,7 +28,7 @@ class AppUtilUnix : public AppUtil {
 public:
     AppUtilUnix(IEventQueue* events);
     virtual ~AppUtilUnix();
-    
+
     int run(int argc, char** argv);
     void startNode();
 };

--- a/src/lib/barrier/win32/AppUtilWindows.cpp
+++ b/src/lib/barrier/win32/AppUtilWindows.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -60,13 +60,13 @@ BOOL WINAPI AppUtilWindows::consoleHandler(DWORD)
 }
 
 static
-int 
-mainLoopStatic() 
+int
+mainLoopStatic()
 {
     return AppUtil::instance().app().mainLoop();
 }
 
-int 
+int
 AppUtilWindows::daemonNTMainLoop(int argc, const char** argv)
 {
     app().initApp(argc, argv);
@@ -74,11 +74,11 @@ AppUtilWindows::daemonNTMainLoop(int argc, const char** argv)
 
     // NB: what the hell does this do?!
     app().argsBase().m_backend = false;
-    
+
     return ArchMiscWindows::runDaemon(mainLoopStatic);
 }
 
-void 
+void
 AppUtilWindows::exitApp(int code)
 {
     switch (m_exitMode) {
@@ -97,7 +97,7 @@ int daemonNTMainLoopStatic(int argc, const char** argv)
     return AppUtilWindows::instance().daemonNTMainLoop(argc, argv);
 }
 
-int 
+int
 AppUtilWindows::daemonNTStartup(int, char**)
 {
     SystemLogger sysLogger(app().daemonName(), false);
@@ -155,13 +155,13 @@ AppUtilWindows::run(int argc, char** argv)
     return app().runInner(argc, argv, NULL, startup);
 }
 
-AppUtilWindows& 
+AppUtilWindows&
 AppUtilWindows::instance()
 {
     return (AppUtilWindows&)AppUtil::instance();
 }
 
-void 
+void
 AppUtilWindows::debugServiceWait()
 {
     if (app().argsBase().m_debugServiceWait)
@@ -169,8 +169,8 @@ AppUtilWindows::debugServiceWait()
         while(true)
         {
             // this code is only executed when the process is launched via the
-            // windows service controller (and --debug-service-wait arg is 
-            // used). to debug, set a breakpoint on this line so that 
+            // windows service controller (and --debug-service-wait arg is
+            // used). to debug, set a breakpoint on this line so that
             // execution is delayed until the debugger is attached.
             ARCH->sleep(1);
             LOG((CLOG_INFO "waiting for debugger to attach"));
@@ -178,7 +178,7 @@ AppUtilWindows::debugServiceWait()
     }
 }
 
-void 
+void
 AppUtilWindows::startNode()
 {
     app().startNode();

--- a/src/lib/barrier/win32/AppUtilWindows.h
+++ b/src/lib/barrier/win32/AppUtilWindows.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -39,7 +39,7 @@ public:
     virtual ~AppUtilWindows();
 
     int daemonNTStartup(int, char**);
-    
+
     int daemonNTMainLoop(int argc, const char** argv);
 
     void debugServiceWait();

--- a/src/lib/barrier/win32/DaemonApp.cpp
+++ b/src/lib/barrier/win32/DaemonApp.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2012 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -87,7 +87,7 @@ DaemonApp::run(int argc, char** argv)
 {
     // win32 instance needed for threading, etc.
     ArchMiscWindows::setInstanceWin32(GetModuleHandle(NULL));
-    
+
     Arch arch;
     arch.init();
 
@@ -174,7 +174,7 @@ DaemonApp::mainLoop(bool daemonized)
     try
     {
         DAEMON_RUNNING(true);
-        
+
         if (daemonized) {
             m_fileLogOutputter = new FileLogOutputter(logFilename().c_str());
             CLOG->insert(m_fileLogOutputter);
@@ -190,19 +190,19 @@ DaemonApp::mainLoop(bool daemonized)
         // send logging to gui via ipc, log system adopts outputter.
         m_ipcLogOutputter = new IpcLogOutputter(*m_ipcServer, kIpcClientGui, true);
         CLOG->insert(m_ipcLogOutputter);
-        
+
         m_watchdog = new MSWindowsWatchdog(daemonized, false, *m_ipcServer, *m_ipcLogOutputter);
         m_watchdog->setFileLogOutputter(m_fileLogOutputter);
-        
+
         m_events->adoptHandler(
             m_events->forIpcServer().messageReceived(), m_ipcServer,
             new TMethodEventJob<DaemonApp>(this, &DaemonApp::handleIpcMessage));
 
         m_ipcServer->listen();
-        
+
         // install the platform event queue to handle service stop events.
         m_events->adoptBuffer(new MSWindowsEventQueueBuffer(m_events));
-        
+
         String command = ARCH->setting("Command");
         bool elevate = ARCH->setting("Elevate") == "1";
         if (command != "") {
@@ -219,11 +219,11 @@ DaemonApp::mainLoop(bool daemonized)
 
         m_events->removeHandler(
             m_events->forIpcServer().messageReceived(), m_ipcServer);
-        
+
         CLOG->remove(m_ipcLogOutputter);
         delete m_ipcLogOutputter;
         delete m_ipcServer;
-        
+
         DAEMON_RUNNING(false);
     }
     catch (std::exception& e) {
@@ -287,7 +287,7 @@ DaemonApp::handleIpcMessage(const Event& e, void*)
                 }
 
                 delete[] argv;
-                
+
                 String logLevel(argBase->m_logFilter);
                 if (!logLevel.empty()) {
                     try {

--- a/src/lib/barrier/win32/DaemonApp.h
+++ b/src/lib/barrier/win32/DaemonApp.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2012 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
- 
+
 #pragma once
 
 #include "arch/Arch.h"

--- a/src/lib/base/CMakeLists.txt
+++ b/src/lib/base/CMakeLists.txt
@@ -1,11 +1,11 @@
 # barrier -- mouse and keyboard sharing utility
 # Copyright (C) 2012-2016 Symless Ltd.
 # Copyright (C) 2009 Nick Bolton
-# 
+#
 # This package is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # found in the file LICENSE that should have accompanied this file.
-# 
+#
 # This package is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/base/ELevel.h
+++ b/src/lib/base/ELevel.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2011 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/base/Event.cpp
+++ b/src/lib/base/Event.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/base/Event.h
+++ b/src/lib/base/Event.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -71,7 +71,7 @@ public:
     Deletes event data for the given event (using free()).
     */
     static void            deleteData(const Event&);
-    
+
     //! Set data (non-POD)
     /*!
     Set non-POD (non plain old data), where delete is called when the event
@@ -114,7 +114,7 @@ public:
     Returns the event flags.
     */
     Flags                getFlags() const;
-    
+
     //@}
 
 private:

--- a/src/lib/base/EventQueue.cpp
+++ b/src/lib/base/EventQueue.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -100,7 +100,7 @@ EventQueue::~EventQueue()
     delete m_buffer;
     delete m_readyCondVar;
     delete m_readyMutex;
-    
+
     ARCH->setSignalHandler(Arch::kINTERRUPT, NULL, NULL);
     ARCH->setSignalHandler(Arch::kTERMINATE, NULL, NULL);
 }
@@ -121,7 +121,7 @@ EventQueue::loop()
         addEventToBuffer(event);
         m_pending.pop();
     }
-    
+
     Event event;
     getEvent(event);
     while (event.getType() != Event::kQuit) {
@@ -298,7 +298,7 @@ EventQueue::addEvent(const Event& event)
     default:
         break;
     }
-    
+
     if ((event.getFlags() & Event::kDeliverImmediately) != 0) {
         dispatchEvent(event);
         Event::deleteData(event);
@@ -315,10 +315,10 @@ void
 EventQueue::addEventToBuffer(const Event& event)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
-    
+
     // store the event's data locally
     UInt32 eventID = saveEvent(event);
-    
+
     // add it
     if (!m_buffer->addEvent(eventID)) {
         // failed to send event
@@ -568,7 +568,7 @@ EventQueue::waitForReady() const
 {
     double timeout = ARCH->time() + 10;
     Lock lock(m_readyMutex);
-    
+
     while (!m_readyCondVar->wait()) {
         if (ARCH->time() > timeout) {
             throw std::runtime_error("event queue is not ready within 5 sec");

--- a/src/lib/base/EventQueue.h
+++ b/src/lib/base/EventQueue.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -71,7 +71,7 @@ private:
     double                getNextTimerTimeout() const;
     void                addEventToBuffer(const Event& event);
     bool                parent_requests_shutdown() const;
-    
+
 private:
     class Timer {
     public:

--- a/src/lib/base/EventTypes.cpp
+++ b/src/lib/base/EventTypes.cpp
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2013-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/base/EventTypes.h
+++ b/src/lib/base/EventTypes.h
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2013-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -134,7 +134,7 @@ public:
     Event::Type        outputShutdown();
 
     //@}
-        
+
 private:
     Event::Type        m_inputReady;
     Event::Type        m_outputFlushed;
@@ -159,7 +159,7 @@ public:
     Event::Type        messageReceived();
 
     //@}
-    
+
 private:
     Event::Type        m_connected;
     Event::Type        m_messageReceived;
@@ -179,7 +179,7 @@ public:
 
     //! Raised when the client disconnects from the server.
     Event::Type        disconnected();
-        
+
     //@}
 
 private:
@@ -198,7 +198,7 @@ public:
 
     //! Raised when we have created the client proxy.
     Event::Type        clientConnected();
-    
+
     //! Raised when a message is received through a client proxy.
     Event::Type        messageReceived();
 
@@ -242,7 +242,7 @@ public:
     event when a remote connection has been established.
     */
     Event::Type        connected();
-    
+
     //! Get secure connected event type
     /*!
      Returns the secure socket connected event type.  A secure socket sends
@@ -342,14 +342,14 @@ public:
 
     //! @name accessors
     //@{
-    
+
     //! Get accepted event type
     /*!
      Returns the accepted event type.  This is sent whenever a server
      accepts a client.
      */
     Event::Type        accepted();
-    
+
     //! Get connected event type
     /*!
     Returns the connected event type.  This is sent whenever a
@@ -419,7 +419,7 @@ public:
     Event::Type        failure();
 
     //@}
-        
+
 private:
     Event::Type        m_success;
     Event::Type        m_failure;
@@ -510,7 +510,7 @@ public:
     Event::Type        screenSwitched();
 
     //@}
-        
+
 private:
     Event::Type        m_error;
     Event::Type        m_connected;
@@ -529,16 +529,16 @@ public:
         m_reloadConfig(Event::kUnknown),
         m_forceReconnect(Event::kUnknown),
         m_resetServer(Event::kUnknown) { }
-        
+
     //! @name accessors
     //@{
-        
+
     Event::Type        reloadConfig();
     Event::Type        forceReconnect();
     Event::Type        resetServer();
 
     //@}
-        
+
 private:
     Event::Type        m_reloadConfig;
     Event::Type        m_forceReconnect;
@@ -565,7 +565,7 @@ public:
     Event::Type        keyRepeat();
 
     //@}
-        
+
 private:
     Event::Type        m_keyDown;
     Event::Type        m_keyUp;
@@ -589,7 +589,7 @@ public:
 
     //! @name accessors
     //@{
-    
+
     //!  button down event type.  Event data is ButtonInfo*.
     Event::Type        buttonDown();
 
@@ -677,7 +677,7 @@ public:
     to sleep or a user session is deactivated (fast user switching).
     */
     Event::Type        suspend();
-    
+
     //! Get resume event type
     /*!
     Returns the resume event type. This is sent whenever the system wakes
@@ -686,7 +686,7 @@ public:
     Event::Type        resume();
 
     //@}
-        
+
 private:
     Event::Type        m_error;
     Event::Type        m_shapeChanged;
@@ -722,7 +722,7 @@ public:
 
     //! Clipboard sending event type
     /*!
-    Returns the clipboard sending event type. This is used to send 
+    Returns the clipboard sending event type. This is used to send
     clipboard chunks.
     */
     Event::Type        clipboardSending();

--- a/src/lib/base/FunctionEventJob.cpp
+++ b/src/lib/base/FunctionEventJob.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/base/FunctionEventJob.h
+++ b/src/lib/base/FunctionEventJob.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/base/FunctionJob.cpp
+++ b/src/lib/base/FunctionJob.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/base/FunctionJob.h
+++ b/src/lib/base/FunctionJob.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/base/IEventJob.h
+++ b/src/lib/base/IEventJob.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/base/IEventQueue.h
+++ b/src/lib/base/IEventQueue.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -184,7 +184,7 @@ public:
     be added.
     */
     virtual void        waitForReady() const = 0;
-    
+
     //@}
     //! @name accessors
     //@{
@@ -216,7 +216,7 @@ public:
     virtual void*        getSystemTarget() = 0;
 
     //@}
-    
+
     //
     // Event type providers.
     //

--- a/src/lib/base/IEventQueueBuffer.h
+++ b/src/lib/base/IEventQueueBuffer.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -38,7 +38,7 @@ public:
 
     //! @name manipulators
     //@{
-    
+
     //! Initialize
     /*!
     Useful for platform-specific initialisation from a specific thread.

--- a/src/lib/base/IJob.h
+++ b/src/lib/base/IJob.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/base/ILogOutputter.h
+++ b/src/lib/base/ILogOutputter.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/base/Log.cpp
+++ b/src/lib/base/Log.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.    See the
@@ -25,7 +25,7 @@
 #include <cstdio>
 #include <cstring>
 #include <iostream>
-#include <ctime> 
+#include <ctime>
 
 // names of priorities
 static const char*        g_priority[] = {

--- a/src/lib/base/Log.h
+++ b/src/lib/base/Log.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -91,7 +91,7 @@ public:
     then it simply returns true.
     */
     bool                setFilter(const char* name);
-    
+
     //! Set the minimum priority filter (by ordinal).
     void                setFilter(int);
 
@@ -193,9 +193,9 @@ otherwise it expands to a call that doesn't.
 #define CLOG_TRACE        __FILE__, __LINE__,
 #endif
 
-// the CLOG_* defines are line and file plus %z and an octal number (060=0, 
-// 071=9), but the limitation is that once we run out of numbers at either 
-// end, then we resort to using non-numerical chars. this still works (since 
+// the CLOG_* defines are line and file plus %z and an octal number (060=0,
+// 071=9), but the limitation is that once we run out of numbers at either
+// end, then we resort to using non-numerical chars. this still works (since
 // to deduce the number we subtract octal \060, so '/' is -1, and ':' is 10
 
 #define CLOG_PRINT        CLOG_TRACE "%z\057" // char is '/'

--- a/src/lib/base/PriorityQueue.h
+++ b/src/lib/base/PriorityQueue.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2003 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/base/SimpleEventQueueBuffer.cpp
+++ b/src/lib/base/SimpleEventQueueBuffer.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/base/SimpleEventQueueBuffer.h
+++ b/src/lib/base/SimpleEventQueueBuffer.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -28,7 +28,7 @@ An event queue buffer provides a queue of events for an IEventQueue.
 */
 class SimpleEventQueueBuffer : public IEventQueueBuffer {
 public:
-    SimpleEventQueueBuffer();    
+    SimpleEventQueueBuffer();
     ~SimpleEventQueueBuffer();
 
     // IEventQueueBuffer overrides

--- a/src/lib/base/Stopwatch.cpp
+++ b/src/lib/base/Stopwatch.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/base/Stopwatch.h
+++ b/src/lib/base/Stopwatch.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -88,7 +88,7 @@ public:
     */
     bool                isStopped() const;
 
-    // return the time since the last reset().  
+    // return the time since the last reset().
     //! Get elapsed time
     /*!
     Returns the time since the last reset().  This cannot trigger the

--- a/src/lib/base/String.cpp
+++ b/src/lib/base/String.cpp
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2014-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/base/String.h
+++ b/src/lib/base/String.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/base/TMethodEventJob.h
+++ b/src/lib/base/TMethodEventJob.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/base/TMethodJob.h
+++ b/src/lib/base/TMethodJob.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/base/Unicode.cpp
+++ b/src/lib/base/Unicode.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/base/Unicode.h
+++ b/src/lib/base/Unicode.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/base/XBase.cpp
+++ b/src/lib/base/XBase.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/base/XBase.h
+++ b/src/lib/base/XBase.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/base/log_outputters.cpp
+++ b/src/lib/base/log_outputters.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -305,7 +305,7 @@ MesssageBoxLogOutputter::~MesssageBoxLogOutputter()
 }
 
 void
-MesssageBoxLogOutputter::open(const char* title) 
+MesssageBoxLogOutputter::open(const char* title)
 {
     // do nothing
 }

--- a/src/lib/base/log_outputters.h
+++ b/src/lib/base/log_outputters.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/client/CMakeLists.txt
+++ b/src/lib/client/CMakeLists.txt
@@ -1,11 +1,11 @@
 # barrier -- mouse and keyboard sharing utility
 # Copyright (C) 2012-2016 Symless Ltd.
 # Copyright (C) 2009 Nick Bolton
-# 
+#
 # This package is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # found in the file LICENSE that should have accompanied this file.
-# 
+#
 # This package is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/client/Client.cpp
+++ b/src/lib/client/Client.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -134,11 +134,11 @@ Client::connect()
         // being shuttled between various networks).  patch by Brent
         // Priddy.
         m_serverAddress.resolve();
-        
+
         // m_serverAddress will be null if the hostname address is not reolved
         if (m_serverAddress.getAddress() != NULL) {
           // to help users troubleshoot, show server host name (issue: 60)
-          LOG((CLOG_NOTE "connecting to '%s': %s:%i", 
+          LOG((CLOG_NOTE "connecting to '%s': %s:%i",
           m_serverAddress.getHostname().c_str(),
           ARCH->addrToString(m_serverAddress.getAddress()).c_str(),
           m_serverAddress.getPort()));
@@ -255,7 +255,7 @@ Client::leave()
     m_active = false;
 
     m_screen->leave();
-    
+
     if (m_enableClipboard) {
         // send clipboards that we own and that have changed
         for (ClipboardID id = 0; id < kClipboardEnd; ++id) {
@@ -775,7 +775,7 @@ Client::writeToDropDirThread(void*)
     while (m_screen->isFakeDraggingStarted()) {
         ARCH->sleep(.1f);
     }
-    
+
     DropHelper::writeToDir(m_screen->getDropTarget(), m_dragFileList,
                     m_receivedFileData);
 }
@@ -790,7 +790,7 @@ Client::dragInfoReceived(UInt32 fileNum, std::string data)
     }
 
     DragInformation::parseDragInfo(m_dragFileList, fileNum, data);
-    
+
     m_screen->startDraggingFiles(m_dragFileList);
 }
 
@@ -806,7 +806,7 @@ Client::sendFileToServer(const char* filename)
     if (m_sendFileThread != NULL) {
         StreamChunker::interruptFile();
     }
-    
+
     m_sendFileThread = new Thread(
         new TMethodJob<Client>(
             this, &Client::sendFileThread,

--- a/src/lib/client/Client.h
+++ b/src/lib/client/Client.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -90,11 +90,11 @@ public:
 
     //! Create a new thread and use it to send file to Server
     void                sendFileToServer(const char* filename);
-    
+
     //! Send dragging file information back to server
     void sendDragInfo(UInt32 fileCount, std::string& info, size_t size);
 
-    
+
     //@}
     //! @name accessors
     //@{
@@ -118,7 +118,7 @@ public:
     to connect) to.
     */
     NetworkAddress        getServerAddress() const;
-    
+
     //! Return true if recieved file size is valid
     bool                isReceivedFileSizeValid();
 

--- a/src/lib/client/ServerProxy.cpp
+++ b/src/lib/client/ServerProxy.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -553,7 +553,7 @@ ServerProxy::setClipboard()
     static std::string dataCached;
     ClipboardID id;
     UInt32 seq;
-    
+
     int r = ClipboardChunk::assemble(m_stream, dataCached, id, seq);
 
     if (r == kStart) {
@@ -562,7 +562,7 @@ ServerProxy::setClipboard()
     }
     else if (r == kFinish) {
         LOG((CLOG_DEBUG "received clipboard %d size=%d", id, dataCached.size()));
-        
+
         // forward
         Clipboard clipboard;
         clipboard.unmarshall(dataCached, 0);

--- a/src/lib/client/ServerProxy.h
+++ b/src/lib/client/ServerProxy.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -58,7 +58,7 @@ public:
 
     // sending dragging information to server
     void                sendDragInfo(UInt32 fileCount, const char* info, size_t size);
-    
+
 #ifdef BARRIER_TEST_ENV
     void                handleDataForTest() { handleData(Event(), NULL); }
 #endif

--- a/src/lib/common/CMakeLists.txt
+++ b/src/lib/common/CMakeLists.txt
@@ -1,11 +1,11 @@
 # barrier -- mouse and keyboard sharing utility
 # Copyright (C) 2012-2016 Symless Ltd.
 # Copyright (C) 2009 Nick Bolton
-# 
+#
 # This package is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # found in the file LICENSE that should have accompanied this file.
-# 
+#
 # This package is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/common/IInterface.h
+++ b/src/lib/common/IInterface.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/common/MacOSXPrecomp.h
+++ b/src/lib/common/MacOSXPrecomp.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
- 
+
  //
 // Prefix header for all source files of the 'deleteme' target in the 'deleteme' project.
 //

--- a/src/lib/common/Version.cpp
+++ b/src/lib/common/Version.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/common/Version.h
+++ b/src/lib/common/Version.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/common/basic_types.h
+++ b/src/lib/common/basic_types.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/common/common.h
+++ b/src/lib/common/common.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/common/stdbitset.h
+++ b/src/lib/common/stdbitset.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/common/stddeque.h
+++ b/src/lib/common/stddeque.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/common/stdfstream.h
+++ b/src/lib/common/stdfstream.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/common/stdistream.h
+++ b/src/lib/common/stdistream.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/common/stdlist.h
+++ b/src/lib/common/stdlist.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/common/stdmap.h
+++ b/src/lib/common/stdmap.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/common/stdostream.h
+++ b/src/lib/common/stdostream.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/common/stdpost.h
+++ b/src/lib/common/stdpost.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/common/stdpre.h
+++ b/src/lib/common/stdpre.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/common/stdset.h
+++ b/src/lib/common/stdset.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/common/stdsstream.h
+++ b/src/lib/common/stdsstream.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/common/stdstring.h
+++ b/src/lib/common/stdstring.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/common/stdvector.h
+++ b/src/lib/common/stdvector.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/io/CMakeLists.txt
+++ b/src/lib/io/CMakeLists.txt
@@ -1,11 +1,11 @@
 # barrier -- mouse and keyboard sharing utility
 # Copyright (C) 2012-2016 Symless Ltd.
 # Copyright (C) 2009 Nick Bolton
-# 
+#
 # This package is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # found in the file LICENSE that should have accompanied this file.
-# 
+#
 # This package is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/io/IStream.h
+++ b/src/lib/io/IStream.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/io/StreamBuffer.cpp
+++ b/src/lib/io/StreamBuffer.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/io/StreamBuffer.h
+++ b/src/lib/io/StreamBuffer.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/io/StreamFilter.cpp
+++ b/src/lib/io/StreamFilter.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/io/StreamFilter.h
+++ b/src/lib/io/StreamFilter.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/io/XIO.cpp
+++ b/src/lib/io/XIO.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/io/XIO.h
+++ b/src/lib/io/XIO.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/ipc/CMakeLists.txt
+++ b/src/lib/ipc/CMakeLists.txt
@@ -1,11 +1,11 @@
 # barrier -- mouse and keyboard sharing utility
 # Copyright (C) 2012-2016 Symless Ltd.
 # Copyright (C) 2009 Nick Bolton
-# 
+#
 # This package is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # found in the file LICENSE that should have accompanied this file.
-# 
+#
 # This package is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/ipc/Ipc.h
+++ b/src/lib/ipc/Ipc.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2012 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/ipc/IpcClient.cpp
+++ b/src/lib/ipc/IpcClient.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2012 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/ipc/IpcClient.h
+++ b/src/lib/ipc/IpcClient.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2012 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -42,7 +42,7 @@ public:
 
     //! Connects to the IPC server at localhost.
     void                connect();
-    
+
     //! Disconnects from the IPC server.
     void                disconnect();
 

--- a/src/lib/ipc/IpcClientProxy.cpp
+++ b/src/lib/ipc/IpcClientProxy.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2012 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -67,7 +67,7 @@ IpcClientProxy::~IpcClientProxy()
         m_events->forIStream().inputShutdown(), m_stream.getEventTarget());
     m_events->removeHandler(
         m_events->forIStream().outputShutdown(), m_stream.getEventTarget());
-    
+
     // don't delete the stream while it's being used.
     {
         std::lock_guard<std::mutex> lock_read(m_readMutex);
@@ -145,7 +145,7 @@ IpcClientProxy::send(const IpcMessage& message)
         ProtocolUtil::writef(&m_stream, kIpcMsgLogLine, &logLine);
         break;
     }
-            
+
     case kIpcShutdown:
         ProtocolUtil::writef(&m_stream, kIpcMsgShutdown);
         break;

--- a/src/lib/ipc/IpcClientProxy.h
+++ b/src/lib/ipc/IpcClientProxy.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2012 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -46,7 +46,7 @@ private:
     IpcHelloMessage*    parseHello();
     IpcCommandMessage*    parseCommand();
     void                disconnect();
-    
+
 private:
     barrier::IStream&    m_stream;
     EIpcClientType        m_clientType;

--- a/src/lib/ipc/IpcLogOutputter.cpp
+++ b/src/lib/ipc/IpcLogOutputter.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2012 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/ipc/IpcLogOutputter.h
+++ b/src/lib/ipc/IpcLogOutputter.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2012 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -50,7 +50,7 @@ public:
     virtual void        close();
     virtual void        show(bool showIfEmpty);
     virtual bool        write(ELevel level, const char* message);
-    
+
     //! @name manipulators
     //@{
 
@@ -76,18 +76,18 @@ public:
     when threaded mode is on.
     */
     void                sendBuffer();
-    
+
     //@}
-    
+
     //! @name accessors
     //@{
-    
+
     //! Get the buffer size
     /*!
     Returns the maximum size of the buffer.
     */
     UInt16                bufferMaxSize() const;
-    
+
     //@}
 
 private:

--- a/src/lib/ipc/IpcMessage.cpp
+++ b/src/lib/ipc/IpcMessage.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2012 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/ipc/IpcMessage.h
+++ b/src/lib/ipc/IpcMessage.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2012 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/ipc/IpcServer.cpp
+++ b/src/lib/ipc/IpcServer.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2012 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/ipc/IpcServer.h
+++ b/src/lib/ipc/IpcServer.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2012 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -73,7 +73,7 @@ private:
 
 private:
     typedef std::list<IpcClientProxy*> ClientList;
-    
+
     bool                m_mock;
     IEventQueue*        m_events;
     SocketMultiplexer*    m_socketMultiplexer;

--- a/src/lib/ipc/IpcServerProxy.cpp
+++ b/src/lib/ipc/IpcServerProxy.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2012 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -56,7 +56,7 @@ IpcServerProxy::handleData(const Event&, void*)
 
         LOG((CLOG_DEBUG "ipc read: %c%c%c%c",
             code[0], code[1], code[2], code[3]));
-        
+
         IpcMessage* m = nullptr;
         if (memcmp(code, kIpcMsgLogLine, 4) == 0) {
             m = parseLogLine();
@@ -68,7 +68,7 @@ IpcServerProxy::handleData(const Event&, void*)
             LOG((CLOG_ERR "invalid ipc message"));
             disconnect();
         }
-        
+
         // don't delete with this event; the data is passed to a new event.
         Event e(m_events->forIpcServerProxy().messageReceived(), this, NULL, Event::kDontFreeData);
         e.setDataObject(m);
@@ -76,7 +76,7 @@ IpcServerProxy::handleData(const Event&, void*)
 
         n = m_stream.read(code, 4);
     }
-    
+
     LOG((CLOG_DEBUG "finished ipc handle data"));
 }
 
@@ -110,7 +110,7 @@ IpcServerProxy::parseLogLine()
 {
     std::string logLine;
     ProtocolUtil::readf(&m_stream, kIpcMsgLogLine + 4, &logLine);
-    
+
     // must be deleted by event handler.
     return new IpcLogLineMessage(logLine);
 }

--- a/src/lib/ipc/IpcServerProxy.h
+++ b/src/lib/ipc/IpcServerProxy.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2012 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/mt/CMakeLists.txt
+++ b/src/lib/mt/CMakeLists.txt
@@ -1,11 +1,11 @@
 # barrier -- mouse and keyboard sharing utility
 # Copyright (C) 2012-2016 Symless Ltd.
 # Copyright (C) 2009 Nick Bolton
-# 
+#
 # This package is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # found in the file LICENSE that should have accompanied this file.
-# 
+#
 # This package is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/mt/CondVar.cpp
+++ b/src/lib/mt/CondVar.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -24,7 +24,7 @@
 // CondVarBase
 //
 
-CondVarBase::CondVarBase(Mutex* mutex) : 
+CondVarBase::CondVarBase(Mutex* mutex) :
     m_mutex(mutex)
 {
     assert(m_mutex != NULL);

--- a/src/lib/mt/CondVar.h
+++ b/src/lib/mt/CondVar.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -78,7 +78,7 @@ public:
     signalled, otherwise up to \c timeout seconds or until signalled,
     whichever comes first.    Returns true if the object was signalled
     during the wait, false otherwise.
-    
+
     The proper way to wait for a condition is:
     \code
     cv.lock();

--- a/src/lib/mt/Lock.cpp
+++ b/src/lib/mt/Lock.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/mt/Lock.h
+++ b/src/lib/mt/Lock.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/mt/Mutex.cpp
+++ b/src/lib/mt/Mutex.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/mt/Mutex.h
+++ b/src/lib/mt/Mutex.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/mt/Thread.cpp
+++ b/src/lib/mt/Thread.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/mt/Thread.h
+++ b/src/lib/mt/Thread.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -98,7 +98,7 @@ public:
     enabled.  If cancellation is disabled then the cancel is
     remembered but not acted on until the first call to a
     cancellation point after cancellation is enabled.
-    
+
     A cancellation point is a function that can act on cancellation.
     A cancellation point does not return if there's a cancel pending.
     Instead, it unwinds the stack and destroys automatic objects, as
@@ -110,7 +110,7 @@ public:
     objects (like Lock).  Clients are strongly encouraged to do the latter.
     During cancellation, further cancel() calls are ignored (i.e.
     a thread cannot be interrupted by a cancel during cancellation).
-    
+
     Clients that \c catch(XThreadCancel) must always rethrow the
     exception.  Clients that \c catch(...) must either rethrow the
     exception or include a \c catch(XThreadCancel) handler that

--- a/src/lib/mt/XMT.cpp
+++ b/src/lib/mt/XMT.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/mt/XMT.h
+++ b/src/lib/mt/XMT.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/mt/XThread.h
+++ b/src/lib/mt/XThread.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/net/CMakeLists.txt
+++ b/src/lib/net/CMakeLists.txt
@@ -1,11 +1,11 @@
 # barrier -- mouse and keyboard sharing utility
 # Copyright (C) 2012-2016 Symless Ltd.
 # Copyright (C) 2009 Nick Bolton
-# 
+#
 # This package is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # found in the file LICENSE that should have accompanied this file.
-# 
+#
 # This package is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/net/IDataSocket.cpp
+++ b/src/lib/net/IDataSocket.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/net/IDataSocket.h
+++ b/src/lib/net/IDataSocket.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/net/IListenSocket.h
+++ b/src/lib/net/IListenSocket.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -41,7 +41,7 @@ public:
     */
     virtual IDataSocket*
                         accept() = 0;
-    
+
     //@}
 
     // ISocket overrides

--- a/src/lib/net/ISocket.h
+++ b/src/lib/net/ISocket.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/net/ISocketFactory.h
+++ b/src/lib/net/ISocketFactory.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/net/ISocketMultiplexerJob.h
+++ b/src/lib/net/ISocketMultiplexerJob.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/net/NetworkAddress.cpp
+++ b/src/lib/net/NetworkAddress.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/net/NetworkAddress.h
+++ b/src/lib/net/NetworkAddress.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/net/SecureListenSocket.cpp
+++ b/src/lib/net/SecureListenSocket.cpp
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2015-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/net/SecureListenSocket.h
+++ b/src/lib/net/SecureListenSocket.h
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2015-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2015-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -133,7 +133,7 @@ std::unique_ptr<ISocketMultiplexerJob> SecureSocket::newJob()
     if (m_connected && !m_secureReady) {
         return {};
     }
-    
+
     return TCPSocket::newJob();
 }
 
@@ -173,20 +173,20 @@ SecureSocket::doRead()
     else {
         return kRetry;
     }
-    
+
     if (bytesRead > 0) {
         bool wasEmpty = (m_inputBuffer.getSize() == 0);
-        
+
         // slurp up as much as possible
         do {
             m_inputBuffer.write(buffer, bytesRead);
-            
+
             status = secureRead(buffer, sizeof(buffer), bytesRead);
             if (status < 0) {
                 return kBreak;
             }
         } while (bytesRead > 0 || status > 0);
-        
+
         // send input ready if input buffer was empty
         if (wasEmpty) {
             sendEvent(m_events->forIStream().inputReady());
@@ -204,7 +204,7 @@ SecureSocket::doRead()
         m_readable = false;
         return kNew;
     }
-    
+
     return kRetry;
 }
 
@@ -236,7 +236,7 @@ SecureSocket::doWrite()
             memcpy(s_staticBuffer.get(), m_outputBuffer.peek(bufferSize), bufferSize);
         }
     }
-    
+
     if (bufferSize == 0) {
         return kRetry;
     }
@@ -251,7 +251,7 @@ SecureSocket::doWrite()
         s_retrySize = bufferSize;
         return kNew;
     }
-    
+
     if (bytesWrote > 0) {
         discardWrittenData(bytesWrote);
         return kNew;
@@ -266,12 +266,12 @@ SecureSocket::secureRead(void* buffer, int size, int& read)
     if (m_ssl->m_ssl != NULL) {
         LOG((CLOG_DEBUG2 "reading secure socket"));
         read = SSL_read(m_ssl->m_ssl, buffer, size);
-        
+
         static int retry;
 
         // Check result will cleanup the connection in the case of a fatal
         checkResult(read, retry);
-        
+
         if (retry) {
             return 0;
         }
@@ -293,7 +293,7 @@ SecureSocket::secureWrite(const void* buffer, int size, int& wrote)
         LOG((CLOG_DEBUG2 "writing secure socket:%p", this));
 
         wrote = SSL_write(m_ssl->m_ssl, buffer, size);
-        
+
         static int retry;
 
         // Check result will cleanup the connection in the case of a fatal
@@ -374,7 +374,7 @@ SecureSocket::initContext(bool server)
     SSL_library_init();
 
     const SSL_METHOD* method;
- 
+
     // load & register all cryptos, etc.
     OpenSSL_add_all_algorithms();
 
@@ -392,7 +392,7 @@ SecureSocket::initContext(bool server)
     else {
         method = SSLv23_client_method();
     }
-    
+
     // create new context from method
     SSL_METHOD* m = const_cast<SSL_METHOD*>(method);
     m_ssl->m_context = SSL_CTX_new(m);
@@ -423,10 +423,10 @@ SecureSocket::secureAccept(int socket)
 
     // set connection socket to SSL state
     SSL_set_fd(m_ssl->m_ssl, socket);
-    
+
     LOG((CLOG_DEBUG2 "accepting secure socket"));
     int r = SSL_accept(m_ssl->m_ssl);
-    
+
     static int retry;
 
     checkResult(r, retry);
@@ -472,10 +472,10 @@ SecureSocket::secureConnect(int socket)
 
     // attach the socket descriptor
     SSL_set_fd(m_ssl->m_ssl, socket);
-    
+
     LOG((CLOG_DEBUG2 "connecting secure socket"));
     int r = SSL_connect(m_ssl->m_ssl);
-    
+
     static int retry;
 
     checkResult(r, retry);
@@ -522,7 +522,7 @@ SecureSocket::showCertificate()
 {
     X509* cert;
     char* line;
- 
+
     // get the server's certificate
     cert = SSL_get_peer_certificate(m_ssl->m_ssl);
     if (cert != NULL) {
@@ -566,7 +566,7 @@ SecureSocket::checkResult(int status, int& retry)
 
     case SSL_ERROR_WANT_WRITE:
         // Need to make sure the socket is known to be writable so the impending
-        // select action actually triggers on a write. This isn't necessary for 
+        // select action actually triggers on a write. This isn't necessary for
         // m_readable because the socket logic is always readable
         m_writable = true;
         retry++;

--- a/src/lib/net/SecureSocket.h
+++ b/src/lib/net/SecureSocket.h
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2015-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -43,7 +43,7 @@ public:
 
     // IDataSocket overrides
     virtual void        connect(const NetworkAddress&) override;
-    
+
     std::unique_ptr<ISocketMultiplexerJob> newJob() override;
     bool                isFatal() const override { return m_fatal; }
     void                isFatal(bool b) { m_fatal = b; }
@@ -77,7 +77,7 @@ private:
     void                showSecureConnectInfo();
     void                showSecureLibInfo();
     void                showSecureCipherInfo();
-    
+
     void                handleTCPConnected(const Event& event, void*);
 
     void freeSSLResources();

--- a/src/lib/net/SocketMultiplexer.cpp
+++ b/src/lib/net/SocketMultiplexer.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -179,7 +179,7 @@ SocketMultiplexer::serviceThread(void*)
                         pfd.m_events |= IArchNetwork::kPOLLOUT;
                     }
                     pfds.push_back(pfd);
-                }                
+                }
                 jobCursor = nextCursor(cursor);
             }
             deleteCursor(cursor);

--- a/src/lib/net/SocketMultiplexer.h
+++ b/src/lib/net/SocketMultiplexer.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/net/TCPListenSocket.cpp
+++ b/src/lib/net/TCPListenSocket.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/net/TCPListenSocket.h
+++ b/src/lib/net/TCPListenSocket.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/net/TCPSocket.cpp
+++ b/src/lib/net/TCPSocket.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -335,19 +335,19 @@ TCPSocket::doRead()
     UInt8 buffer[4096];
     memset(buffer, 0, sizeof(buffer));
     size_t bytesRead = 0;
-    
+
     bytesRead = ARCH->readSocket(m_socket, buffer, sizeof(buffer));
-    
+
     if (bytesRead > 0) {
         bool wasEmpty = (m_inputBuffer.getSize() == 0);
-        
+
         // slurp up as much as possible
         do {
             m_inputBuffer.write(buffer, (UInt32)bytesRead);
 
             bytesRead = ARCH->readSocket(m_socket, buffer, sizeof(buffer));
         } while (bytesRead > 0);
-        
+
         // send input ready if input buffer was empty
         if (wasEmpty) {
             sendEvent(m_events->forIStream().inputReady());
@@ -365,7 +365,7 @@ TCPSocket::doRead()
         m_readable = false;
         return kNew;
     }
-    
+
     return kRetry;
 }
 
@@ -384,7 +384,7 @@ TCPSocket::doWrite()
         discardWrittenData(bytesWrote);
         return kNew;
     }
-    
+
     return kRetry;
 }
 

--- a/src/lib/net/TCPSocket.h
+++ b/src/lib/net/TCPSocket.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -59,7 +59,7 @@ public:
     // IDataSocket overrides
     virtual void        connect(const NetworkAddress&);
 
-    
+
     virtual std::unique_ptr<ISocketMultiplexerJob> newJob();
 
 protected:
@@ -68,7 +68,7 @@ protected:
         kRetry,            //!< Retry the same job
         kNew            //!< Require a new job
     };
-    
+
     ArchSocket            getSocket() { return m_socket; }
     IEventQueue*        getEvents() { return m_events; }
     virtual EJobResult    doRead();
@@ -105,7 +105,7 @@ protected:
     IEventQueue*        m_events;
     StreamBuffer        m_inputBuffer;
     StreamBuffer        m_outputBuffer;
-    
+
 private:
     Mutex                m_mutex;
     ArchSocket            m_socket;

--- a/src/lib/net/TCPSocketFactory.cpp
+++ b/src/lib/net/TCPSocketFactory.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/net/TCPSocketFactory.h
+++ b/src/lib/net/TCPSocketFactory.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/net/TSocketMultiplexerMethodJob.h
+++ b/src/lib/net/TSocketMultiplexerMethodJob.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/net/XSocket.cpp
+++ b/src/lib/net/XSocket.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -63,7 +63,7 @@ std::string XSocketAddress::getWhat() const noexcept
         "invalid port"                // m_port may not be set to the bad port
     };
     return format(s_errorID[m_error], s_errorMsg[m_error],
-                                m_hostname.c_str(), 
+                                m_hostname.c_str(),
                                 barrier::string::sprintf("%d", m_port).c_str());
 }
 

--- a/src/lib/net/XSocket.h
+++ b/src/lib/net/XSocket.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/CMakeLists.txt
+++ b/src/lib/platform/CMakeLists.txt
@@ -1,11 +1,11 @@
 # barrier -- mouse and keyboard sharing utility
 # Copyright (C) 2012-2016 Symless Ltd.
 # Copyright (C) 2009 Nick Bolton
-# 
+#
 # This package is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # found in the file LICENSE that should have accompanied this file.
-# 
+#
 # This package is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/IMSWindowsClipboardFacade.h
+++ b/src/lib/platform/IMSWindowsClipboardFacade.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/IOSXKeyResource.cpp
+++ b/src/lib/platform/IOSXKeyResource.cpp
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -128,7 +128,7 @@ IOSXKeyResource::getKeyID(UInt8 c)
         // encoding with char value 214).  if it did then make no key,
         // otherwise CFStringCreateMutableCopy() will crash.
         if (cfString == NULL) {
-            return kKeyNone; 
+            return kKeyNone;
         }
 
         // convert to precomposed

--- a/src/lib/platform/IOSXKeyResource.h
+++ b/src/lib/platform/IOSXKeyResource.h
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -27,10 +27,10 @@ public:
     virtual UInt32    getNumButtons() const = 0;
     virtual UInt32    getTableForModifier(UInt32 mask) const = 0;
     virtual KeyID    getKey(UInt32 table, UInt32 button) const = 0;
-    
+
     // Convert a character in the current script to the equivalent KeyID
     static KeyID    getKeyID(UInt8);
-    
+
     // Convert a unicode character to the equivalent KeyID.
     static KeyID    unicharToKeyID(UniChar);
 };

--- a/src/lib/platform/MSWindowsClipboard.cpp
+++ b/src/lib/platform/MSWindowsClipboard.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -70,7 +70,7 @@ MSWindowsClipboard::emptyUnowned()
 
     // empty the clipboard (and take ownership)
     if (!EmptyClipboard()) {
-        // unable to cause this in integ tests, but this error has never 
+        // unable to cause this in integ tests, but this error has never
         // actually been reported by users.
         LOG((CLOG_DEBUG "failed to grab clipboard"));
         return false;

--- a/src/lib/platform/MSWindowsClipboard.h
+++ b/src/lib/platform/MSWindowsClipboard.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/MSWindowsClipboardAnyTextConverter.cpp
+++ b/src/lib/platform/MSWindowsClipboardAnyTextConverter.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/MSWindowsClipboardAnyTextConverter.h
+++ b/src/lib/platform/MSWindowsClipboardAnyTextConverter.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/MSWindowsClipboardBitmapConverter.cpp
+++ b/src/lib/platform/MSWindowsClipboardBitmapConverter.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/MSWindowsClipboardBitmapConverter.h
+++ b/src/lib/platform/MSWindowsClipboardBitmapConverter.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/MSWindowsClipboardFacade.cpp
+++ b/src/lib/platform/MSWindowsClipboardFacade.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/MSWindowsClipboardFacade.h
+++ b/src/lib/platform/MSWindowsClipboardFacade.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/MSWindowsClipboardHTMLConverter.cpp
+++ b/src/lib/platform/MSWindowsClipboardHTMLConverter.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/MSWindowsClipboardHTMLConverter.h
+++ b/src/lib/platform/MSWindowsClipboardHTMLConverter.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/MSWindowsClipboardTextConverter.cpp
+++ b/src/lib/platform/MSWindowsClipboardTextConverter.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/MSWindowsClipboardTextConverter.h
+++ b/src/lib/platform/MSWindowsClipboardTextConverter.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/MSWindowsClipboardUTF16Converter.cpp
+++ b/src/lib/platform/MSWindowsClipboardUTF16Converter.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/MSWindowsClipboardUTF16Converter.h
+++ b/src/lib/platform/MSWindowsClipboardUTF16Converter.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/MSWindowsDebugOutputter.cpp
+++ b/src/lib/platform/MSWindowsDebugOutputter.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2012 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/MSWindowsDebugOutputter.h
+++ b/src/lib/platform/MSWindowsDebugOutputter.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2012 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
- 
+
 #pragma once
 
 #include "base/ILogOutputter.h"

--- a/src/lib/platform/MSWindowsDesks.cpp
+++ b/src/lib/platform/MSWindowsDesks.cpp
@@ -3,11 +3,11 @@
  * Copyright (C) 2018 Debauchee Open Source Group
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -793,7 +793,7 @@ MSWindowsDesks::checkDesk()
         desk = index->second;
     }
 
-    // if we are told to shut down on desk switch, and this is not the 
+    // if we are told to shut down on desk switch, and this is not the
     // first switch, then shut down.
     if (m_stopOnDeskSwitch && m_activeDesk != NULL && name != m_activeDeskName) {
         LOG((CLOG_DEBUG "shutting down because of desk switch to \"%s\"", name.c_str()));

--- a/src/lib/platform/MSWindowsDesks.h
+++ b/src/lib/platform/MSWindowsDesks.h
@@ -3,11 +3,11 @@
  * Copyright (C) 2018 Debauchee Open Source Group
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/MSWindowsDropTarget.cpp
+++ b/src/lib/platform/MSWindowsDropTarget.cpp
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2014-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -53,7 +53,7 @@ MSWindowsDropTarget::DragEnter(IDataObject* dataObject, DWORD keyState, POINTL p
     if (m_allowDrop) {
         getDropData(dataObject);
     }
-    
+
     *effect = DROPEFFECT_NONE;
 
     return S_OK;
@@ -132,7 +132,7 @@ getDropData(IDataObject* dataObject)
             wcstombs(filename, wcData, wcslen(wcData));
 
             MSWindowsDropTarget::instance().setDraggingFilename(filename);
-            
+
             GlobalUnlock(stgMed.hGlobal);
 
             // release the data using the COM API
@@ -167,7 +167,7 @@ ULONG __stdcall
 MSWindowsDropTarget::Release(void)
 {
     LONG count = InterlockedDecrement(&m_refCount);
-        
+
     if (count == 0) {
         delete this;
         return 0;

--- a/src/lib/platform/MSWindowsDropTarget.h
+++ b/src/lib/platform/MSWindowsDropTarget.h
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2014-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -44,7 +44,7 @@ public:
     std::string            getDraggingFilename();
     void                clearDraggingFilename();
 
-    static MSWindowsDropTarget& 
+    static MSWindowsDropTarget&
                         instance();
 
 private:
@@ -53,7 +53,7 @@ private:
     long                m_refCount;
     bool                m_allowDrop;
     std::string            m_dragFilename;
-    
+
     static MSWindowsDropTarget*
                         s_instance;
 };

--- a/src/lib/platform/MSWindowsEventQueueBuffer.cpp
+++ b/src/lib/platform/MSWindowsEventQueueBuffer.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/MSWindowsEventQueueBuffer.h
+++ b/src/lib/platform/MSWindowsEventQueueBuffer.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/MSWindowsHook.cpp
+++ b/src/lib/platform/MSWindowsHook.cpp
@@ -3,11 +3,11 @@
  * Copyright (C) 2018 Debauchee Open Source Group
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2011 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/MSWindowsHook.h
+++ b/src/lib/platform/MSWindowsHook.h
@@ -3,11 +3,11 @@
  * Copyright (C) 2018 Debauchee Open Source Group
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2011 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/MSWindowsKeyState.cpp
+++ b/src/lib/platform/MSWindowsKeyState.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2003 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -68,10 +68,10 @@ const KeyID				MSWindowsKeyState::s_virtualKey[] =
 	/* 0x019 */ { kKeyKanzi },		// VK_HANJA, VK_KANJI
 	/* 0x01a */ { kKeyNone },		// undefined
 	/* 0x01b */ { kKeyEscape },		// VK_ESCAPE
-	/* 0x01c */ { kKeyHenkan },		// VK_CONVERT		
-	/* 0x01d */ { kKeyMuhenkan },	// VK_NONCONVERT	
-	/* 0x01e */ { kKeyNone },		// VK_ACCEPT		
-	/* 0x01f */ { kKeyNone },		// VK_MODECHANGE	
+	/* 0x01c */ { kKeyHenkan },		// VK_CONVERT
+	/* 0x01d */ { kKeyMuhenkan },	// VK_NONCONVERT
+	/* 0x01e */ { kKeyNone },		// VK_ACCEPT
+	/* 0x01f */ { kKeyNone },		// VK_MODECHANGE
 	/* 0x020 */ { kKeyNone },		// VK_SPACE
 	/* 0x021 */ { kKeyKP_PageUp },	// VK_PRIOR
 	/* 0x022 */ { kKeyKP_PageDown },// VK_NEXT
@@ -286,15 +286,15 @@ const KeyID				MSWindowsKeyState::s_virtualKey[] =
 	/* 0x0f3 */ { kKeyZenkaku },	// VK_OEM_AUTO
 	/* 0x0f4 */ { kKeyZenkaku },	// VK_OEM_ENLW
 	/* 0x0f5 */ { kKeyNone },		// OEM specific
-	/* 0x0f6 */ { kKeyNone },		// VK_ATTN			
-	/* 0x0f7 */ { kKeyNone },		// VK_CRSEL			
-	/* 0x0f8 */ { kKeyNone },		// VK_EXSEL			
-	/* 0x0f9 */ { kKeyNone },		// VK_EREOF			
-	/* 0x0fa */ { kKeyNone },		// VK_PLAY			
-	/* 0x0fb */ { kKeyNone },		// VK_ZOOM			
+	/* 0x0f6 */ { kKeyNone },		// VK_ATTN
+	/* 0x0f7 */ { kKeyNone },		// VK_CRSEL
+	/* 0x0f8 */ { kKeyNone },		// VK_EXSEL
+	/* 0x0f9 */ { kKeyNone },		// VK_EREOF
+	/* 0x0fa */ { kKeyNone },		// VK_PLAY
+	/* 0x0fb */ { kKeyNone },		// VK_ZOOM
 	/* 0x0fc */ { kKeyNone },		// reserved
-	/* 0x0fd */ { kKeyNone },		// VK_PA1			
-	/* 0x0fe */ { kKeyNone },		// VK_OEM_CLEAR		
+	/* 0x0fd */ { kKeyNone },		// VK_PA1
+	/* 0x0fe */ { kKeyNone },		// VK_OEM_CLEAR
 	/* 0x0ff */ { kKeyNone },		// reserved
 
 	/* 0x100 */ { kKeyNone },		// reserved
@@ -320,15 +320,15 @@ const KeyID				MSWindowsKeyState::s_virtualKey[] =
 	/* 0x114 */ { kKeyNone },		// VK_CAPITAL
 	/* 0x115 */ { kKeyHangul },		// VK_HANGUL
 	/* 0x116 */ { kKeyNone },		// undefined
-	/* 0x117 */ { kKeyNone },		// VK_JUNJA			
-	/* 0x118 */ { kKeyNone },		// VK_FINAL			
+	/* 0x117 */ { kKeyNone },		// VK_JUNJA
+	/* 0x118 */ { kKeyNone },		// VK_FINAL
 	/* 0x119 */ { kKeyHanja },		// VK_HANJA
 	/* 0x11a */ { kKeyNone },		// undefined
 	/* 0x11b */ { kKeyNone },		// VK_ESCAPE
-	/* 0x11c */ { kKeyNone },		// VK_CONVERT		
-	/* 0x11d */ { kKeyNone },		// VK_NONCONVERT	
-	/* 0x11e */ { kKeyNone },		// VK_ACCEPT		
-	/* 0x11f */ { kKeyNone },		// VK_MODECHANGE	
+	/* 0x11c */ { kKeyNone },		// VK_CONVERT
+	/* 0x11d */ { kKeyNone },		// VK_NONCONVERT
+	/* 0x11e */ { kKeyNone },		// VK_ACCEPT
+	/* 0x11f */ { kKeyNone },		// VK_MODECHANGE
 	/* 0x120 */ { kKeyNone },		// VK_SPACE
 	/* 0x121 */ { kKeyPageUp },		// VK_PRIOR
 	/* 0x122 */ { kKeyPageDown },	// VK_NEXT
@@ -543,15 +543,15 @@ const KeyID				MSWindowsKeyState::s_virtualKey[] =
 	/* 0x1f3 */ { kKeyNone },		// VK_OEM_AUTO
 	/* 0x1f4 */ { kKeyNone },		// VK_OEM_ENLW
 	/* 0x1f5 */ { kKeyNone },		// OEM specific
-	/* 0x1f6 */ { kKeyNone },		// VK_ATTN			
-	/* 0x1f7 */ { kKeyNone },		// VK_CRSEL			
-	/* 0x1f8 */ { kKeyNone },		// VK_EXSEL			
-	/* 0x1f9 */ { kKeyNone },		// VK_EREOF			
-	/* 0x1fa */ { kKeyNone },		// VK_PLAY			
-	/* 0x1fb */ { kKeyNone },		// VK_ZOOM			
+	/* 0x1f6 */ { kKeyNone },		// VK_ATTN
+	/* 0x1f7 */ { kKeyNone },		// VK_CRSEL
+	/* 0x1f8 */ { kKeyNone },		// VK_EXSEL
+	/* 0x1f9 */ { kKeyNone },		// VK_EREOF
+	/* 0x1fa */ { kKeyNone },		// VK_PLAY
+	/* 0x1fb */ { kKeyNone },		// VK_ZOOM
 	/* 0x1fc */ { kKeyNone },		// reserved
-	/* 0x1fd */ { kKeyNone },		// VK_PA1			
-	/* 0x1fe */ { kKeyNone },		// VK_OEM_CLEAR		
+	/* 0x1fd */ { kKeyNone },		// VK_PA1
+	/* 0x1fe */ { kKeyNone },		// VK_OEM_CLEAR
 	/* 0x1ff */ { kKeyNone }		// reserved
 };
 
@@ -959,7 +959,7 @@ MSWindowsKeyState::getKeyMap(barrier::KeyMap& keyMap)
 			// deal with certain virtual keys specially
 			switch (vk) {
 			case VK_SHIFT:
-				// this is important for sending the correct modifier to the 
+				// this is important for sending the correct modifier to the
 				// client, a patch from bug #242 (right shift broken for ms
 				// remote desktop) removed this to just use left shift, which
 				// caused bug #2799 (right shift broken for osx).
@@ -1176,7 +1176,7 @@ MSWindowsKeyState::getKeyMap(barrier::KeyMap& keyMap)
 								}
 							}
 						}
-						
+
 						// save each key.  the map will automatically discard
 						// duplicates, like an unshift and shifted version of
 						// a key that's insensitive to shift.
@@ -1374,7 +1374,7 @@ MSWindowsKeyState::getIDForKey(barrier::KeyMap::KeyItem& item,
 		virtualKey, button, keyState, unicode,
 		sizeof(unicode) / sizeof(unicode[0]), 0, hkl);
 	KeyID id = static_cast<KeyID>(unicode[0]);
-	
+
 	switch (n) {
 	case -1:
 		return barrier::KeyMap::getDeadKey(id);

--- a/src/lib/platform/MSWindowsKeyState.h
+++ b/src/lib/platform/MSWindowsKeyState.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2003 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/MSWindowsScreen.cpp
+++ b/src/lib/platform/MSWindowsScreen.cpp
@@ -3,11 +3,11 @@
  * Copyright (C) 2018 Debauchee Open Source Group
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -145,7 +145,7 @@ MSWindowsScreen::MSWindowsScreen(
         forceShowCursor();
         LOG((CLOG_DEBUG "screen shape: %d,%d %dx%d %s", m_x, m_y, m_w, m_h, m_multimon ? "(multi-monitor)" : ""));
         LOG((CLOG_DEBUG "window is 0x%08x", m_window));
-        
+
         // SHGetFolderPath is deprecated in vista, but use it for xp support.
         char desktopPath[MAX_PATH];
         if (SUCCEEDED(SHGetFolderPath(NULL, CSIDL_DESKTOP, NULL, 0, desktopPath))) {
@@ -389,7 +389,7 @@ MSWindowsScreen::sendDragThread(void*)
         LOG((CLOG_DEBUG "send dragging file to server"));
         client->sendFileToServer(draggingFilename.c_str());
     }
-    
+
     m_draggingStarted = false;
 }
 
@@ -636,7 +636,7 @@ MSWindowsScreen::registerHotKey(KeyID key, KeyModifierMask mask)
         LOG((CLOG_WARN "failed to register hotkey %s (id=%04x mask=%04x)", barrier::KeyMap::formatKey(key, mask).c_str(), key, mask));
         return 0;
     }
-    
+
     LOG((CLOG_DEBUG "registered hotkey %s (id=%04x mask=%04x) as id=%d", barrier::KeyMap::formatKey(key, mask).c_str(), key, mask, id));
     return id;
 }
@@ -1360,7 +1360,7 @@ MSWindowsScreen::onMouseMove(SInt32 mx, SInt32 my)
     saveMousePosition(mx, my);
 
     if (m_isOnScreen) {
-        
+
         // motion on primary screen
         sendEvent(
             m_events->forIPrimaryScreen().motionOnPrimary(),
@@ -1370,15 +1370,15 @@ MSWindowsScreen::onMouseMove(SInt32 mx, SInt32 my)
             m_draggingStarted = true;
         }
     }
-    else 
+    else
     {
         // the motion is on the secondary screen, so we warp mouse back to
-        // center on the server screen. if we don't do this, then the mouse 
-        // will always try to return to the original entry point on the 
+        // center on the server screen. if we don't do this, then the mouse
+        // will always try to return to the original entry point on the
         // secondary screen.
         LOG((CLOG_DEBUG5 "warping server cursor to center: %+d,%+d", m_xCenter, m_yCenter));
         warpCursorNoFlush(m_xCenter, m_yCenter);
-        
+
         // examine the motion.  if it's about the distance
         // from the center of the screen to an edge then
         // it's probably a bogus motion that we want to
@@ -1389,7 +1389,7 @@ MSWindowsScreen::onMouseMove(SInt32 mx, SInt32 my)
              x + bogusZoneSize > m_x + m_w - m_xCenter ||
             -y + bogusZoneSize > m_yCenter - m_y ||
              y + bogusZoneSize > m_y + m_h - m_yCenter) {
-            
+
             LOG((CLOG_DEBUG "dropped bogus delta motion: %+d,%+d", x, y));
         }
         else {
@@ -1521,8 +1521,8 @@ MSWindowsScreen::warpCursorNoFlush(SInt32 x, SInt32 y)
     POINT cursorPos;
     GetCursorPos(&cursorPos);
 
-    // there is a bug or round error in SetCursorPos and GetCursorPos on 
-    // a high DPI setting. The check here is for Vista/7 login screen. 
+    // there is a bug or round error in SetCursorPos and GetCursorPos on
+    // a high DPI setting. The check here is for Vista/7 login screen.
     // since this feature is mainly for client, so only check on client.
     if (!isPrimary()) {
         if ((cursorPos.x != x) && (cursorPos.y != y)) {
@@ -1531,7 +1531,7 @@ MSWindowsScreen::warpCursorNoFlush(SInt32 x, SInt32 y)
             // when at Vista/7 login screen, SetCursorPos does not work (which could be
             // an MS security feature). instead we can use fakeMouseMove, which calls
             // mouse_event.
-            // IMPORTANT: as of implementing this function, it has an annoying side 
+            // IMPORTANT: as of implementing this function, it has an annoying side
             // effect; instead of the mouse returning to the correct exit point, it
             // returns to the center of the screen. this could have something to do with
             // the center screen warping technique used (see comments for onMouseMove

--- a/src/lib/platform/MSWindowsScreen.h
+++ b/src/lib/platform/MSWindowsScreen.h
@@ -3,11 +3,11 @@
  * Copyright (C) 2018 Debauchee Open Source Group
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -212,12 +212,12 @@ private: // HACK
 
     // our window proc
     static LRESULT CALLBACK wndProc(HWND, UINT, WPARAM, LPARAM);
-    
+
     // save last position of mouse to compute next delta movement
     void saveMousePosition(SInt32 x, SInt32 y);
 
     // check if it is a modifier key repeating message
-    bool                isModifierRepeat(KeyModifierMask oldState, 
+    bool                isModifierRepeat(KeyModifierMask oldState,
                             KeyModifierMask state, WPARAM wParam) const;
 
     // send drag info and data back to server
@@ -324,12 +324,12 @@ private:
     bool                m_gotOldMouseKeys;
     MOUSEKEYS            m_mouseKeys;
     MOUSEKEYS            m_oldMouseKeys;
-    
+
     MSWindowsHook        m_hook;
 
     static MSWindowsScreen*
                         s_screen;
-    
+
     IEventQueue*        m_events;
 
     std::string                m_desktopPath;

--- a/src/lib/platform/MSWindowsScreenSaver.cpp
+++ b/src/lib/platform/MSWindowsScreenSaver.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/MSWindowsScreenSaver.h
+++ b/src/lib/platform/MSWindowsScreenSaver.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/MSWindowsSession.cpp
+++ b/src/lib/platform/MSWindowsSession.cpp
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2013-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -45,7 +45,7 @@ MSWindowsSession::isProcessInSession(const char* name, PHANDLE process = NULL)
     PROCESSENTRY32 entry;
     entry.dwSize = sizeof(PROCESSENTRY32);
 
-    // get the first process, and if we can't do that then it's 
+    // get the first process, and if we can't do that then it's
     // unlikely we can go any further
     BOOL gotEntry = Process32First(snapshot, &entry);
     if (!gotEntry) {
@@ -119,7 +119,7 @@ MSWindowsSession::isProcessInSession(const char* name, PHANDLE process = NULL)
     }
 }
 
-HANDLE 
+HANDLE
 MSWindowsSession::getUserToken(LPSECURITY_ATTRIBUTES security)
 {
     HANDLE sourceToken;
@@ -127,7 +127,7 @@ MSWindowsSession::getUserToken(LPSECURITY_ATTRIBUTES security)
         LOG((CLOG_ERR "could not get token from session %d", m_activeSessionId));
         throw XArch(new XArchEvalWindows);
     }
-    
+
     HANDLE newToken;
     if (!DuplicateTokenEx(
         sourceToken, TOKEN_ASSIGN_PRIMARY | TOKEN_ALL_ACCESS, security,
@@ -136,7 +136,7 @@ MSWindowsSession::getUserToken(LPSECURITY_ATTRIBUTES security)
         LOG((CLOG_ERR "could not duplicate token"));
         throw XArch(new XArchEvalWindows);
     }
-    
+
     LOG((CLOG_DEBUG "duplicated, new token: %i", newToken));
     return newToken;
 }

--- a/src/lib/platform/MSWindowsSession.h
+++ b/src/lib/platform/MSWindowsSession.h
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2013-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -33,7 +33,7 @@ public:
     Returns true if the session ID has changed since updateActiveSession was called.
     */
     BOOL                hasChanged();
-    
+
     bool                isProcessInSession(const char* name, PHANDLE process);
 
     HANDLE                getUserToken(LPSECURITY_ATTRIBUTES security);

--- a/src/lib/platform/MSWindowsUtil.cpp
+++ b/src/lib/platform/MSWindowsUtil.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/MSWindowsUtil.h
+++ b/src/lib/platform/MSWindowsUtil.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/MSWindowsWatchdog.cpp
+++ b/src/lib/platform/MSWindowsWatchdog.cpp
@@ -6,7 +6,7 @@
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -81,7 +81,7 @@ MSWindowsWatchdog::MSWindowsWatchdog(
 {
 }
 
-void 
+void
 MSWindowsWatchdog::startAsync()
 {
     m_thread = new Thread(new TMethodJob<MSWindowsWatchdog>(
@@ -95,7 +95,7 @@ void
 MSWindowsWatchdog::stop()
 {
     m_monitoring = false;
-    
+
     m_thread->wait(5);
     delete m_thread;
 
@@ -117,7 +117,7 @@ MSWindowsWatchdog::duplicateProcessToken(HANDLE process, LPSECURITY_ATTRIBUTES s
         LOG((CLOG_ERR "could not open token, process handle: %d", process));
         throw XArch(new XArchEvalWindows());
     }
-    
+
     LOG((CLOG_DEBUG "got token %i, duplicating", sourceToken));
 
     HANDLE newToken;
@@ -129,22 +129,22 @@ MSWindowsWatchdog::duplicateProcessToken(HANDLE process, LPSECURITY_ATTRIBUTES s
         LOG((CLOG_ERR "could not duplicate token %i", sourceToken));
         throw XArch(new XArchEvalWindows());
     }
-    
+
     LOG((CLOG_DEBUG "duplicated, new token: %i", newToken));
     return newToken;
 }
 
-HANDLE 
+HANDLE
 MSWindowsWatchdog::getUserToken(LPSECURITY_ATTRIBUTES security)
 {
-    // always elevate if we are at the vista/7 login screen. we could also 
+    // always elevate if we are at the vista/7 login screen. we could also
     // elevate for the uac dialog (consent.exe) but this would be pointless,
     // since barrier would re-launch as non-elevated after the desk switch,
     // and so would be unusable with the new elevated process taking focus.
     if (m_elevateProcess || m_autoElevated) {
         LOG((CLOG_DEBUG "getting elevated token, %s",
             (m_elevateProcess ? "elevation required" : "at login screen")));
-        
+
         HANDLE process;
         if (!m_session.isProcessInSession("winlogon.exe", &process)) {
             throw XMSWindowsWatchdogError("cannot get user token without winlogon.exe");
@@ -169,10 +169,10 @@ MSWindowsWatchdog::mainLoop(void*)
         sendSasFunc = (SendSas)GetProcAddress(sasLib, "SendSAS");
     }
 
-    SECURITY_ATTRIBUTES saAttr; 
-    saAttr.nLength = sizeof(SECURITY_ATTRIBUTES); 
-    saAttr.bInheritHandle = TRUE; 
-    saAttr.lpSecurityDescriptor = NULL; 
+    SECURITY_ATTRIBUTES saAttr;
+    saAttr.nLength = sizeof(SECURITY_ATTRIBUTES);
+    saAttr.bInheritHandle = TRUE;
+    saAttr.lpSecurityDescriptor = NULL;
 
     if (!CreatePipe(&m_stdOutRead, &m_stdOutWrite, &saAttr, 0)) {
         throw XArch(new XArchEvalWindows());
@@ -196,7 +196,7 @@ MSWindowsWatchdog::mainLoop(void*)
                 LOG((CLOG_INFO "backing off, wait=%ds, failures=%d", timeout, m_processFailures));
                 ARCH->sleep(timeout);
             }
-        
+
             if (!getCommand().empty() && ((m_processFailures != 0) || m_session.hasChanged() || m_commandChanged)) {
                 startProcess();
             }
@@ -205,7 +205,7 @@ MSWindowsWatchdog::mainLoop(void*)
 
                 m_processFailures++;
                 m_processRunning = false;
-            
+
                 LOG((CLOG_WARN "detected application not running, pid=%d",
                     m_processInfo.dwProcessId));
             }
@@ -228,7 +228,7 @@ MSWindowsWatchdog::mainLoop(void*)
 
             // if the sas event failed, wait by sleeping.
             ARCH->sleep(1);
-        
+
         }
         catch (std::exception& e) {
             LOG((CLOG_ERR "failed to launch, error: %s", e.what()));
@@ -248,7 +248,7 @@ MSWindowsWatchdog::mainLoop(void*)
         LOG((CLOG_DEBUG "terminated running process on exit"));
         shutdownProcess(m_processInfo.hProcess, m_processInfo.dwProcessId, 20);
     }
-    
+
     LOG((CLOG_DEBUG "watchdog main thread finished"));
 }
 
@@ -260,7 +260,7 @@ MSWindowsWatchdog::isProcessActive()
     return exitCode == STILL_ACTIVE;
 }
 
-void 
+void
 MSWindowsWatchdog::setFileLogOutputter(FileLogOutputter* outputter)
 {
     m_fileLogOutputter = outputter;
@@ -367,7 +367,7 @@ BOOL MSWindowsWatchdog::doStartProcessAsUser(std::string& command, HANDLE userTo
         throw XArch(new XArchEvalWindows);
     }
 
-    DWORD creationFlags = 
+    DWORD creationFlags =
         NORMAL_PRIORITY_CLASS |
         CREATE_NO_WINDOW |
         CREATE_UNICODE_ENVIRONMENT;
@@ -428,7 +428,7 @@ MSWindowsWatchdog::outputLoop(void*)
     CHAR buffer[kOutputBufferSize + 1];
 
     while (m_monitoring) {
-        
+
         DWORD bytesRead;
         BOOL success = ReadFile(m_stdOutRead, buffer, kOutputBufferSize, &bytesRead, NULL);
 
@@ -443,7 +443,7 @@ MSWindowsWatchdog::outputLoop(void*)
             if (m_fileLogOutputter != NULL) {
                 m_fileLogOutputter->write(kINFO, buffer);
             }
-        }    
+        }
     }
 }
 
@@ -470,7 +470,7 @@ MSWindowsWatchdog::shutdownProcess(HANDLE handle, DWORD pid, int timeout)
             break;
         }
         else {
-            
+
             double elapsed = (ARCH->time() - start);
             if (elapsed > timeout) {
                 // if timeout reached, kill forcefully.
@@ -500,7 +500,7 @@ MSWindowsWatchdog::shutdownExistingProcesses()
     PROCESSENTRY32 entry;
     entry.dwSize = sizeof(PROCESSENTRY32);
 
-    // get the first process, and if we can't do that then it's 
+    // get the first process, and if we can't do that then it's
     // unlikely we can go any further
     BOOL gotEntry = Process32First(snapshot, &entry);
     if (!gotEntry) {
@@ -517,7 +517,7 @@ MSWindowsWatchdog::shutdownExistingProcesses()
 
             if (_stricmp(entry.szExeFile, "barrierc.exe") == 0 ||
                 _stricmp(entry.szExeFile, "barriers.exe") == 0) {
-                
+
                 HANDLE handle = OpenProcess(PROCESS_ALL_ACCESS, FALSE, entry.th32ProcessID);
                 shutdownProcess(handle, entry.th32ProcessID, 10);
             }

--- a/src/lib/platform/MSWindowsWatchdog.h
+++ b/src/lib/platform/MSWindowsWatchdog.h
@@ -6,7 +6,7 @@
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/OSXClipboard.cpp
+++ b/src/lib/platform/OSXClipboard.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -90,7 +90,7 @@ OSXClipboard::synchronize()
         return true;
     }
     return false;
-}    
+}
 
 void OSXClipboard::add(EFormat format, const std::string& data)
 {
@@ -126,15 +126,15 @@ void OSXClipboard::add(EFormat format, const std::string& data)
                 flavorType,
                 dataRef,
                 kPasteboardFlavorNoFlags);
-            
+
             LOG((CLOG_DEBUG "added %d bytes to clipboard format: %d", data.size(), format));
         }
-        
+
     }
 }
 
 bool
-OSXClipboard::open(Time time) const 
+OSXClipboard::open(Time time) const
 {
     if (m_pboard == NULL)
         return false;

--- a/src/lib/platform/OSXClipboard.h
+++ b/src/lib/platform/OSXClipboard.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/OSXClipboardAnyTextConverter.cpp
+++ b/src/lib/platform/OSXClipboardAnyTextConverter.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/OSXClipboardAnyTextConverter.h
+++ b/src/lib/platform/OSXClipboardAnyTextConverter.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/OSXClipboardHTMLConverter.cpp
+++ b/src/lib/platform/OSXClipboardHTMLConverter.cpp
@@ -66,7 +66,7 @@ std::string OSXClipboardHTMLConverter::convertString(const std::string& data,
         CFRelease(stringRef);
         return {};
     }
-    
+
     CFStringGetBytes(stringRef, entireString, toEncoding,
         0, false, (UInt8*)buffer, buffSize, NULL);
 

--- a/src/lib/platform/OSXClipboardTextConverter.cpp
+++ b/src/lib/platform/OSXClipboardTextConverter.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -24,7 +24,7 @@
 // OSXClipboardTextConverter
 //
 
-OSXClipboardTextConverter::OSXClipboardTextConverter() 
+OSXClipboardTextConverter::OSXClipboardTextConverter()
 {
     // do nothing
 }
@@ -59,12 +59,12 @@ std::string OSXClipboardTextConverter::convertString(const std::string& data,
                             0, false, NULL, 0, &buffSize);
 
     char* buffer = new char[buffSize];
-    
+
     if (buffer == NULL) {
         CFRelease(stringRef);
         return {};
     }
-    
+
     CFStringGetBytes(stringRef, entireString, toEncoding,
                             0, false, (UInt8*)buffer, buffSize, NULL);
 
@@ -72,7 +72,7 @@ std::string OSXClipboardTextConverter::convertString(const std::string& data,
 
     delete[] buffer;
     CFRelease(stringRef);
-    
+
     return result;
 }
 

--- a/src/lib/platform/OSXClipboardTextConverter.h
+++ b/src/lib/platform/OSXClipboardTextConverter.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/OSXClipboardUTF16Converter.cpp
+++ b/src/lib/platform/OSXClipboardUTF16Converter.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/OSXClipboardUTF16Converter.h
+++ b/src/lib/platform/OSXClipboardUTF16Converter.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/OSXDragSimulator.h
+++ b/src/lib/platform/OSXDragSimulator.h
@@ -28,7 +28,7 @@ void                runCocoaApp();
 void                stopCocoaLoop();
 void                fakeDragging(const char* str, int cursorX, int cursorY);
 CFStringRef            getCocoaDropTarget();
-    
+
 #if defined(__cplusplus)
 }
 #endif

--- a/src/lib/platform/OSXEventQueueBuffer.cpp
+++ b/src/lib/platform/OSXEventQueueBuffer.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -83,11 +83,11 @@ OSXEventQueueBuffer::getEvent(Event& event, UInt32& dataID)
     else {
         UInt32 eventClass = GetEventClass(m_event);
         switch (eventClass) {
-        case 'Syne': 
+        case 'Syne':
             dataID = GetEventKind(m_event);
             return kUser;
 
-        default: 
+        default:
             event = Event(Event::kSystem,
                         m_eventQueue->getSystemTarget(), &m_event);
             return kSystem;
@@ -101,24 +101,24 @@ OSXEventQueueBuffer::addEvent(UInt32 dataID)
     EventRef event;
     OSStatus error = CreateEvent(
                             kCFAllocatorDefault,
-                            'Syne', 
+                            'Syne',
                             dataID,
                             0,
                             kEventAttributeNone,
                             &event);
 
     if (error == noErr) {
-    
+
         assert(m_carbonEventQueue != NULL);
-        
+
         error = PostEventToQueue(
             m_carbonEventQueue,
             event,
             kEventPriorityStandard);
-        
+
         ReleaseEvent(event);
     }
-    
+
     return (error == noErr);
 }
 

--- a/src/lib/platform/OSXEventQueueBuffer.h
+++ b/src/lib/platform/OSXEventQueueBuffer.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/OSXKeyState.cpp
+++ b/src/lib/platform/OSXKeyState.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -97,7 +97,7 @@ static const KeyEntry    s_controlKeys[] = {
     { kKeyKP_Divide,    kVK_ANSI_KeypadDivide },
     { kKeyKP_Subtract,    kVK_ANSI_KeypadMinus },
     { kKeyKP_Enter,        kVK_ANSI_KeypadEnter },
-    
+
     // virtual key 110 is fn+enter and i have no idea what that's supposed
     // to map to.  also the enter key with numlock on is a modifier but i
     // don't know which.
@@ -118,7 +118,7 @@ static const KeyEntry    s_controlKeys[] = {
     // toggle modifiers
     { kKeyNumLock,        s_numLockVK },
     { kKeyCapsLock,        s_capsLockVK },
-    
+
     { kKeyMissionControl, s_missionControlVK },
     { kKeyLaunchpad, s_launchpadVK },
     { kKeyBrightnessUp,  s_brightnessUp },
@@ -163,7 +163,7 @@ OSXKeyState::init()
     // build virtual key map
     for (size_t i = 0; i < sizeof(s_controlKeys) / sizeof(s_controlKeys[0]);
         ++i) {
-        
+
         m_virtualKeyMap[s_controlKeys[i].m_virtualKey] =
             s_controlKeys[i].m_keyID;
     }
@@ -218,11 +218,11 @@ OSXKeyState::mapModifiersToCarbon(UInt32 mask) const
     if ((mask & kCGEventFlagMaskNumericPad) != 0) {
         outMask |= s_osxNumLock;
     }
-    
+
     return outMask;
 }
 
-KeyButton 
+KeyButton
 OSXKeyState::mapKeyFromEvent(KeyIDs& ids,
                 KeyModifierMask* maskOut, CGEventRef event) const
 {
@@ -257,7 +257,7 @@ OSXKeyState::mapKeyFromEvent(KeyIDs& ids,
     }
 
     // get keyboard info
-    TISInputSourceRef currentKeyboardLayout = TISCopyCurrentKeyboardLayoutInputSource(); 
+    TISInputSourceRef currentKeyboardLayout = TISCopyCurrentKeyboardLayoutInputSource();
 
     if (currentKeyboardLayout == NULL) {
         return kKeyNone;
@@ -342,27 +342,27 @@ CGEventFlags
 OSXKeyState::getModifierStateAsOSXFlags()
 {
     CGEventFlags modifiers = CGEventFlags(0);
-    
+
     if (m_shiftPressed) {
         modifiers |= CGEventFlags(kCGEventFlagMaskShift);
     }
-    
+
     if (m_controlPressed) {
         modifiers |= CGEventFlags(kCGEventFlagMaskControl);
     }
-    
+
     if (m_altPressed) {
         modifiers |= CGEventFlags(kCGEventFlagMaskAlternate);
     }
-    
+
     if (m_superPressed) {
         modifiers |= CGEventFlags(kCGEventFlagMaskCommand);
     }
-    
+
     if (m_capsPressed) {
         modifiers |= CGEventFlags(kCGEventFlagMaskAlphaShift);
     }
-    
+
     return modifiers;
 }
 
@@ -404,12 +404,12 @@ OSXKeyState::pollActiveGroup() const
     TISInputSourceRef keyboardLayout = TISCopyCurrentKeyboardLayoutInputSource();
     CFDataRef id = (CFDataRef)TISGetInputSourceProperty(
                         keyboardLayout, kTISPropertyInputSourceID);
-    
+
     GroupMap::const_iterator i = m_groupMap.find(id);
     if (i != m_groupMap.end()) {
         return i->second;
     }
-    
+
     LOG((CLOG_DEBUG "can't get the active group, use the first group instead"));
 
     return 0;
@@ -451,7 +451,7 @@ OSXKeyState::getKeyMap(barrier::KeyMap& keyMap)
 
         const void* resource;
         bool layoutValid = false;
-        
+
         // add regular keys
         // try uchr resource first
         CFDataRef resourceRef = (CFDataRef)TISGetInputSourceProperty(
@@ -479,19 +479,19 @@ static io_connect_t getEventDriver(void)
     static mach_port_t sEventDrvrRef = 0;
     mach_port_t masterPort, service, iter;
     kern_return_t kr;
-    
+
     if (!sEventDrvrRef) {
         // Get master device port
         kr = IOMasterPort(bootstrap_port, &masterPort);
         assert(KERN_SUCCESS == kr);
-        
+
         kr = IOServiceGetMatchingServices(masterPort,
                 IOServiceMatching(kIOHIDSystemClass), &iter);
         assert(KERN_SUCCESS == kr);
-        
+
         service = IOIteratorNext(iter);
         assert(service);
-        
+
         kr = IOServiceOpen(service, mach_task_self(),
                 kIOHIDParamConnectType, &sEventDrvrRef);
         assert(KERN_SUCCESS == kr);
@@ -499,7 +499,7 @@ static io_connect_t getEventDriver(void)
         IOObjectRelease(service);
         IOObjectRelease(iter);
     }
-    
+
     return sEventDrvrRef;
 }
 
@@ -508,7 +508,7 @@ OSXKeyState::postHIDVirtualKey(const UInt8 virtualKeyCode,
                 const bool postDown)
 {
     static UInt32 modifiers = 0;
-    
+
     NXEventData event;
     IOGPoint loc = { 0, 0 };
     UInt32 modifiersDelta = 0;
@@ -545,7 +545,7 @@ OSXKeyState::postHIDVirtualKey(const UInt8 virtualKeyCode,
                 m_capsPressed = postDown;
                 break;
         }
-        
+
         // update the modifier bit
         if (postDown) {
             modifiers |= modifiersDelta;
@@ -553,7 +553,7 @@ OSXKeyState::postHIDVirtualKey(const UInt8 virtualKeyCode,
         else {
             modifiers &= ~modifiersDelta;
         }
-            
+
         kern_return_t kr;
         event.key.keyCode = virtualKeyCode;
         kr = IOHIDPostEvent(getEventDriver(), NX_FLAGSCHANGED, loc,
@@ -579,11 +579,11 @@ OSXKeyState::fakeKey(const Keystroke& keystroke)
 {
     switch (keystroke.m_type) {
     case Keystroke::kButton: {
-        
+
         KeyButton button = keystroke.m_data.m_button.m_button;
         bool keyDown = keystroke.m_data.m_button.m_press;
         CGKeyCode virtualKey = mapKeyButtonToVirtualKey(button);
-        
+
         LOG((CLOG_DEBUG1
             "  button=0x%04x virtualKey=0x%04x keyDown=%s",
             button, virtualKey, keyDown ? "down" : "up"));
@@ -767,7 +767,7 @@ OSXKeyState::mapBarrierHotKeyToMac(KeyID key, KeyModifierMask mask,
         return false;
     }
     macVirtualKey = mapKeyButtonToVirtualKey(button);
-    
+
     // calculate modifier mask
     macModifierMask = 0;
     if ((mask & KeyModifierShift) != 0) {
@@ -788,10 +788,10 @@ OSXKeyState::mapBarrierHotKeyToMac(KeyID key, KeyModifierMask mask,
     if ((mask & KeyModifierNumLock) != 0) {
         macModifierMask |= s_osxNumLock;
     }
-    
+
     return true;
 }
-                        
+
 void
 OSXKeyState::handleModifierKeys(void* target,
                 KeyModifierMask oldMask, KeyModifierMask newMask)
@@ -859,7 +859,7 @@ OSXKeyState::getGroups(GroupList& groups) const
     groups.clear();
     for (CFIndex i = 0; i < n; ++i) {
         bool addToGroups = true;
-        TISInputSourceRef keyboardLayout = 
+        TISInputSourceRef keyboardLayout =
             (TISInputSourceRef)CFArrayGetValueAtIndex(kbds, i);
 
         if (addToGroups)

--- a/src/lib/platform/OSXKeyState.h
+++ b/src/lib/platform/OSXKeyState.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -67,7 +67,7 @@ public:
     Still required in a few places for translation calls.
     */
     KeyModifierMask        mapModifiersToCarbon(UInt32 mask) const;
-    
+
     //! Map key event to keys
     /*!
     Converts a key event into a sequence of KeyIDs and the shadow modifier
@@ -149,7 +149,7 @@ private:
     static UInt32        mapKeyButtonToVirtualKey(KeyButton keyButton);
 
     void                init();
-    
+
     // Post a key event to HID manager. It posts an event to HID client, a
     // much lower level than window manager which's the target from carbon
     // CGEventPost

--- a/src/lib/platform/OSXPasteboardPeeker.h
+++ b/src/lib/platform/OSXPasteboardPeeker.h
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 
 CFStringRef                getDraggedFileURL();
-    
+
 #if defined(__cplusplus)
 }
 #endif

--- a/src/lib/platform/OSXScreen.h
+++ b/src/lib/platform/OSXScreen.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -37,7 +37,7 @@ extern "C" {
     typedef int CGSConnectionID;
     CGError CGSSetConnectionProperty(CGSConnectionID cid, CGSConnectionID targetCID, CFStringRef key, CFTypeRef value);
     int _CGSDefaultConnection();
-}    
+}
 
 
 template <class T>
@@ -98,10 +98,10 @@ public:
     virtual bool        isPrimary() const;
     virtual void        fakeDraggingFiles(DragFileList fileList);
     virtual std::string& getDraggingFilename();
-    
+
     const std::string& getDropTarget() const { return m_dropTarget; }
     void                waitForCarbonLoop() const;
-    
+
 protected:
     // IPlatformScreen overrides
     virtual void        handleSystemEvent(const Event&, void*);
@@ -112,7 +112,7 @@ private:
     void                updateScreenShape();
     void                updateScreenShape(const CGDirectDisplayID, const CGDisplayChangeSummaryFlags);
     void                postMouseEvent(CGPoint&) const;
-    
+
     // convenience function to send events
     void                sendEvent(Event::Type type, void* = NULL) const;
     void                sendClipboardEvent(Event::Type type, ClipboardID id) const;
@@ -124,16 +124,16 @@ private:
     // of the button pressed using the mac button mapping.
     bool                onMouseButton(bool pressed, UInt16 macButton);
     bool                onMouseWheel(SInt32 xDelta, SInt32 yDelta) const;
-    
+
     void                constructMouseButtonEventMap();
 
     bool                onKey(CGEventRef event);
 
     void                onMediaKey(CGEventRef event);
-    
+
     bool                onHotKey(EventRef event) const;
-    
-    // Added here to allow the carbon cursor hack to be called. 
+
+    // Added here to allow the carbon cursor hack to be called.
     void                showCursor();
     void                hideCursor();
 
@@ -172,7 +172,7 @@ private:
     static pascal OSStatus
                         userSwitchCallback(EventHandlerCallRef nextHandler,
                            EventRef theEvent, void* inUserData);
-    
+
     // sleep / wakeup support
     void                watchSystemPowerThread(void*);
     static void            testCanceled(CFRunLoopTimerRef timer, void*info);
@@ -182,12 +182,12 @@ private:
                              void* messageArgument);
 
     void                handleConfirmSleep(const Event& event, void*);
-    
+
     // global hotkey operating mode
     static bool            isGlobalHotKeyOperatingModeAvailable();
     static void            setGlobalHotKeysEnabled(bool enabled);
     static bool            getGlobalHotKeysEnabled();
-    
+
     // Quartz event tap support
     static CGEventRef    handleCGInputEvent(CGEventTapProxy proxy,
                                            CGEventType type,
@@ -197,12 +197,12 @@ private:
                                                     CGEventType type,
                                                     CGEventRef event,
                                                     void* refcon);
-    
+
     // convert CFString to char*
     static char*        CFStringRefToUTF8String(CFStringRef aString);
-    
+
     void                getDropTargetThread(void*);
-    
+
 private:
     struct HotKeyItem {
     public:
@@ -225,13 +225,13 @@ private:
         kMouseButtonDown,
         kMouseButtonStateMax
     };
-    
+
 
     class MouseButtonState {
     public:
         void set(UInt32 button, EMouseButtonState state);
         bool any();
-        void reset(); 
+        void reset();
         void overwrite(UInt32 buttons);
 
         bool test(UInt32 button) const;
@@ -262,7 +262,7 @@ private:
     // mouse state
     mutable SInt32        m_xCursor, m_yCursor;
     mutable bool        m_cursorPosValid;
-    
+
     /* FIXME: this data structure is explicitly marked mutable due
        to a need to track the state of buttons since the remote
        side only lets us know of change events, and because the
@@ -321,7 +321,7 @@ private:
     // global hotkey operating mode
     static bool                s_testedForGHOM;
     static bool                s_hasGHOM;
-    
+
     // Quartz input event support
     CFMachPortRef            m_eventTapPort;
     CFRunLoopSourceRef        m_eventTapRLSR;
@@ -336,10 +336,10 @@ private:
     bool                    m_autoShowHideCursor;
 
     IEventQueue*            m_events;
-    
+
     Thread*                m_getDropTargetThread;
     std::string m_dropTarget;
-    
+
 #if defined(MAC_OS_X_VERSION_10_7)
     Mutex*                    m_carbonLoopMutex;
     CondVar<bool>*            m_carbonLoopReady;

--- a/src/lib/platform/OSXScreenSaver.cpp
+++ b/src/lib/platform/OSXScreenSaver.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -48,17 +48,17 @@ OSXScreenSaver::OSXScreenSaver(IEventQueue* events, void* eventTarget) :
     launchEventTypes[0].eventKind  = kEventAppLaunched;
     launchEventTypes[1].eventClass = kEventClassApplication;
     launchEventTypes[1].eventKind  = kEventAppTerminated;
-    
+
     EventHandlerUPP launchTerminationEventHandler =
         NewEventHandlerUPP(launchTerminationCallback);
     InstallApplicationEventHandler(launchTerminationEventHandler, 2,
                                 launchEventTypes, this,
                                 &m_launchTerminationEventHandlerRef);
     DisposeEventHandlerUPP(launchTerminationEventHandler);
-    
+
     m_screenSaverPSN.highLongOfPSN = 0;
     m_screenSaverPSN.lowLongOfPSN  = 0;
-    
+
     if (isActive()) {
         getProcessSerialNumber("ScreenSaverEngine", m_screenSaverPSN);
     }
@@ -128,7 +128,7 @@ OSXScreenSaver::processTerminated(ProcessSerialNumber psn)
                 Event(m_events->forIPrimaryScreen().screensaverDeactivated(),
                     m_eventTarget));
         }
-        
+
         m_screenSaverPSN.highLongOfPSN = 0;
         m_screenSaverPSN.lowLongOfPSN  = 0;
     }
@@ -140,7 +140,7 @@ OSXScreenSaver::launchTerminationCallback(
                 EventRef theEvent, void* userData)
 {
     OSStatus        result;
-    ProcessSerialNumber psn; 
+    ProcessSerialNumber psn;
     EventParamType    actualType;
     ByteCount        actualSize;
 

--- a/src/lib/platform/OSXScreenSaver.h
+++ b/src/lib/platform/OSXScreenSaver.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -36,11 +36,11 @@ public:
     virtual void        activate();
     virtual void        deactivate();
     virtual bool        isActive() const;
-    
+
 private:
     void                processLaunched(ProcessSerialNumber psn);
     void                processTerminated(ProcessSerialNumber psn);
-    
+
     static pascal OSStatus
                         launchTerminationCallback(
                             EventHandlerCallRef nextHandler,

--- a/src/lib/platform/OSXScreenSaverControl.h
+++ b/src/lib/platform/OSXScreenSaverControl.h
@@ -6,7 +6,7 @@
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/OSXScreenSaverUtil.h
+++ b/src/lib/platform/OSXScreenSaverUtil.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/OSXUchrKeyResource.cpp
+++ b/src/lib/platform/OSXUchrKeyResource.cpp
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/OSXUchrKeyResource.h
+++ b/src/lib/platform/OSXUchrKeyResource.h
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -27,7 +27,7 @@ typedef TISInputSourceRef KeyLayout;
 class OSXUchrKeyResource : public IOSXKeyResource {
 public:
     OSXUchrKeyResource(const void*, UInt32 keyboardType);
-    
+
     // KeyResource overrides
     virtual bool    isValid() const;
     virtual UInt32    getNumModifierCombinations() const;
@@ -35,15 +35,15 @@ public:
     virtual UInt32    getNumButtons() const;
     virtual UInt32    getTableForModifier(UInt32 mask) const;
     virtual KeyID    getKey(UInt32 table, UInt32 button) const;
-    
+
 private:
     typedef std::vector<KeyID> KeySequence;
-    
+
     bool            getDeadKey(KeySequence& keys, UInt16 index) const;
     bool            getKeyRecord(KeySequence& keys,
                                  UInt16 index, UInt16& state) const;
     bool            addSequence(KeySequence& keys, UCKeyCharSeq c) const;
-    
+
 private:
     const UCKeyboardLayout*            m_resource;
     const UCKeyModifiersToTableNum*    m_m;

--- a/src/lib/platform/XWindowsClipboard.cpp
+++ b/src/lib/platform/XWindowsClipboard.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/XWindowsClipboard.h
+++ b/src/lib/platform/XWindowsClipboard.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/XWindowsClipboardAnyBitmapConverter.cpp
+++ b/src/lib/platform/XWindowsClipboardAnyBitmapConverter.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/XWindowsClipboardAnyBitmapConverter.h
+++ b/src/lib/platform/XWindowsClipboardAnyBitmapConverter.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/XWindowsClipboardBMPConverter.cpp
+++ b/src/lib/platform/XWindowsClipboardBMPConverter.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/XWindowsClipboardBMPConverter.h
+++ b/src/lib/platform/XWindowsClipboardBMPConverter.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/XWindowsClipboardHTMLConverter.cpp
+++ b/src/lib/platform/XWindowsClipboardHTMLConverter.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/XWindowsClipboardHTMLConverter.h
+++ b/src/lib/platform/XWindowsClipboardHTMLConverter.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/XWindowsClipboardTextConverter.cpp
+++ b/src/lib/platform/XWindowsClipboardTextConverter.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/XWindowsClipboardTextConverter.h
+++ b/src/lib/platform/XWindowsClipboardTextConverter.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/XWindowsClipboardUCS2Converter.cpp
+++ b/src/lib/platform/XWindowsClipboardUCS2Converter.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/XWindowsClipboardUCS2Converter.h
+++ b/src/lib/platform/XWindowsClipboardUCS2Converter.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/XWindowsClipboardUTF8Converter.cpp
+++ b/src/lib/platform/XWindowsClipboardUTF8Converter.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/XWindowsClipboardUTF8Converter.h
+++ b/src/lib/platform/XWindowsClipboardUTF8Converter.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/XWindowsEventQueueBuffer.cpp
+++ b/src/lib/platform/XWindowsEventQueueBuffer.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -104,7 +104,7 @@ XWindowsEventQueueBuffer::waitForEvent(double dtimeout)
 
     char buf[16];
     ssize_t read_response = read(m_pipefd[0], buf, 15);
-    
+
     // with linux automake, warnings are treated as errors by default
     if (read_response < 0)
     {
@@ -181,7 +181,7 @@ XWindowsEventQueueBuffer::waitForEvent(double dtimeout)
     retval = poll(pfds, 2, TIMEOUT_DELAY); //16ms = 60hz, but we make it > to play nicely with the cpu
      if (pfds[1].revents & POLLIN) {
          ssize_t read_response = read(m_pipefd[0], buf, 15);
-        
+
         // with linux automake, warnings are treated as errors by default
         if (read_response < 0)
         {

--- a/src/lib/platform/XWindowsEventQueueBuffer.h
+++ b/src/lib/platform/XWindowsEventQueueBuffer.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/XWindowsKeyState.cpp
+++ b/src/lib/platform/XWindowsKeyState.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2003 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -348,7 +348,7 @@ XWindowsKeyState::updateKeysymMap(barrier::KeyMap& keyMap)
                 else {
                     tmpKeysyms[maxKeysyms * i + j] = NoSymbol;
                 }
-            }    
+            }
         }
         m_impl->XFree(allKeysyms);
         allKeysyms = tmpKeysyms;

--- a/src/lib/platform/XWindowsKeyState.h
+++ b/src/lib/platform/XWindowsKeyState.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2003 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -97,7 +97,7 @@ XWindowsScreen::XWindowsScreen(
 
 	if (mouseScrollDelta==0) m_mouseScrollDelta=120;
 	s_screen = this;
-	
+
 	if (!disableXInitThreads) {
 	  // initializes Xlib support for concurrent threads.
       if (m_impl->XInitThreads() == 0)
@@ -266,14 +266,14 @@ XWindowsScreen::enter()
             m_impl->DPMSForceLevel(m_display, DPMSModeOn);
 	}
 	#endif
-	
+
 	// unmap the hider/grab window.  this also ungrabs the mouse and
 	// keyboard if they're grabbed.
     m_impl->XUnmapWindow(m_display, m_window);
 
 /* maybe call this if entering for the screensaver
 	// set keyboard focus to root window.  the screensaver should then
-	// pick up key events for when the user enters a password to unlock. 
+	// pick up key events for when the user enters a password to unlock.
 	XSetInputFocus(m_display, PointerRoot, PointerRoot, CurrentTime);
 */
 

--- a/src/lib/platform/XWindowsScreen.h
+++ b/src/lib/platform/XWindowsScreen.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/XWindowsScreenSaver.cpp
+++ b/src/lib/platform/XWindowsScreenSaver.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -490,7 +490,7 @@ XWindowsScreenSaver::addWatchXScreenSaver(Window window)
     }
 
     // if successful and window uses override_redirect (like xscreensaver
-    // does) then watch it for property changes.  
+    // does) then watch it for property changes.
     if (!error && attr.override_redirect == True) {
         error = false;
         {

--- a/src/lib/platform/XWindowsScreenSaver.h
+++ b/src/lib/platform/XWindowsScreenSaver.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/XWindowsUtil.cpp
+++ b/src/lib/platform/XWindowsUtil.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/platform/XWindowsUtil.h
+++ b/src/lib/platform/XWindowsUtil.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -123,7 +123,7 @@ public:
     This class sets an X error handler in the c'tor and restores the
     previous error handler in the d'tor.  A lock should only be
     installed while the display is locked by the thread.
-    
+
     ErrorLock() ignores errors
     ErrorLock(bool* flag) sets *flag to true if any error occurs
     */

--- a/src/lib/platform/synwinhk.h
+++ b/src/lib/platform/synwinhk.h
@@ -3,11 +3,11 @@
  * Copyright (C) 2018 Debauchee Open Source Group
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/server/BaseClientProxy.cpp
+++ b/src/lib/server/BaseClientProxy.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2006 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/server/BaseClientProxy.h
+++ b/src/lib/server/BaseClientProxy.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/server/CMakeLists.txt
+++ b/src/lib/server/CMakeLists.txt
@@ -1,11 +1,11 @@
 # barrier -- mouse and keyboard sharing utility
 # Copyright (C) 2012-2016 Symless Ltd.
 # Copyright (C) 2009 Nick Bolton
-# 
+#
 # This package is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # found in the file LICENSE that should have accompanied this file.
-# 
+#
 # This package is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/server/ClientListener.cpp
+++ b/src/lib/server/ClientListener.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -54,7 +54,7 @@ ClientListener::ClientListener(const NetworkAddress& address,
                     m_listen,
                     new TMethodEventJob<ClientListener>(this,
                             &ClientListener::handleClientConnecting));
-        
+
         // bind listen address
         LOG((CLOG_DEBUG1 "binding listen socket"));
         m_listen->bind(address);
@@ -130,14 +130,14 @@ ClientListener::handleClientConnecting(const Event&, void*)
     if (socket == NULL) {
         return;
     }
-    
+
     m_clientSockets.insert(socket);
 
     m_events->adoptHandler(m_events->forClientListener().accepted(),
                 socket->getEventTarget(),
                 new TMethodEventJob<ClientListener>(this,
                         &ClientListener::handleClientAccepted, socket));
-    
+
     // When using non SSL, server accepts clients immediately, while SSL
     // has to call secure accept which may require retry
     if (!m_useSecureNetwork) {
@@ -152,7 +152,7 @@ ClientListener::handleClientAccepted(const Event&, void* vsocket)
     LOG((CLOG_NOTE "accepted client connection"));
 
     IDataSocket* socket = static_cast<IDataSocket*>(vsocket);
-    
+
     // filter socket messages, including a packetizing filter
     barrier::IStream* stream = new PacketStreamFilter(m_events, socket, false);
     assert(m_server != NULL);

--- a/src/lib/server/ClientListener.h
+++ b/src/lib/server/ClientListener.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/server/ClientProxy.cpp
+++ b/src/lib/server/ClientProxy.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/server/ClientProxy.h
+++ b/src/lib/server/ClientProxy.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/server/ClientProxy1_0.cpp
+++ b/src/lib/server/ClientProxy1_0.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/server/ClientProxy1_0.h
+++ b/src/lib/server/ClientProxy1_0.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/server/ClientProxy1_1.cpp
+++ b/src/lib/server/ClientProxy1_1.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/server/ClientProxy1_1.h
+++ b/src/lib/server/ClientProxy1_1.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/server/ClientProxy1_2.cpp
+++ b/src/lib/server/ClientProxy1_2.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/server/ClientProxy1_2.h
+++ b/src/lib/server/ClientProxy1_2.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/server/ClientProxy1_3.cpp
+++ b/src/lib/server/ClientProxy1_3.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2006 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/server/ClientProxy1_3.h
+++ b/src/lib/server/ClientProxy1_3.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2006 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/server/ClientProxy1_4.cpp
+++ b/src/lib/server/ClientProxy1_4.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2011 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/server/ClientProxy1_4.h
+++ b/src/lib/server/ClientProxy1_4.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2011 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/server/ClientProxy1_5.cpp
+++ b/src/lib/server/ClientProxy1_5.cpp
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2013-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -86,7 +86,7 @@ ClientProxy1_5::fileChunkReceived()
                     getStream(),
                     server->getReceivedFileData(),
                     server->getExpectedFileSize());
-    
+
 
     if (result == kFinish) {
         m_events->addEvent(Event(m_events->forFile().fileRecieveCompleted(), server));
@@ -106,6 +106,6 @@ ClientProxy1_5::dragInfoReceived()
     UInt32 fileNum = 0;
     std::string content;
     ProtocolUtil::readf(getStream(), kMsgDDragInfo + 4, &fileNum, &content);
-    
+
     m_server->dragInfoReceived(fileNum, content);
 }

--- a/src/lib/server/ClientProxy1_5.h
+++ b/src/lib/server/ClientProxy1_5.h
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2013-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/server/ClientProxy1_6.cpp
+++ b/src/lib/server/ClientProxy1_6.cpp
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2015-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -88,7 +88,7 @@ ClientProxy1_6::recvClipboard()
         // save clipboard
         m_clipboard[id].m_clipboard.unmarshall(dataCached, 0);
         m_clipboard[id].m_sequenceNumber = seq;
-        
+
         // notify
         ClipboardInfo* info = new ClipboardInfo;
         info->m_id = id;

--- a/src/lib/server/ClientProxy1_6.h
+++ b/src/lib/server/ClientProxy1_6.h
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2015-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/server/ClientProxyUnknown.cpp
+++ b/src/lib/server/ClientProxyUnknown.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/server/ClientProxyUnknown.h
+++ b/src/lib/server/ClientProxyUnknown.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -1776,7 +1776,7 @@ operator<<(std::ostream& s, const Config& config)
 
 		for (Config::link_const_iterator
 				link = config.beginNeighbor(*screen),
-				nend = config.endNeighbor(*screen); link != nend; ++link) {			
+				nend = config.endNeighbor(*screen); link != nend; ++link) {
 			s << "\t\t" << Config::dirName(link->first.getSide()) <<
 				Config::formatInterval(link->first.getInterval()) <<
 				" = " << link->second.getName().c_str() <<

--- a/src/lib/server/Config.h
+++ b/src/lib/server/Config.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/server/InputFilter.cpp
+++ b/src/lib/server/InputFilter.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2005 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -191,7 +191,7 @@ std::string InputFilter::MouseButtonCondition::format() const
     return barrier::string::sprintf("mousebutton(%s%d)", key.c_str(), m_button);
 }
 
-InputFilter::EFilterStatus        
+InputFilter::EFilterStatus
 InputFilter::MouseButtonCondition::match(const Event& event)
 {
     static const KeyModifierMask s_ignoreMask =
@@ -252,7 +252,7 @@ InputFilter::EFilterStatus
 InputFilter::ScreenConnectedCondition::match(const Event& event)
 {
     if (event.getType() == m_events->forServer().connected()) {
-        Server::ScreenConnectedInfo* info = 
+        Server::ScreenConnectedInfo* info =
             static_cast<Server::ScreenConnectedInfo*>(event.getData());
         if (m_screen == info->m_screen || m_screen.empty()) {
             return kActivate;
@@ -312,7 +312,7 @@ InputFilter::LockCursorToScreenAction::perform(const Event& event)
     };
 
     // send event
-    Server::LockCursorToScreenInfo* info = 
+    Server::LockCursorToScreenInfo* info =
         Server::LockCursorToScreenInfo::alloc(s_state[m_mode]);
     m_events->addEvent(Event(m_events->forServer().lockCursorToScreen(),
                                 event.getTarget(), info,
@@ -350,7 +350,7 @@ InputFilter::SwitchToScreenAction::perform(const Event& event)
     // event if it has one.
     std::string screen = m_screen;
     if (screen.empty() && event.getType() == m_events->forServer().connected()) {
-        Server::ScreenConnectedInfo* info = 
+        Server::ScreenConnectedInfo* info =
             static_cast<Server::ScreenConnectedInfo*>(event.getData());
         screen = info->m_screen;
     }
@@ -493,7 +493,7 @@ InputFilter::KeyboardBroadcastAction::perform(const Event& event)
     };
 
     // send event
-    Server::KeyboardBroadcastInfo* info = 
+    Server::KeyboardBroadcastInfo* info =
         Server::KeyboardBroadcastInfo::alloc(s_state[m_mode], m_screens);
     m_events->addEvent(Event(m_events->forServer().keyboardBroadcast(),
                                 event.getTarget(), info,
@@ -569,7 +569,7 @@ InputFilter::KeystrokeAction::perform(const Event& event)
     Event::Type type = m_press ?
         m_events->forIKeyState().keyDown() :
         m_events->forIKeyState().keyUp();
-    
+
     m_events->addEvent(Event(m_events->forIPrimaryScreen().fakeInputBegin(),
                                 event.getTarget(), NULL,
                                 Event::kDeliverImmediately));

--- a/src/lib/server/InputFilter.h
+++ b/src/lib/server/InputFilter.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2005 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -53,7 +53,7 @@ public:
         virtual void            enablePrimary(PrimaryClient*);
         virtual void            disablePrimary(PrimaryClient*);
     };
-    
+
     // KeystrokeCondition
     class KeystrokeCondition : public Condition {
     public:
@@ -118,7 +118,7 @@ public:
     // -------------------------------------------------------------------------
     // Input Filter Action Classes
     // -------------------------------------------------------------------------
-    
+
     class Action {
     public:
         Action();
@@ -129,7 +129,7 @@ public:
 
         virtual void            perform(const Event&) = 0;
     };
-    
+
     // LockCursorToScreenAction
     class LockCursorToScreenAction : public Action {
     public:
@@ -148,7 +148,7 @@ public:
         Mode                    m_mode;
         IEventQueue*            m_events;
     };
-    
+
     // SwitchToScreenAction
     class SwitchToScreenAction : public Action {
     public:
@@ -165,7 +165,7 @@ public:
         std::string                    m_screen;
         IEventQueue*            m_events;
     };
-    
+
     // ToggleScreenAction
     class ToggleScreenAction : public Action {
     public:
@@ -196,7 +196,7 @@ public:
         EDirection                m_direction;
         IEventQueue*            m_events;
     };
-    
+
     // KeyboardBroadcastAction
     class KeyboardBroadcastAction : public Action {
     public:

--- a/src/lib/server/PrimaryClient.cpp
+++ b/src/lib/server/PrimaryClient.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/lib/server/PrimaryClient.h
+++ b/src/lib/server/PrimaryClient.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -96,12 +96,12 @@ public:
     the edges of the screen, typically the center.
     */
     void                getCursorCenter(SInt32& x, SInt32& y) const;
-    
+
     //! Get toggle key state
     /*!
     Returns the primary screen's current toggle modifier key state.
     */
-    virtual KeyModifierMask        
+    virtual KeyModifierMask
                         getToggleMask() const;
 
     //! Get screen lock state

--- a/src/lib/server/Server.h
+++ b/src/lib/server/Server.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2002 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -150,7 +150,7 @@ public:
 
     //! Store ClientListener pointer
     void                setListener(ClientListener* p) { m_clientListener = p; }
-    
+
     //@}
     //! @name accessors
     //@{
@@ -166,7 +166,7 @@ public:
     Set the \c list to the names of the currently connected clients.
     */
     void getClients(std::vector<std::string>& list) const;
-    
+
     //! Return true if recieved file size is valid
     bool                isReceivedFileSizeValid();
 
@@ -356,10 +356,10 @@ private:
 
     // force the cursor off of \p client
     void                forceLeaveClient(BaseClientProxy* client);
-    
+
     // thread funciton for sending file
     void                sendFileThread(void*);
-    
+
     // thread function for writing file to drop directory
     void                writeToDropDirThread(void*);
 
@@ -448,7 +448,7 @@ private:
     bool                m_switchNeedsShift;
     bool                m_switchNeedsControl;
     bool                m_switchNeedsAlt;
-    
+
     // relative mouse move option
     bool                m_relativeMoves;
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1,11 +1,11 @@
 # barrier -- mouse and keyboard sharing utility
 # Copyright (C) 2012-2016 Symless Ltd.
 # Copyright (C) 2011 Nick Bolton
-# 
+#
 # This package is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # found in the file LICENSE that should have accompanied this file.
-# 
+#
 # This package is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/test/global/TestEventQueue.cpp
+++ b/src/test/global/TestEventQueue.cpp
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2013-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -23,7 +23,7 @@
 #include <stdexcept>
 
 void
-TestEventQueue::raiseQuitEvent() 
+TestEventQueue::raiseQuitEvent()
 {
     addEvent(Event(Event::kQuit));
 }

--- a/src/test/global/TestEventQueue.h
+++ b/src/test/global/TestEventQueue.h
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2013-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/test/global/gmock.h
+++ b/src/test/global/gmock.h
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2014-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/test/global/gtest.h
+++ b/src/test/global/gtest.h
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2014-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/test/guitests/src/VersionCheckerTests.cpp
+++ b/src/test/guitests/src/VersionCheckerTests.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2012 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/test/guitests/src/VersionCheckerTests.h
+++ b/src/test/guitests/src/VersionCheckerTests.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2012 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/test/guitests/src/main.cpp
+++ b/src/test/guitests/src/main.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2012 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/test/integtests/CMakeLists.txt
+++ b/src/test/integtests/CMakeLists.txt
@@ -1,11 +1,11 @@
 # barrier -- mouse and keyboard sharing utility
 # Copyright (C) 2012-2016 Symless Ltd.
 # Copyright (C) 2009 Nick Bolton
-# 
+#
 # This package is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # found in the file LICENSE that should have accompanied this file.
-# 
+#
 # This package is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/test/integtests/Main.cpp
+++ b/src/test/integtests/Main.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2011 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -44,7 +44,7 @@ main(int argc, char **argv)
 
     Arch arch;
     arch.init();
-    
+
     Log log;
     log.setFilter(kDEBUG2);
 
@@ -67,7 +67,7 @@ main(int argc, char **argv)
     if (!lockFile.empty()) {
         unlock(lockFile);
     }
-  
+
   // gtest seems to randomly finish with error codes (e.g. -1, -1073741819)
   // even when no tests have failed. not sure what causes this, but it
   // happens on all platforms and  keeps leading to false positives.
@@ -80,7 +80,7 @@ void
 lock(string lockFile)
 {
     double start = ARCH->time();
-    
+
     // keep checking until timeout is reached.
     while ((ARCH->time() - start) < LOCK_TIMEOUT) {
 
@@ -102,7 +102,7 @@ lock(string lockFile)
 }
 
 void
-unlock(string lockFile) 
+unlock(string lockFile)
 {
     remove(lockFile.c_str());
 }

--- a/src/test/integtests/ipc/IpcTests.cpp
+++ b/src/test/integtests/ipc/IpcTests.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2012 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -46,7 +46,7 @@ class IpcTests : public ::testing::Test
 public:
     IpcTests();
     virtual ~IpcTests();
-    
+
     void                connectToServer_handleMessageReceived(const Event&, void*);
     void                sendMessageToServer_serverHandleMessageReceived(const Event&, void*);
     void                sendMessageToClient_serverHandleClientConnected(const Event&, void*);
@@ -76,15 +76,15 @@ TEST_F(IpcTests, connectToServer)
         m_events.forIpcServer().messageReceived(), &server,
         new TMethodEventJob<IpcTests>(
         this, &IpcTests::connectToServer_handleMessageReceived));
-    
+
     IpcClient client(&m_events, &socketMultiplexer, TEST_IPC_PORT);
     client.connect();
-    
+
     m_events.initQuitTimeout(5);
     m_events.loop();
     m_events.removeHandler(m_events.forIpcServer().messageReceived(), &server);
     m_events.cleanupQuitTimeout();
-    
+
     EXPECT_EQ(true, m_connectToServer_helloMessageReceived);
     EXPECT_EQ(true, m_connectToServer_hasClientNode);
 }
@@ -94,13 +94,13 @@ TEST_F(IpcTests, sendMessageToServer)
     SocketMultiplexer socketMultiplexer;
     IpcServer server(&m_events, &socketMultiplexer, TEST_IPC_PORT);
     server.listen();
-    
+
     // event handler sends "test" command to server.
     m_events.adoptHandler(
         m_events.forIpcServer().messageReceived(), &server,
         new TMethodEventJob<IpcTests>(
         this, &IpcTests::sendMessageToServer_serverHandleMessageReceived));
-    
+
     IpcClient client(&m_events, &socketMultiplexer, TEST_IPC_PORT);
     client.connect();
     m_sendMessageToServer_client = &client;
@@ -128,7 +128,7 @@ TEST_F(IpcTests, sendMessageToClient)
 
     IpcClient client(&m_events, &socketMultiplexer, TEST_IPC_PORT);
     client.connect();
-    
+
     m_events.adoptHandler(
         m_events.forIpcClient().messageReceived(), &client,
         new TMethodEventJob<IpcTests>(

--- a/src/test/integtests/net/NetworkTests.cpp
+++ b/src/test/integtests/net/NetworkTests.cpp
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2013-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -84,19 +84,19 @@ public:
     }
 
     void                sendMockData(void* eventTarget);
-    
+
     void                sendToClient_mockData_handleClientConnected(const Event&, void* vlistener);
     void                sendToClient_mockData_fileRecieveCompleted(const Event&, void*);
-    
+
     void                sendToClient_mockFile_handleClientConnected(const Event&, void* vlistener);
     void                sendToClient_mockFile_fileRecieveCompleted(const Event& event, void*);
-    
+
     void                sendToServer_mockData_handleClientConnected(const Event&, void* vlistener);
     void                sendToServer_mockData_fileRecieveCompleted(const Event& event, void*);
 
     void                sendToServer_mockFile_handleClientConnected(const Event&, void* vlistener);
     void                sendToServer_mockFile_fileRecieveCompleted(const Event& event, void*);
-    
+
 public:
     TestEventQueue        m_events;
     UInt8*                m_mockData;
@@ -111,7 +111,7 @@ TEST_F(NetworkTests, sendToClient_mockData)
     NetworkAddress serverAddress(TEST_HOST, TEST_PORT);
 
     serverAddress.resolve();
-    
+
     // server
     SocketMultiplexer serverSocketMultiplexer;
     TCPSocketFactory* serverSocketFactory = new TCPSocketFactory(&m_events, &serverSocketMultiplexer);
@@ -120,7 +120,7 @@ TEST_F(NetworkTests, sendToClient_mockData)
     NiceMock<MockPrimaryClient> primaryClient;
     NiceMock<MockConfig> serverConfig;
     NiceMock<MockInputFilter> serverInputFilter;
-    
+
     m_events.adoptHandler(
         m_events.forClientListener().connected(), &listener,
         new TMethodEventJob<NetworkTests>(
@@ -128,7 +128,7 @@ TEST_F(NetworkTests, sendToClient_mockData)
 
     ON_CALL(serverConfig, isScreen(_)).WillByDefault(Return(true));
     ON_CALL(serverConfig, getInputFilter()).WillByDefault(Return(&serverInputFilter));
-    
+
     ServerArgs serverArgs;
     serverArgs.m_enableDragDrop = true;
     Server server(serverConfig, &primaryClient, &serverScreen, &m_events, serverArgs);
@@ -139,7 +139,7 @@ TEST_F(NetworkTests, sendToClient_mockData)
     NiceMock<MockScreen> clientScreen;
     SocketMultiplexer clientSocketMultiplexer;
     TCPSocketFactory* clientSocketFactory = new TCPSocketFactory(&m_events, &clientSocketMultiplexer);
-    
+
     ON_CALL(clientScreen, getShape(_, _, _, _)).WillByDefault(Invoke(getScreenShape));
     ON_CALL(clientScreen, getCursorPos(_, _)).WillByDefault(Invoke(getCursorPos));
 
@@ -148,7 +148,7 @@ TEST_F(NetworkTests, sendToClient_mockData)
     clientArgs.m_enableDragDrop = true;
     clientArgs.m_enableCrypto = false;
     Client client(&m_events, "stub", serverAddress, clientSocketFactory, &clientScreen, clientArgs);
-        
+
     m_events.adoptHandler(
         m_events.forFile().fileRecieveCompleted(), &client,
         new TMethodEventJob<NetworkTests>(
@@ -169,7 +169,7 @@ TEST_F(NetworkTests, sendToClient_mockFile)
     NetworkAddress serverAddress(TEST_HOST, TEST_PORT);
 
     serverAddress.resolve();
-    
+
     // server
     SocketMultiplexer serverSocketMultiplexer;
     TCPSocketFactory* serverSocketFactory = new TCPSocketFactory(&m_events, &serverSocketMultiplexer);
@@ -178,7 +178,7 @@ TEST_F(NetworkTests, sendToClient_mockFile)
     NiceMock<MockPrimaryClient> primaryClient;
     NiceMock<MockConfig> serverConfig;
     NiceMock<MockInputFilter> serverInputFilter;
-    
+
     m_events.adoptHandler(
         m_events.forClientListener().connected(), &listener,
         new TMethodEventJob<NetworkTests>(
@@ -186,7 +186,7 @@ TEST_F(NetworkTests, sendToClient_mockFile)
 
     ON_CALL(serverConfig, isScreen(_)).WillByDefault(Return(true));
     ON_CALL(serverConfig, getInputFilter()).WillByDefault(Return(&serverInputFilter));
-    
+
     ServerArgs serverArgs;
     serverArgs.m_enableDragDrop = true;
     Server server(serverConfig, &primaryClient, &serverScreen, &m_events, serverArgs);
@@ -197,7 +197,7 @@ TEST_F(NetworkTests, sendToClient_mockFile)
     NiceMock<MockScreen> clientScreen;
     SocketMultiplexer clientSocketMultiplexer;
     TCPSocketFactory* clientSocketFactory = new TCPSocketFactory(&m_events, &clientSocketMultiplexer);
-    
+
     ON_CALL(clientScreen, getShape(_, _, _, _)).WillByDefault(Invoke(getScreenShape));
     ON_CALL(clientScreen, getCursorPos(_, _)).WillByDefault(Invoke(getCursorPos));
 
@@ -206,7 +206,7 @@ TEST_F(NetworkTests, sendToClient_mockFile)
     clientArgs.m_enableDragDrop = true;
     clientArgs.m_enableCrypto = false;
     Client client(&m_events, "stub", serverAddress, clientSocketFactory, &clientScreen, clientArgs);
-        
+
     m_events.adoptHandler(
         m_events.forFile().fileRecieveCompleted(), &client,
         new TMethodEventJob<NetworkTests>(
@@ -238,7 +238,7 @@ TEST_F(NetworkTests, sendToServer_mockData)
 
     ON_CALL(serverConfig, isScreen(_)).WillByDefault(Return(true));
     ON_CALL(serverConfig, getInputFilter()).WillByDefault(Return(&serverInputFilter));
-    
+
     ServerArgs serverArgs;
     serverArgs.m_enableDragDrop = true;
     Server server(serverConfig, &primaryClient, &serverScreen, &m_events, serverArgs);
@@ -249,7 +249,7 @@ TEST_F(NetworkTests, sendToServer_mockData)
     NiceMock<MockScreen> clientScreen;
     SocketMultiplexer clientSocketMultiplexer;
     TCPSocketFactory* clientSocketFactory = new TCPSocketFactory(&m_events, &clientSocketMultiplexer);
-    
+
     ON_CALL(clientScreen, getShape(_, _, _, _)).WillByDefault(Invoke(getScreenShape));
     ON_CALL(clientScreen, getCursorPos(_, _)).WillByDefault(Invoke(getCursorPos));
 
@@ -257,7 +257,7 @@ TEST_F(NetworkTests, sendToServer_mockData)
     clientArgs.m_enableDragDrop = true;
     clientArgs.m_enableCrypto = false;
     Client client(&m_events, "stub", serverAddress, clientSocketFactory, &clientScreen, clientArgs);
-    
+
     m_events.adoptHandler(
         m_events.forClientListener().connected(), &listener,
         new TMethodEventJob<NetworkTests>(
@@ -295,7 +295,7 @@ TEST_F(NetworkTests, sendToServer_mockFile)
 
     ON_CALL(serverConfig, isScreen(_)).WillByDefault(Return(true));
     ON_CALL(serverConfig, getInputFilter()).WillByDefault(Return(&serverInputFilter));
-    
+
     ServerArgs serverArgs;
     serverArgs.m_enableDragDrop = true;
     Server server(serverConfig, &primaryClient, &serverScreen, &m_events, serverArgs);
@@ -306,7 +306,7 @@ TEST_F(NetworkTests, sendToServer_mockFile)
     NiceMock<MockScreen> clientScreen;
     SocketMultiplexer clientSocketMultiplexer;
     TCPSocketFactory* clientSocketFactory = new TCPSocketFactory(&m_events, &clientSocketMultiplexer);
-    
+
     ON_CALL(clientScreen, getShape(_, _, _, _)).WillByDefault(Invoke(getScreenShape));
     ON_CALL(clientScreen, getCursorPos(_, _)).WillByDefault(Invoke(getCursorPos));
 
@@ -334,7 +334,7 @@ TEST_F(NetworkTests, sendToServer_mockFile)
     m_events.cleanupQuitTimeout();
 }
 
-void 
+void
 NetworkTests::sendToClient_mockData_handleClientConnected(const Event&, void* vlistener)
 {
     ClientListener* listener = static_cast<ClientListener*>(vlistener);
@@ -352,7 +352,7 @@ NetworkTests::sendToClient_mockData_handleClientConnected(const Event&, void* vl
     sendMockData(server);
 }
 
-void 
+void
 NetworkTests::sendToClient_mockData_fileRecieveCompleted(const Event& event, void*)
 {
     Client* client = static_cast<Client*>(event.getTarget());
@@ -361,7 +361,7 @@ NetworkTests::sendToClient_mockData_fileRecieveCompleted(const Event& event, voi
     m_events.raiseQuitEvent();
 }
 
-void 
+void
 NetworkTests::sendToClient_mockFile_handleClientConnected(const Event&, void* vlistener)
 {
     ClientListener* listener = static_cast<ClientListener*>(vlistener);
@@ -379,7 +379,7 @@ NetworkTests::sendToClient_mockFile_handleClientConnected(const Event&, void* vl
     server->sendFileToClient(kMockFilename);
 }
 
-void 
+void
 NetworkTests::sendToClient_mockFile_fileRecieveCompleted(const Event& event, void*)
 {
     Client* client = static_cast<Client*>(event.getTarget());
@@ -388,14 +388,14 @@ NetworkTests::sendToClient_mockFile_fileRecieveCompleted(const Event& event, voi
     m_events.raiseQuitEvent();
 }
 
-void 
+void
 NetworkTests::sendToServer_mockData_handleClientConnected(const Event&, void* vclient)
 {
     Client* client = static_cast<Client*>(vclient);
     sendMockData(client);
 }
 
-void 
+void
 NetworkTests::sendToServer_mockData_fileRecieveCompleted(const Event& event, void*)
 {
     Server* server = static_cast<Server*>(event.getTarget());
@@ -404,14 +404,14 @@ NetworkTests::sendToServer_mockData_fileRecieveCompleted(const Event& event, voi
     m_events.raiseQuitEvent();
 }
 
-void 
+void
 NetworkTests::sendToServer_mockFile_handleClientConnected(const Event&, void* vclient)
 {
     Client* client = static_cast<Client*>(vclient);
     client->sendFileToServer(kMockFilename);
 }
 
-void 
+void
 NetworkTests::sendToServer_mockFile_fileRecieveCompleted(const Event& event, void*)
 {
     Server* server = static_cast<Server*>(event.getTarget());
@@ -420,13 +420,13 @@ NetworkTests::sendToServer_mockFile_fileRecieveCompleted(const Event& event, voi
     m_events.raiseQuitEvent();
 }
 
-void 
+void
 NetworkTests::sendMockData(void* eventTarget)
 {
     // send first message (file size)
     String size = barrier::string::sizeTypeToString(kMockDataSize);
     FileChunk* sizeMessage = FileChunk::start(size);
-    
+
     m_events.addEvent(Event(m_events.forFile().fileChunkSending(), eventTarget, sizeMessage));
 
     // send chunk messages with incrementing chunk size
@@ -452,7 +452,7 @@ NetworkTests::sendMockData(void* eventTarget)
         }
 
     }
-    
+
     // send last message
     FileChunk* transferFinished = FileChunk::end();
     m_events.addEvent(Event(m_events.forFile().fileChunkSending(), eventTarget, transferFinished));

--- a/src/test/integtests/platform/MSWindowsClipboardTests.cpp
+++ b/src/test/integtests/platform/MSWindowsClipboardTests.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2011 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -36,7 +36,7 @@ protected:
     }
 
 private:
-    void emptyClipboard() 
+    void emptyClipboard()
     {
         MSWindowsClipboard clipboard(NULL);
         clipboard.open(0);

--- a/src/test/integtests/platform/MSWindowsKeyStateTests.cpp
+++ b/src/test/integtests/platform/MSWindowsKeyStateTests.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2011 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -73,7 +73,7 @@ TEST_F(MSWindowsKeyStateTests, disable_eventQueueNotUsed)
 	MSWindowsDesks* desks = newDesks(&eventQueue);
 	MockKeyMap keyMap;
 	MSWindowsKeyState keyState(desks, getEventTarget(), &eventQueue, keyMap);
-	
+
 	EXPECT_CALL(eventQueue, removeHandler(_, _)).Times(0);
 
 	keyState.disable();

--- a/src/test/integtests/platform/OSXClipboardTests.cpp
+++ b/src/test/integtests/platform/OSXClipboardTests.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2011 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -25,9 +25,9 @@ TEST(OSXClipboardTests, empty_openCalled_returnsTrue)
 {
     OSXClipboard clipboard;
     clipboard.open(0);
-    
+
     bool actual = clipboard.empty();
-    
+
     EXPECT_EQ(true, actual);
 }
 
@@ -36,9 +36,9 @@ TEST(OSXClipboardTests, empty_singleFormat_hasReturnsFalse)
     OSXClipboard clipboard;
     clipboard.open(0);
     clipboard.add(OSXClipboard::kText, "barrier rocks!");
-    
+
     clipboard.empty();
-    
+
     bool actual = clipboard.has(OSXClipboard::kText);
     EXPECT_EQ(false, actual);
 }
@@ -47,9 +47,9 @@ TEST(OSXClipboardTests, add_newValue_valueWasStored)
 {
     OSXClipboard clipboard;
     clipboard.open(0);
-    
+
     clipboard.add(IClipboard::kText, "barrier rocks!");
-    
+
     String actual = clipboard.get(IClipboard::kText);
     EXPECT_EQ("barrier rocks!", actual);
 }
@@ -58,10 +58,10 @@ TEST(OSXClipboardTests, add_replaceValue_valueWasReplaced)
 {
     OSXClipboard clipboard;
     clipboard.open(0);
-    
+
     clipboard.add(IClipboard::kText, "barrier rocks!");
     clipboard.add(IClipboard::kText, "maxivista sucks"); // haha, just kidding.
-    
+
     String actual = clipboard.get(IClipboard::kText);
     EXPECT_EQ("maxivista sucks", actual);
 }
@@ -69,18 +69,18 @@ TEST(OSXClipboardTests, add_replaceValue_valueWasReplaced)
 TEST(OSXClipboardTests, open_timeIsZero_returnsTrue)
 {
     OSXClipboard clipboard;
-    
+
     bool actual = clipboard.open(0);
-    
+
     EXPECT_EQ(true, actual);
 }
 
 TEST(OSXClipboardTests, open_timeIsOne_returnsTrue)
 {
     OSXClipboard clipboard;
-    
+
     bool actual = clipboard.open(1);
-    
+
     EXPECT_EQ(true, actual);
 }
 
@@ -88,9 +88,9 @@ TEST(OSXClipboardTests, close_isOpen_noErrors)
 {
     OSXClipboard clipboard;
     clipboard.open(0);
-    
+
     clipboard.close();
-    
+
     // can't assert anything
 }
 
@@ -98,9 +98,9 @@ TEST(OSXClipboardTests, getTime_openWithNoEmpty_returnsOne)
 {
     OSXClipboard clipboard;
     clipboard.open(1);
-    
+
     OSXClipboard::Time actual = clipboard.getTime();
-    
+
     // this behavior is different to that of Clipboard which only
     // returns the value passed into open(t) after empty() is called.
     EXPECT_EQ((UInt32)1, actual);
@@ -111,9 +111,9 @@ TEST(OSXClipboardTests, getTime_openAndEmpty_returnsOne)
     OSXClipboard clipboard;
     clipboard.open(1);
     clipboard.empty();
-    
+
     OSXClipboard::Time actual = clipboard.getTime();
-    
+
     EXPECT_EQ((UInt32)1, actual);
 }
 
@@ -123,9 +123,9 @@ TEST(OSXClipboardTests, has_withFormatAdded_returnsTrue)
     clipboard.open(0);
     clipboard.empty();
     clipboard.add(IClipboard::kText, "barrier rocks!");
-    
+
     bool actual = clipboard.has(IClipboard::kText);
-    
+
     EXPECT_EQ(true, actual);
 }
 
@@ -134,9 +134,9 @@ TEST(OSXClipboardTests, has_withNoFormats_returnsFalse)
     OSXClipboard clipboard;
     clipboard.open(0);
     clipboard.empty();
-    
+
     bool actual = clipboard.has(IClipboard::kText);
-    
+
     EXPECT_EQ(false, actual);
 }
 
@@ -145,9 +145,9 @@ TEST(OSXClipboardTests, get_withNoFormats_returnsEmpty)
     OSXClipboard clipboard;
     clipboard.open(0);
     clipboard.empty();
-    
+
     String actual = clipboard.get(IClipboard::kText);
-    
+
     EXPECT_EQ("", actual);
 }
 
@@ -157,8 +157,8 @@ TEST(OSXClipboardTests, get_withFormatAdded_returnsExpected)
     clipboard.open(0);
     clipboard.empty();
     clipboard.add(IClipboard::kText, "barrier rocks!");
-    
+
     String actual = clipboard.get(IClipboard::kText);
-    
+
     EXPECT_EQ("barrier rocks!", actual);
 }

--- a/src/test/integtests/platform/OSXScreenTests.cpp
+++ b/src/test/integtests/platform/OSXScreenTests.cpp
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/test/integtests/platform/XWindowsClipboardTests.cpp
+++ b/src/test/integtests/platform/XWindowsClipboardTests.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2011 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -33,12 +33,12 @@ protected:
         m_display = XOpenDisplay(NULL);
         int screen = DefaultScreen(m_display);
         Window root = XRootWindow(m_display, screen);
-        
+
         XSetWindowAttributes attr;
         attr.do_not_propagate_mask = 0;
         attr.override_redirect = True;
         attr.cursor = Cursor();
-        
+
         m_window = XCreateWindow(
             m_display, root, 0, 0, 1, 1, 0, 0,
             InputOnly, CopyFromParent, 0, &attr);
@@ -68,9 +68,9 @@ protected:
 TEST_F(CXWindowsClipboardTests, empty_openCalled_returnsTrue)
 {
     CXWindowsClipboard clipboard = createClipboard();
-    
+
     bool actual = clipboard.empty();
-    
+
     EXPECT_EQ(true, actual);
 }
 
@@ -78,9 +78,9 @@ TEST_F(CXWindowsClipboardTests, empty_singleFormat_hasReturnsFalse)
 {
     CXWindowsClipboard clipboard = createClipboard();
     clipboard.add(CXWindowsClipboard::kText, "barrier rocks!");
-    
+
     clipboard.empty();
-    
+
     bool actual = clipboard.has(CXWindowsClipboard::kText);
     EXPECT_FALSE(actual);
 }
@@ -88,9 +88,9 @@ TEST_F(CXWindowsClipboardTests, empty_singleFormat_hasReturnsFalse)
 TEST_F(CXWindowsClipboardTests, add_newValue_valueWasStored)
 {
     CXWindowsClipboard clipboard = createClipboard();
-    
+
     clipboard.add(IClipboard::kText, "barrier rocks!");
-    
+
     String actual = clipboard.get(IClipboard::kText);
     EXPECT_EQ("barrier rocks!", actual);
 }
@@ -98,10 +98,10 @@ TEST_F(CXWindowsClipboardTests, add_newValue_valueWasStored)
 TEST_F(CXWindowsClipboardTests, add_replaceValue_valueWasReplaced)
 {
     CXWindowsClipboard clipboard = createClipboard();
-    
+
     clipboard.add(IClipboard::kText, "barrier rocks!");
     clipboard.add(IClipboard::kText, "maxivista sucks"); // haha, just kidding.
-    
+
     String actual = clipboard.get(IClipboard::kText);
     EXPECT_EQ("maxivista sucks", actual);
 }
@@ -109,10 +109,10 @@ TEST_F(CXWindowsClipboardTests, add_replaceValue_valueWasReplaced)
 TEST_F(CXWindowsClipboardTests, close_isOpen_noErrors)
 {
     CXWindowsClipboard clipboard = createClipboard();
-    
+
     // clipboard opened in createClipboard()
     clipboard.close();
-    
+
     // can't assert anything
 }
 
@@ -120,27 +120,27 @@ TEST_F(CXWindowsClipboardTests, has_withFormatAdded_returnsTrue)
 {
     CXWindowsClipboard clipboard = createClipboard();
     clipboard.add(IClipboard::kText, "barrier rocks!");
-    
+
     bool actual = clipboard.has(IClipboard::kText);
-    
+
     EXPECT_EQ(true, actual);
 }
 
 TEST_F(CXWindowsClipboardTests, has_withNoFormats_returnsFalse)
 {
     CXWindowsClipboard clipboard = createClipboard();
-    
+
     bool actual = clipboard.has(IClipboard::kText);
-    
+
     EXPECT_FALSE(actual);
 }
 
 TEST_F(CXWindowsClipboardTests, get_withNoFormats_returnsEmpty)
 {
     CXWindowsClipboard clipboard = createClipboard();
-    
+
     String actual = clipboard.get(IClipboard::kText);
-    
+
     EXPECT_EQ("", actual);
 }
 
@@ -148,9 +148,9 @@ TEST_F(CXWindowsClipboardTests, get_withFormatAdded_returnsExpected)
 {
     CXWindowsClipboard clipboard = createClipboard();
     clipboard.add(IClipboard::kText, "barrier rocks!");
-    
+
     String actual = clipboard.get(IClipboard::kText);
-    
+
     EXPECT_EQ("barrier rocks!", actual);
 }
 

--- a/src/test/mock/barrier/MockEventQueue.h
+++ b/src/test/mock/barrier/MockEventQueue.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2011 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/test/mock/barrier/MockKeyState.h
+++ b/src/test/mock/barrier/MockKeyState.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2011 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/test/mock/ipc/MockIpcServer.h
+++ b/src/test/mock/ipc/MockIpcServer.h
@@ -34,7 +34,7 @@ public:
     MockIpcServer() :
         m_sendCond(ARCH->newCondVar()),
         m_sendMutex(ARCH->newMutex()) { }
-    
+
     ~MockIpcServer() {
         if (m_sendCond != NULL) {
             ARCH->closeCondVar(m_sendCond);

--- a/src/test/unittests/CMakeLists.txt
+++ b/src/test/unittests/CMakeLists.txt
@@ -1,11 +1,11 @@
 # barrier -- mouse and keyboard sharing utility
 # Copyright (C) 2012-2016 Symless Ltd.
 # Copyright (C) 2009 Nick Bolton
-# 
+#
 # This package is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # found in the file LICENSE that should have accompanied this file.
-# 
+#
 # This package is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/test/unittests/Main.cpp
+++ b/src/test/unittests/Main.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2011 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -35,12 +35,12 @@ main(int argc, char **argv)
 
     Arch arch;
     arch.init();
-    
+
     Log log;
     log.setFilter(kDEBUG4);
 
     testing::InitGoogleTest(&argc, argv);
-  
+
   // gtest seems to randomly finish with error codes (e.g. -1, -1073741819)
   // even when no tests have failed. not sure what causes this, but it
   // happens on all platforms and  keeps leading to false positives.

--- a/src/test/unittests/barrier/ArgParserTests.cpp
+++ b/src/test/unittests/barrier/ArgParserTests.cpp
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2014-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/test/unittests/barrier/ClientArgsParsingTests.cpp
+++ b/src/test/unittests/barrier/ClientArgsParsingTests.cpp
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2014-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/test/unittests/barrier/ClipboardChunkTests.cpp
+++ b/src/test/unittests/barrier/ClipboardChunkTests.cpp
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2015-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/test/unittests/barrier/ClipboardTests.cpp
+++ b/src/test/unittests/barrier/ClipboardTests.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2011 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -192,7 +192,7 @@ TEST(ClipboardTests, marshall_withTextAdded_lastSizeCharIs14)
     EXPECT_EQ(14, (int)actual[11]);
 }
 
-// TODO: there's some integer -> char encoding going on here. i find it 
+// TODO: there's some integer -> char encoding going on here. i find it
 // hard to believe that the clipboard is the only thing doing this. maybe
 // we should refactor this stuff out of the clipboard.
 TEST(ClipboardTests, marshall_withTextSize285_sizeCharsValid)
@@ -212,12 +212,12 @@ TEST(ClipboardTests, marshall_withTextSize285_sizeCharsValid)
 
     String actual = clipboard.marshall();
 
-    // 4 asserts here, but that's ok because we're really just asserting 1 
+    // 4 asserts here, but that's ok because we're really just asserting 1
     // thing. the 32-bit size value is split into 4 chars. if the size is 285
-    // (29 more than the 8-bit max size), the last char "rolls over" to 29 
-    // (this is caused by a bit-wise & on 0xff and 8-bit truncation). each 
-    // char before the last stores a bit-shifted version of the number, each 
-    // 1 more power than the last, which is done by bit-shifting [0] by 24, 
+    // (29 more than the 8-bit max size), the last char "rolls over" to 29
+    // (this is caused by a bit-wise & on 0xff and 8-bit truncation). each
+    // char before the last stores a bit-shifted version of the number, each
+    // 1 more power than the last, which is done by bit-shifting [0] by 24,
     // [1] by 16, [2] by 8 ([3] is not bit-shifted).
     EXPECT_EQ(0, actual[8]); // 285 >> 24 = 285 / (256^3) = 0
     EXPECT_EQ(0, actual[9]); // 285 >> 16 = 285 / (256^2) = 0

--- a/src/test/unittests/barrier/GenericArgsParsingTests.cpp
+++ b/src/test/unittests/barrier/GenericArgsParsingTests.cpp
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2014-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -50,7 +50,7 @@ TEST(GenericArgsParsingTests, parseGenericArgs_logLevelCmd_setLogLevel)
     ArgParser argParser(NULL);
     ArgsBase argsBase;
     argParser.setArgsBase(argsBase);
-    
+
     argParser.parseGenericArgs(argc, kLogLevelCmd, i);
 
     String logFilter(argsBase.m_logFilter);
@@ -68,7 +68,7 @@ TEST(GenericArgsParsingTests, parseGenericArgs_logFileCmd_saveLogFilename)
     ArgParser argParser(NULL);
     ArgsBase argsBase;
     argParser.setArgsBase(argsBase);
-    
+
     argParser.parseGenericArgs(argc, kLogFileCmd, i);
 
     String logFile(argsBase.m_logFile);
@@ -86,7 +86,7 @@ TEST(GenericArgsParsingTests, parseGenericArgs_logFileCmdWithSpace_saveLogFilena
     ArgParser argParser(NULL);
     ArgsBase argsBase;
     argParser.setArgsBase(argsBase);
-    
+
     argParser.parseGenericArgs(argc, kLogFileCmdWithSpace, i);
 
     String logFile(argsBase.m_logFile);
@@ -104,7 +104,7 @@ TEST(GenericArgsParsingTests, parseGenericArgs_noDeamonCmd_daemonFalse)
     ArgParser argParser(NULL);
     ArgsBase argsBase;
     argParser.setArgsBase(argsBase);
-    
+
     argParser.parseGenericArgs(argc, kNoDeamonCmd, i);
 
     EXPECT_FALSE(argsBase.m_daemon);
@@ -120,7 +120,7 @@ TEST(GenericArgsParsingTests, parseGenericArgs_deamonCmd_daemonTrue)
     ArgParser argParser(NULL);
     ArgsBase argsBase;
     argParser.setArgsBase(argsBase);
-    
+
     argParser.parseGenericArgs(argc, kDeamonCmd, i);
 
     EXPECT_EQ(true, argsBase.m_daemon);
@@ -136,7 +136,7 @@ TEST(GenericArgsParsingTests, parseGenericArgs_nameCmd_saveName)
     ArgParser argParser(NULL);
     ArgsBase argsBase;
     argParser.setArgsBase(argsBase);
-    
+
     argParser.parseGenericArgs(argc, kNameCmd, i);
 
     EXPECT_EQ("mock", argsBase.m_name);
@@ -152,7 +152,7 @@ TEST(GenericArgsParsingTests, parseGenericArgs_noRestartCmd_restartFalse)
     ArgParser argParser(NULL);
     ArgsBase argsBase;
     argParser.setArgsBase(argsBase);
-    
+
     argParser.parseGenericArgs(argc, kNoRestartCmd, i);
 
     EXPECT_FALSE(argsBase.m_restartable);
@@ -168,7 +168,7 @@ TEST(GenericArgsParsingTests, parseGenericArgs_restartCmd_restartTrue)
     ArgParser argParser(NULL);
     ArgsBase argsBase;
     argParser.setArgsBase(argsBase);
-    
+
     argParser.parseGenericArgs(argc, kRestartCmd, i);
 
     EXPECT_EQ(true, argsBase.m_restartable);
@@ -184,7 +184,7 @@ TEST(GenericArgsParsingTests, parseGenericArgs_backendCmd_backendTrue)
     ArgParser argParser(NULL);
     ArgsBase argsBase;
     argParser.setArgsBase(argsBase);
-    
+
     argParser.parseGenericArgs(argc, kBackendCmd, i);
 
     EXPECT_EQ(true, argsBase.m_backend);
@@ -200,7 +200,7 @@ TEST(GenericArgsParsingTests, parseGenericArgs_noHookCmd_noHookTrue)
     ArgParser argParser(NULL);
     ArgsBase argsBase;
     argParser.setArgsBase(argsBase);
-    
+
     argParser.parseGenericArgs(argc, kNoHookCmd, i);
 
     EXPECT_EQ(true, argsBase.m_noHooks);
@@ -219,7 +219,7 @@ TEST(GenericArgsParsingTests, parseGenericArgs_helpCmd_showHelp)
     ArgsBase argsBase;
     argParser.setArgsBase(argsBase);
     ON_CALL(app, help()).WillByDefault(Invoke(showMockHelp));
-    
+
     argParser.parseGenericArgs(argc, kHelpCmd, i);
 
     EXPECT_EQ(true, g_helpShowed);
@@ -239,7 +239,7 @@ TEST(GenericArgsParsingTests, parseGenericArgs_versionCmd_showVersion)
     ArgsBase argsBase;
     argParser.setArgsBase(argsBase);
     ON_CALL(app, version()).WillByDefault(Invoke(showMockVersion));
-    
+
     argParser.parseGenericArgs(argc, kVersionCmd, i);
 
     EXPECT_EQ(true, g_versionShowed);
@@ -255,7 +255,7 @@ TEST(GenericArgsParsingTests, parseGenericArgs_noTrayCmd_disableTrayTrue)
     ArgParser argParser(NULL);
     ArgsBase argsBase;
     argParser.setArgsBase(argsBase);
-    
+
     argParser.parseGenericArgs(argc, kNoTrayCmd, i);
 
     EXPECT_EQ(true, argsBase.m_disableTray);
@@ -271,7 +271,7 @@ TEST(GenericArgsParsingTests, parseGenericArgs_ipcCmd_enableIpcTrue)
     ArgParser argParser(NULL);
     ArgsBase argsBase;
     argParser.setArgsBase(argsBase);
-    
+
     argParser.parseGenericArgs(argc, kIpcCmd, i);
 
     EXPECT_EQ(true, argsBase.m_enableIpc);
@@ -288,7 +288,7 @@ TEST(GenericArgsParsingTests, parseGenericArgs_dragDropCmdOnNonLinux_enableDragD
     ArgParser argParser(NULL);
     ArgsBase argsBase;
     argParser.setArgsBase(argsBase);
-    
+
     argParser.parseGenericArgs(argc, kDragDropCmd, i);
 
     EXPECT_EQ(true, argsBase.m_enableDragDrop);
@@ -306,7 +306,7 @@ TEST(GenericArgsParsingTests, parseGenericArgs_dragDropCmdOnLinux_enableDragDrop
     ArgParser argParser(NULL);
     ArgsBase argsBase;
     argParser.setArgsBase(argsBase);
-    
+
     argParser.parseGenericArgs(argc, kDragDropCmd, i);
 
     EXPECT_FALSE(argsBase.m_enableDragDrop);

--- a/src/test/unittests/barrier/KeyMapTests.cpp
+++ b/src/test/unittests/barrier/KeyMapTests.cpp
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2016 Symless
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -30,7 +30,7 @@ using ::testing::ReturnRef;
 using ::testing::SaveArg;
 
 namespace barrier {
-    
+
 TEST(KeyMapTests, findBestKey_requiredDown_matchExactFirstItem)
 {
     KeyMap keyMap;
@@ -46,7 +46,7 @@ TEST(KeyMapTests, findBestKey_requiredDown_matchExactFirstItem)
 
     EXPECT_EQ(0, keyMap.findBestKey(entryList, currentState, desiredState));
 }
-    
+
 TEST(KeyMapTests, findBestKey_requiredAndExtraSensitiveDown_matchExactFirstItem)
 {
     KeyMap keyMap;
@@ -84,7 +84,7 @@ TEST(KeyMapTests, findBestKey_requiredAndExtraSensitiveDown_matchExactSecondItem
 
     EXPECT_EQ(1, keyMap.findBestKey(entryList, currentState, desiredState));
 }
-    
+
 TEST(KeyMapTests, findBestKey_extraSensitiveDown_matchExactSecondItem)
 {
     KeyMap keyMap;
@@ -103,7 +103,7 @@ TEST(KeyMapTests, findBestKey_extraSensitiveDown_matchExactSecondItem)
     itemList2.push_back(item2);
     entryList.push_back(itemList1);
     entryList.push_back(itemList2);
-        
+
     EXPECT_EQ(1, keyMap.findBestKey(entryList, currentState, desiredState));
 }
 
@@ -125,7 +125,7 @@ TEST(KeyMapTests, findBestKey_noRequiredDown_matchOneRequiredChangeItem)
     itemList2.push_back(item2);
     entryList.push_back(itemList1);
     entryList.push_back(itemList2);
-    
+
     EXPECT_EQ(1, keyMap.findBestKey(entryList, currentState, desiredState));
 }
 
@@ -150,7 +150,7 @@ TEST(KeyMapTests, findBestKey_onlyOneRequiredDown_matchTwoRequiredChangesItem)
 
     EXPECT_EQ(1, keyMap.findBestKey(entryList, currentState, desiredState));
 }
-    
+
 TEST(KeyMapTests, findBestKey_noRequiredDown_cannotMatch)
 {
     KeyMap keyMap;
@@ -163,31 +163,31 @@ TEST(KeyMapTests, findBestKey_noRequiredDown_cannotMatch)
     KeyModifierMask desiredState = 0;
     itemList.push_back(item);
     entryList.push_back(itemList);
-    
+
     EXPECT_EQ(-1, keyMap.findBestKey(entryList, currentState, desiredState));
 }
-    
+
 TEST(KeyMapTests, isCommand_shiftMask_returnFalse)
 {
     KeyMap keyMap;
     KeyModifierMask mask= KeyModifierShift;
-    
+
     EXPECT_FALSE(keyMap.isCommand(mask));
 }
-    
+
 TEST(KeyMapTests, isCommand_controlMask_returnTrue)
 {
     KeyMap keyMap;
     KeyModifierMask mask= KeyModifierControl;
-        
+
     EXPECT_EQ(true, keyMap.isCommand(mask));
 }
-    
+
 TEST(KeyMapTests, isCommand_alternateMask_returnTrue)
 {
     KeyMap keyMap;
     KeyModifierMask mask= KeyModifierAlt;
-    
+
     EXPECT_EQ(true, keyMap.isCommand(mask));
 }
 
@@ -195,15 +195,15 @@ TEST(KeyMapTests, isCommand_alternateGraphicMask_returnTrue)
 {
     KeyMap keyMap;
     KeyModifierMask mask= KeyModifierAltGr;
-    
+
     EXPECT_EQ(true, keyMap.isCommand(mask));
 }
-    
+
 TEST(KeyMapTests, isCommand_metaMask_returnTrue)
 {
     KeyMap keyMap;
     KeyModifierMask mask= KeyModifierMeta;
-    
+
     EXPECT_EQ(true, keyMap.isCommand(mask));
 }
 
@@ -211,8 +211,8 @@ TEST(KeyMapTests, isCommand_superMask_returnTrue)
 {
     KeyMap keyMap;
     KeyModifierMask mask= KeyModifierSuper;
-    
+
     EXPECT_EQ(true, keyMap.isCommand(mask));
 }
-    
+
 }

--- a/src/test/unittests/barrier/KeyStateTests.cpp
+++ b/src/test/unittests/barrier/KeyStateTests.cpp
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2011 Nick Bolton
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -100,7 +100,7 @@ TEST(KeyStateTests, sendKeyEvent_halfDuplex_addEventCalledTwice)
     KeyStateImpl keyState(eventQueue, keyMap);
     IKeyStateEvents keyStateEvents;
     keyStateEvents.setEvents(&eventQueue);
-    
+
     ON_CALL(keyMap, isHalfDuplex(_, _)).WillByDefault(Return(true));
     ON_CALL(eventQueue, forIKeyState()).WillByDefault(ReturnRef(keyStateEvents));
 
@@ -116,7 +116,7 @@ TEST(KeyStateTests, sendKeyEvent_keyRepeat_addEventCalledOnce)
     KeyStateImpl keyState(eventQueue, keyMap);
     IKeyStateEvents keyStateEvents;
     keyStateEvents.setEvents(&eventQueue);
-    
+
     ON_CALL(eventQueue, forIKeyState()).WillByDefault(ReturnRef(keyStateEvents));
 
     EXPECT_CALL(eventQueue, addEvent(_)).Times(1);
@@ -131,7 +131,7 @@ TEST(KeyStateTests, sendKeyEvent_keyDown_addEventCalledOnce)
     KeyStateImpl keyState(eventQueue, keyMap);
     IKeyStateEvents keyStateEvents;
     keyStateEvents.setEvents(&eventQueue);
-    
+
     ON_CALL(eventQueue, forIKeyState()).WillByDefault(ReturnRef(keyStateEvents));
 
     EXPECT_CALL(eventQueue, addEvent(_)).Times(1);
@@ -146,7 +146,7 @@ TEST(KeyStateTests, sendKeyEvent_keyUp_addEventCalledOnce)
     KeyStateImpl keyState(eventQueue, keyMap);
     IKeyStateEvents keyStateEvents;
     keyStateEvents.setEvents(&eventQueue);
-    
+
     ON_CALL(eventQueue, forIKeyState()).WillByDefault(ReturnRef(keyStateEvents));
 
     EXPECT_CALL(eventQueue, addEvent(_)).Times(1);

--- a/src/test/unittests/base/StringTests.cpp
+++ b/src/test/unittests/base/StringTests.cpp
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2014-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/src/test/unittests/ipc/IpcLogOutputterTests.cpp
+++ b/src/test/unittests/ipc/IpcLogOutputterTests.cpp
@@ -1,11 +1,11 @@
 /*
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2015-2016 Symless Ltd.
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -50,7 +50,7 @@ TEST(IpcLogOutputterTests, write_threadingEnabled_bufferIsSent)
 {
     MockIpcServer mockServer;
     mockServer.delegateToFake();
-    
+
     ON_CALL(mockServer, hasClients(_)).WillByDefault(Return(true));
 
     EXPECT_CALL(mockServer, hasClients(_)).Times(AtLeast(3));
@@ -67,7 +67,7 @@ TEST(IpcLogOutputterTests, write_threadingEnabled_bufferIsSent)
 TEST(IpcLogOutputterTests, write_overBufferMaxSize_firstLineTruncated)
 {
     MockIpcServer mockServer;
-    
+
     ON_CALL(mockServer, hasClients(_)).WillByDefault(Return(true));
     EXPECT_CALL(mockServer, hasClients(_)).Times(1);
     EXPECT_CALL(mockServer, send(IpcLogLineMessageEq("mock 2\nmock 3\n"), _)).Times(1);
@@ -85,7 +85,7 @@ TEST(IpcLogOutputterTests, write_overBufferMaxSize_firstLineTruncated)
 TEST(IpcLogOutputterTests, write_underBufferMaxSize_allLinesAreSent)
 {
     MockIpcServer mockServer;
-    
+
     ON_CALL(mockServer, hasClients(_)).WillByDefault(Return(true));
 
     EXPECT_CALL(mockServer, hasClients(_)).Times(1);
@@ -107,7 +107,7 @@ TEST(IpcLogOutputterTests, write_underBufferMaxSize_allLinesAreSent)
 TEST(IpcLogOutputterTests, write_overBufferRateLimit_lastLineTruncated)
 {
     MockIpcServer mockServer;
-    
+
     ON_CALL(mockServer, hasClients(_)).WillByDefault(Return(true));
 
     EXPECT_CALL(mockServer, hasClients(_)).Times(2);
@@ -123,7 +123,7 @@ TEST(IpcLogOutputterTests, write_overBufferRateLimit_lastLineTruncated)
     outputter.write(kNOTE, "mock 3");
 
     outputter.sendBuffer();
-    
+
     // after waiting the time limit send another to make sure
     // we can log after the time limit passes.
     // HACK: sleep causes the unit test to fail intermittently,
@@ -140,7 +140,7 @@ TEST(IpcLogOutputterTests, write_overBufferRateLimit_lastLineTruncated)
 TEST(IpcLogOutputterTests, write_underBufferRateLimit_allLinesAreSent)
 {
     MockIpcServer mockServer;
-    
+
     ON_CALL(mockServer, hasClients(_)).WillByDefault(Return(true));
 
     EXPECT_CALL(mockServer, hasClients(_)).Times(2);
@@ -154,7 +154,7 @@ TEST(IpcLogOutputterTests, write_underBufferRateLimit_allLinesAreSent)
     outputter.write(kNOTE, "mock 1");
     outputter.write(kNOTE, "mock 2");
     outputter.sendBuffer();
-    
+
     // after waiting the time limit send another to make sure
     // we can log after the time limit passes.
     outputter.write(kNOTE, "mock 3");

--- a/src/test/unittests/platform/OSXKeyStateTests.cpp
+++ b/src/test/unittests/platform/OSXKeyStateTests.cpp
@@ -30,27 +30,27 @@ TEST(OSXKeyStateTests, mapModifiersFromOSX_OSXMask_returnBarrierMask)
     OSXKeyState keyState(&eventQueue, keyMap);
 
     KeyModifierMask outMask = 0;
-    
+
     UInt32 shiftMask = 0 | kCGEventFlagMaskShift;
     outMask = keyState.mapModifiersFromOSX(shiftMask);
     EXPECT_EQ(KeyModifierShift, outMask);
-    
+
     UInt32 ctrlMask = 0 | kCGEventFlagMaskControl;
     outMask = keyState.mapModifiersFromOSX(ctrlMask);
     EXPECT_EQ(KeyModifierControl, outMask);
-    
+
     UInt32 altMask = 0 | kCGEventFlagMaskAlternate;
     outMask = keyState.mapModifiersFromOSX(altMask);
     EXPECT_EQ(KeyModifierAlt, outMask);
-    
+
     UInt32 cmdMask = 0 | kCGEventFlagMaskCommand;
     outMask = keyState.mapModifiersFromOSX(cmdMask);
     EXPECT_EQ(KeyModifierSuper, outMask);
-    
+
     UInt32 capsMask = 0 | kCGEventFlagMaskAlphaShift;
     outMask = keyState.mapModifiersFromOSX(capsMask);
     EXPECT_EQ(KeyModifierCapsLock, outMask);
-    
+
     UInt32 numMask = 0 | kCGEventFlagMaskNumericPad;
     outMask = keyState.mapModifiersFromOSX(numMask);
     EXPECT_EQ(KeyModifierNumLock, outMask);


### PR DESCRIPTION
Many tools strip trailing whitespaces by default, so after editing a file with
whitespace errors we end up with a bunch of unrelated hunks that need to be
reverted locally.

This could be fixed by configuring each tool to not do this (at least for the
barrier repo), or, simpler, we just sed the problem away and make barrier
whitespace-compliant.

sed commands run:
``` 
 sed -i 's/[ \t]\+$//' **/*.(cpp|h) **/*CMakeLists.txt
```
Verified with `git diff --ignore-space-change`, this shows the empty diff.