### PR TITLE
Perform clean uninstall on windows

### DIFF
--- a/dist/inno/barrier.iss.in
+++ b/dist/inno/barrier.iss.in
@@ -1,7 +1,9 @@
 #define MyAppName "Barrier"
-#define MyAppVersion "@BARRIER_VERSION@"
+#define MyAppVersion "@BARRIER_VERSION_MAJOR@.@BARRIER_VERSION_MINOR@.@BARRIER_VERSION_PATCH@.@BARRIER_BUILD_NUMBER@"
+#define MyAppTextVersion "@BARRIER_VERSION@"
 #define MyAppPublisher "Debauchee Open Source Group"
 #define MyAppURL "https://github.com/debauchee/barrier/wiki"
+#define MyAppCopyright "Copyright (C) 2018 Debauchee Open Source Group"
 #define MyAppExeName "barrier.exe"
 #define MyAppServiceName "Barrier"
 #define MyAppServiceExe "barrierd.exe"
@@ -11,8 +13,8 @@
 [Setup]
 AppId={{41036EA6-3F7A-4803-8AE0-469E5E91EFCC}
 AppName={#MyAppName}
-AppVersion={#MyAppVersion}
-AppVerName={#MyAppName} {#MyAppVersion}
+AppVersion={#MyAppTextVersion}
+AppVerName={#MyAppName} {#MyAppTextVersion}
 AppPublisher={#MyAppPublisher}
 AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}
@@ -21,8 +23,14 @@ DefaultDirName={pf}\{#MyAppName}
 DisableProgramGroupPage=yes
 LicenseFile=@CMAKE_CURRENT_SOURCE_DIR@/res/License.rtf
 OutputDir=@CMAKE_RUNTIME_OUTPUT_DIRECTORY@/../installer-inno/bin
-OutputBaseFilename=BarrierSetup-{#MyAppVersion}
+OutputBaseFilename=BarrierSetup-{#MyAppTextVersion}
 SetupIconFile=@CMAKE_CURRENT_SOURCE_DIR@/res/barrier.ico
+VersionInfoProductTextVersion={#MyAppTextVersion}
+VersionInfoProductVersion={#MyAppVersion}
+VersionInfoTextVersion={#MyAppTextVersion}
+VersionInfoVersion={#MyAppVersion}
+VersionInfoCopyright={#MyAppCopyright}
+
 Compression=lzma
 SolidCompression=yes
 ArchitecturesInstallIn64BitMode=x64 ia64

--- a/dist/inno/barrier.iss.in
+++ b/dist/inno/barrier.iss.in
@@ -26,6 +26,7 @@ SetupIconFile=@CMAKE_CURRENT_SOURCE_DIR@/res/barrier.ico
 Compression=lzma
 SolidCompression=yes
 ArchitecturesInstallIn64BitMode=x64 ia64
+UninstallDisplayIcon={app}\{#MyAppExeName}
 
 #include "scripts\lang\english.iss"
 
@@ -51,10 +52,11 @@ Filename: {sys}\sc.exe; Parameters: "start {#MyAppServiceName}"; Flags: runhidde
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
 
 [UninstallDelete]
-Type: files; Name: "{app}\barrierd.log"
+Type: filesandordirs; Name: "{commonappdata}\Barrier"
 
 [UninstallRun]
-Filename: {sys}\sc.exe; Parameters: "stop {#MyAppServiceName}"; Flags: runhidden
+Filename: {sys}\taskkill; Parameters: "/im {#MyAppExeName} /f /t"; Flags: runhidden
+Filename: {sys}\net.exe; Parameters: "stop {#MyAppServiceName}"; Flags: runhidden
 Filename: {sys}\sc.exe; Parameters: "delete {#MyAppServiceName}"; Flags: runhidden
 Filename: {sys}\netsh.exe; Parameters: "advfirewall firewall delete rule name=""{#MyAppListenerDesc}"""; Flags: runhidden
 


### PR DESCRIPTION
Changes:
1) Killing the main application process (with any children) before uninstalling.
   - Existing version will just leave it running and uninstall whatever it is able to, which is then not much, leaving a behind most program files.
   - Alternative could be to abort the uninstall if application is running, but don't think that is necessary(?)
2) Using `net stop` instead of `sc stop` for stopping the service before uninstalling it.
   - Because `sc stop` will run completely async and then the following `sc delete` typically fails because it is still running, leaving `barrierd.exe` behind after uninstall.
   - `net stop` will automatically wait until it has stopped, but will not block forever - aborts with error if service is unresponsive or takes more than 30 seconds.
3) Delete `C:\ProgramData\Barrier`, containing `barrierd.log`, on uninstall.
   - Existing installer had statement for deleting `barrierd.log` i application folder, but this is not (no longer) where the log file is created.
4) Show application icon in entry in "Programs and Features" control panel.

Will still leave registry settings and user configuration in `%LocalAppData%\Barrier` folder (server config file, certificates and fingerprints) behind, I guess this is the sort of user-specific settings that are expected to be left behind in case of reinstall..