### PR TITLE
Remove some #defines that had no useful effect

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,11 +195,6 @@ if (UNIX)
         check_include_files ("X11/extensions/XInput2.h" HAVE_XI2)
         check_include_files ("dns_sd.h" HAVE_DNSSD)
 
-        if (HAVE_X11_EXTENSIONS_DPMS_H)
-            # Assume that function prototypes declared, when include exists.
-            set (HAVE_DPMS_PROTOTYPES 1)
-        endif()
-
         if (NOT HAVE_X11_EXTENSIONS_XTEST_H)
             message (FATAL_ERROR "Missing header: X11/extensions/XTest.h")
         endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,6 +200,10 @@ if (UNIX)
             set (HAVE_DPMS_PROTOTYPES 1)
         endif()
 
+        if (NOT HAVE_X11_EXTENSIONS_XTEST_H)
+            message (FATAL_ERROR "Missing header: X11/extensions/XTest.h")
+        endif()
+
         if (NOT HAVE_X11_XKBLIB_H)
             message (FATAL_ERROR "Missing header: " ${XKBlib})
         endif()

--- a/res/config.h.in
+++ b/res/config.h.in
@@ -115,9 +115,6 @@
 /* Define to 1 if you have the <X11/extensions/XKBstr.h> header file. */
 #cmakedefine HAVE_X11_EXTENSIONS_XKBSTR_H ${HAVE_X11_EXTENSIONS_XKBSTR_H}
 
-/* Define to 1 if you have the <X11/extensions/XTest.h> header file. */
-#cmakedefine HAVE_X11_EXTENSIONS_XTEST_H ${HAVE_X11_EXTENSIONS_XTEST_H}
-
 /* Define to 1 if you have the <X11/XKBlib.h> header file. */
 #cmakedefine HAVE_X11_XKBLIB_H ${HAVE_X11_XKBLIB_H}
 

--- a/res/config.h.in
+++ b/res/config.h.in
@@ -160,8 +160,5 @@
 /* Define to 1 if your <sys/time.h> declares `struct tm`. */
 #cmakedefine TM_IN_SYS_TIME ${TM_IN_SYS_TIME}
 
-/* Define to 1 if the X Window System is missing or not being used. */
-#cmakedefine X_DISPLAY_MISSING ${X_DISPLAY_MISSING}
-
 /* Define to `unsigned int` if <sys/types.h> does not define. */
 #cmakedefine size_t ${size_t}

--- a/res/config.h.in
+++ b/res/config.h.in
@@ -19,9 +19,6 @@
 /* Define if your compiler has standard C++ library support. */
 #cmakedefine HAVE_CXX_STDLIB ${HAVE_CXX_STDLIB}
 
-/* Define if the <X11/extensions/dpms.h> header file declares function prototypes. */
-#cmakedefine HAVE_DPMS_PROTOTYPES ${HAVE_DPMS_PROTOTYPES}
-
 /* Define if you have a working `getpwuid_r` function. */
 #cmakedefine HAVE_GETPWUID_R ${HAVE_GETPWUID_R}
 

--- a/src/lib/platform/IXWindowsImpl.h
+++ b/src/lib/platform/IXWindowsImpl.h
@@ -13,11 +13,7 @@
 #	include <X11/extensions/dpms.h>
      }
 #endif
-#if HAVE_X11_EXTENSIONS_XTEST_H
-#	include <X11/extensions/XTest.h>
-#else
-#	error The XTest extension is required to build barrier
-#endif
+#include <X11/extensions/XTest.h>
 #if HAVE_X11_EXTENSIONS_XINERAMA_H
      // Xinerama.h may lack extern "C" for inclusion by C++
      extern "C" {

--- a/src/lib/platform/IXWindowsImpl.h
+++ b/src/lib/platform/IXWindowsImpl.h
@@ -3,39 +3,35 @@
 
 #include "config.h"
 
-#if X_DISPLAY_MISSING
-#	error X11 is required to build barrier
+#include <X11/X.h>
+#include <X11/Xutil.h>
+#define XK_MISCELLANY
+#define XK_XKB_KEYS
+#include <X11/keysymdef.h>
+#if HAVE_X11_EXTENSIONS_DPMS_H
+     extern "C" {
+#	include <X11/extensions/dpms.h>
+     }
+#endif
+#if HAVE_X11_EXTENSIONS_XTEST_H
+#	include <X11/extensions/XTest.h>
 #else
-#	include <X11/X.h>
-#	include <X11/Xutil.h>
-#	define XK_MISCELLANY
-#	define XK_XKB_KEYS
-#	include <X11/keysymdef.h>
-#	if HAVE_X11_EXTENSIONS_DPMS_H
-        extern "C" {
-#		include <X11/extensions/dpms.h>
-        }
-#	endif
-#	if HAVE_X11_EXTENSIONS_XTEST_H
-#		include <X11/extensions/XTest.h>
-#	else
-#		error The XTest extension is required to build barrier
-#	endif
-#	if HAVE_X11_EXTENSIONS_XINERAMA_H
-        // Xinerama.h may lack extern "C" for inclusion by C++
-        extern "C" {
-#		include <X11/extensions/Xinerama.h>
-        }
-#	endif
-#	if HAVE_X11_EXTENSIONS_XRANDR_H
-#		include <X11/extensions/Xrandr.h>
-#	endif
-#	if HAVE_XKB_EXTENSION
-#		include <X11/XKBlib.h>
-#	endif
-#	ifdef HAVE_XI2
-#		include <X11/extensions/XInput2.h>
-#	endif
+#	error The XTest extension is required to build barrier
+#endif
+#if HAVE_X11_EXTENSIONS_XINERAMA_H
+     // Xinerama.h may lack extern "C" for inclusion by C++
+     extern "C" {
+#	include <X11/extensions/Xinerama.h>
+     }
+#endif
+#if HAVE_X11_EXTENSIONS_XRANDR_H
+#	include <X11/extensions/Xrandr.h>
+#endif
+#if HAVE_XKB_EXTENSION
+#	include <X11/XKBlib.h>
+#endif
+#ifdef HAVE_XI2
+#	include <X11/extensions/XInput2.h>
 #endif
 
 class IXWindowsImpl {

--- a/src/lib/platform/XWindowsClipboard.h
+++ b/src/lib/platform/XWindowsClipboard.h
@@ -25,11 +25,7 @@
 #include "common/stdvector.h"
 #include "XWindowsImpl.h"
 
-#if X_DISPLAY_MISSING
-#    error X11 is required to build barrier
-#else
-#    include <X11/Xlib.h>
-#endif
+#include <X11/Xlib.h>
 
 class IXWindowsClipboardConverter;
 

--- a/src/lib/platform/XWindowsEventQueueBuffer.h
+++ b/src/lib/platform/XWindowsEventQueueBuffer.h
@@ -23,11 +23,7 @@
 #include "common/stdvector.h"
 #include "XWindowsImpl.h"
 
-#if X_DISPLAY_MISSING
-#    error X11 is required to build barrier
-#else
-#    include <X11/Xlib.h>
-#endif
+#include <X11/Xlib.h>
 
 class IEventQueue;
 

--- a/src/lib/platform/XWindowsKeyState.cpp
+++ b/src/lib/platform/XWindowsKeyState.cpp
@@ -24,17 +24,13 @@
 
 #include <cstddef>
 #include <algorithm>
-#if X_DISPLAY_MISSING
-#    error X11 is required to build barrier
-#else
-#    include <X11/X.h>
-#    include <X11/Xutil.h>
-#    define XK_MISCELLANY
-#    define XK_XKB_KEYS
-#    include <X11/keysymdef.h>
+#include <X11/X.h>
+#include <X11/Xutil.h>
+#define XK_MISCELLANY
+#define XK_XKB_KEYS
+#include <X11/keysymdef.h>
 #if HAVE_XKB_EXTENSION
 #    include <X11/XKBlib.h>
-#endif
 #endif
 
 static const size_t ModifiersFromXDefaultSize = 32;

--- a/src/lib/platform/XWindowsKeyState.h
+++ b/src/lib/platform/XWindowsKeyState.h
@@ -23,18 +23,14 @@
 #include "common/stdvector.h"
 #include "XWindowsImpl.h"
 
-#if X_DISPLAY_MISSING
-#    error X11 is required to build barrier
+#include <X11/Xlib.h>
+#if HAVE_X11_EXTENSIONS_XTEST_H
+#    include <X11/extensions/XTest.h>
 #else
-#    include <X11/Xlib.h>
-#    if HAVE_X11_EXTENSIONS_XTEST_H
-#        include <X11/extensions/XTest.h>
-#    else
-#        error The XTest extension is required to build barrier
-#    endif
-#    if HAVE_XKB_EXTENSION
-#        include <X11/extensions/XKBstr.h>
-#    endif
+#    error The XTest extension is required to build barrier
+#endif
+#if HAVE_XKB_EXTENSION
+#    include <X11/extensions/XKBstr.h>
 #endif
 
 class IEventQueue;

--- a/src/lib/platform/XWindowsKeyState.h
+++ b/src/lib/platform/XWindowsKeyState.h
@@ -24,11 +24,7 @@
 #include "XWindowsImpl.h"
 
 #include <X11/Xlib.h>
-#if HAVE_X11_EXTENSIONS_XTEST_H
-#    include <X11/extensions/XTest.h>
-#else
-#    error The XTest extension is required to build barrier
-#endif
+#include <X11/extensions/XTest.h>
 #if HAVE_XKB_EXTENSION
 #    include <X11/extensions/XKBstr.h>
 #endif

--- a/src/lib/platform/XWindowsScreen.h
+++ b/src/lib/platform/XWindowsScreen.h
@@ -24,11 +24,7 @@
 #include "common/stdvector.h"
 #include "XWindowsImpl.h"
 
-#if X_DISPLAY_MISSING
-#    error X11 is required to build barrier
-#else
-#    include <X11/Xlib.h>
-#endif
+#include <X11/Xlib.h>
 
 class XWindowsClipboard;
 class XWindowsKeyState;

--- a/src/lib/platform/XWindowsScreenSaver.cpp
+++ b/src/lib/platform/XWindowsScreenSaver.cpp
@@ -31,22 +31,6 @@
 extern "C" {
 #    include <X11/Xmd.h>
 #    include <X11/extensions/dpms.h>
-#    if !HAVE_DPMS_PROTOTYPES
-#        undef DPMSModeOn
-#        undef DPMSModeStandby
-#        undef DPMSModeSuspend
-#        undef DPMSModeOff
-#        define DPMSModeOn        0
-#        define DPMSModeStandby    1
-#        define DPMSModeSuspend    2
-#        define DPMSModeOff        3
-extern Bool DPMSQueryExtension(Display *, int *, int *);
-extern Bool DPMSCapable(Display *);
-extern Status DPMSEnable(Display *);
-extern Status DPMSDisable(Display *);
-extern Status DPMSForceLevel(Display *, CARD16);
-extern Status DPMSInfo(Display *, CARD16 *, BOOL *);
-#    endif
 }
 #endif
 

--- a/src/lib/platform/XWindowsScreenSaver.cpp
+++ b/src/lib/platform/XWindowsScreenSaver.cpp
@@ -26,11 +26,7 @@
 #include "base/TMethodEventJob.h"
 
 #include <X11/Xatom.h>
-#if HAVE_X11_EXTENSIONS_XTEST_H
-#    include <X11/extensions/XTest.h>
-#else
-#    error The XTest extension is required to build barrier
-#endif
+#include <X11/extensions/XTest.h>
 #if HAVE_X11_EXTENSIONS_DPMS_H
 extern "C" {
 #    include <X11/Xmd.h>

--- a/src/lib/platform/XWindowsScreenSaver.h
+++ b/src/lib/platform/XWindowsScreenSaver.h
@@ -23,11 +23,7 @@
 #include "common/stdmap.h"
 #include "XWindowsImpl.h"
 
-#if X_DISPLAY_MISSING
-#    error X11 is required to build barrier
-#else
-#    include <X11/Xlib.h>
-#endif
+#include <X11/Xlib.h>
 
 class Event;
 class EventQueueTimer;

--- a/src/lib/platform/XWindowsUtil.h
+++ b/src/lib/platform/XWindowsUtil.h
@@ -22,11 +22,7 @@
 #include "common/stdmap.h"
 #include "common/stdvector.h"
 
-#if X_DISPLAY_MISSING
-#    error X11 is required to build barrier
-#else
-#    include <X11/Xlib.h>
-#endif
+#include <X11/Xlib.h>
 
 #include <string>
 


### PR DESCRIPTION
- `X_DISPLAY_MISSING` was never set by anything and thus could never be true
- `HAVE_DPMS_PROTOTYPES` was always true in the one instance where we checked for it
- `HAVE_X11_EXTENSIONS_XTEST_H` caused a compiler error, moved to a cmake error now.