### PR TITLE
lib: Remove unnecessary use of std::endl

### DIFF
--- a/src/lib/barrier/App.cpp
+++ b/src/lib/barrier/App.cpp
@@ -79,9 +79,9 @@ App::~App()
 void
 App::version()
 {
-    std::cout << argsBase().m_exename << " " << kVersion << std::endl;
-    std::cout <<"Protocol version " << kProtocolMajorVersion << "." << kProtocolMinorVersion << std::endl;
-    std::cout << kCopyright << std::endl;
+    std::cout << argsBase().m_exename << " " << kVersion << "\n";
+    std::cout <<"Protocol version " << kProtocolMajorVersion << "." << kProtocolMinorVersion << "\n";
+    std::cout << kCopyright << "\n";
 }
 
 int

--- a/src/lib/barrier/ClientApp.cpp
+++ b/src/lib/barrier/ClientApp.cpp
@@ -118,23 +118,23 @@ ClientApp::help()
 #endif
 
     std::ostringstream buffer;
-    buffer << "Start the barrier client and connect to a remote server component." << std::endl
-           << std::endl
+    buffer << "Start the barrier client and connect to a remote server component.\n"
+           << "\n"
            << "Usage: " << args().m_exename << " [--yscroll <delta>]" <<  WINAPI_ARG << HELP_SYS_ARGS
-           << HELP_COMMON_ARGS << " <server-address>" << std::endl
-           << std::endl
-           << "Options:" << std::endl
+           << HELP_COMMON_ARGS << " <server-address>\n"
+           << "\n"
+           << "Options:\n"
            << HELP_COMMON_INFO_1 << WINAPI_INFO << HELP_SYS_INFO
-           << "      --yscroll <delta>    defines the vertical scrolling delta, which is" << std::endl
-           << "                           120 by default." << std::endl
+           << "      --yscroll <delta>    defines the vertical scrolling delta, which is\n"
+           << "                           120 by default.\n"
            << HELP_COMMON_INFO_2
-           << std::endl
-           << "Default options are marked with a *" << std::endl
-           << std::endl
-           << "The server address is of the form: [<hostname>][:<port>]. The hostname" << std::endl
-           << "must be the address or hostname of the server. Placing brackets around" << std::endl
-           << "an IPv6 address is required when also specifying a port number and " << std::endl
-           << "optional otherwise. The default port number is " << kDefaultPort << "." << std::endl;
+           << "\n"
+           << "Default options are marked with a *\n"
+           << "\n"
+           << "The server address is of the form: [<hostname>][:<port>]. The hostname\n"
+           << "must be the address or hostname of the server. Placing brackets around\n"
+           << "an IPv6 address is required when also specifying a port number and \n"
+           << "optional otherwise. The default port number is " << kDefaultPort << ".\n";
 
     LOG((CLOG_PRINT "%s", buffer.str().c_str()));
 }

--- a/src/lib/barrier/ServerApp.cpp
+++ b/src/lib/barrier/ServerApp.cpp
@@ -135,29 +135,29 @@ ServerApp::help()
     }
 
     std::ostringstream buffer;
-    buffer << "Start the barrier server component." << std::endl
-           << std::endl
+    buffer << "Start the barrier server component.\n"
+           << "\n"
            << "Usage: " << args().m_exename
            << " [--address <address>]"
            << " [--config <pathname>]"
-           << WINAPI_ARGS << HELP_SYS_ARGS << HELP_COMMON_ARGS << std::endl
-           << std::endl
-           << "Options:" << std::endl
-           << "  -a, --address <address>  listen for clients on the given address." << std::endl
-           << "  -c, --config <pathname>  use the named configuration file instead." << std::endl
-           << HELP_COMMON_INFO_1 << WINAPI_INFO << HELP_SYS_INFO << HELP_COMMON_INFO_2 << std::endl
-           << "Default options are marked with a *" << std::endl
-           << std::endl
-           << "The argument for --address is of the form: [<hostname>][:<port>].  The" << std::endl
-           << "hostname must be the address or hostname of an interface on the system." << std::endl
-           << "Placing brackets around an IPv6 address is required when also specifying " << std::endl
-           << "a port number and optional otherwise. The default is to listen on all" << std::endl
-           << "interfaces using port number " << kDefaultPort << "." << std::endl
-           << std::endl
-           << "If no configuration file pathname is provided then the first of the" << std::endl
-           << "following to load successfully sets the configuration:" << std::endl
-           << "  " << PathUtilities::concat(profilePath, USR_CONFIG_NAME) << std::endl
-           << "  " << PathUtilities::concat(DataDirectories::systemconfig(), SYS_CONFIG_NAME) << std::endl;
+           << WINAPI_ARGS << HELP_SYS_ARGS << HELP_COMMON_ARGS << "\n"
+           << "\n"
+           << "Options:\n"
+           << "  -a, --address <address>  listen for clients on the given address.\n"
+           << "  -c, --config <pathname>  use the named configuration file instead.\n"
+           << HELP_COMMON_INFO_1 << WINAPI_INFO << HELP_SYS_INFO << HELP_COMMON_INFO_2 << "\n"
+           << "Default options are marked with a *\n"
+           << "\n"
+           << "The argument for --address is of the form: [<hostname>][:<port>].  The\n"
+           << "hostname must be the address or hostname of an interface on the system.\n"
+           << "Placing brackets around an IPv6 address is required when also specifying \n"
+           << "a port number and optional otherwise. The default is to listen on all\n"
+           << "interfaces using port number " << kDefaultPort << ".\n"
+           << "\n"
+           << "If no configuration file pathname is provided then the first of the\n"
+           << "following to load successfully sets the configuration:\n"
+           << "  " << PathUtilities::concat(profilePath, USR_CONFIG_NAME) << "\n"
+           << "  " << PathUtilities::concat(DataDirectories::systemconfig(), SYS_CONFIG_NAME) << "\n";
 
     LOG((CLOG_PRINT "%s", buffer.str().c_str()));
 }

--- a/src/lib/barrier/win32/AppUtilWindows.cpp
+++ b/src/lib/barrier/win32/AppUtilWindows.cpp
@@ -126,7 +126,7 @@ AppUtilWindows::beforeAppExit()
     // a new console window, and will normally close on exit (making it so
     // that we can't see error messages).
     if (app().argsBase().m_pauseOnExit) {
-        std::cout << std::endl << "press any key to exit..." << std::endl;
+        std::cout << "\n" << "press any key to exit...\n";
         int c = _getch();
     }
 }

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -1748,10 +1748,10 @@ std::ostream&
 operator<<(std::ostream& s, const Config& config)
 {
 	// screens section
-	s << "section: screens" << std::endl;
+    s << "section: screens\n";
 	for (Config::const_iterator screen = config.begin();
 								screen != config.end(); ++screen) {
-		s << "\t" << screen->c_str() << ":" << std::endl;
+        s << "\t" << screen->c_str() << ":\n";
 		const Config::ScreenOptions* options = config.getOptions(*screen);
 		if (options != NULL && options->size() > 0) {
 			for (Config::ScreenOptions::const_iterator
@@ -1760,19 +1760,19 @@ operator<<(std::ostream& s, const Config& config)
 				const char* name = Config::getOptionName(option->first);
                 std::string value = Config::getOptionValue(option->first, option->second);
 				if (name != NULL && !value.empty()) {
-					s << "\t\t" << name << " = " << value << std::endl;
+                    s << "\t\t" << name << " = " << value << "\n";
 				}
 			}
 		}
 	}
-	s << "end" << std::endl;
+    s << "end\n";
 
 	// links section
     std::string neighbor;
-	s << "section: links" << std::endl;
+    s << "section: links\n";
 	for (Config::const_iterator screen = config.begin();
 								screen != config.end(); ++screen) {
-		s << "\t" << screen->c_str() << ":" << std::endl;
+        s << "\t" << screen->c_str() << ":\n";
 
 		for (Config::link_const_iterator
 				link = config.beginNeighbor(*screen),
@@ -1781,10 +1781,10 @@ operator<<(std::ostream& s, const Config& config)
 				Config::formatInterval(link->first.getInterval()) <<
 				" = " << link->second.getName().c_str() <<
 				Config::formatInterval(link->second.getInterval()) <<
-				std::endl;
+                "\n";
 		}
 	}
-	s << "end" << std::endl;
+    s << "end\n";
 
 	// aliases section (if there are any)
 	if (config.m_map.size() != config.m_nameToCanonicalName.size()) {
@@ -1802,20 +1802,20 @@ operator<<(std::ostream& s, const Config& config)
 
 		// dump it
         std::string screen;
-		s << "section: aliases" << std::endl;
+        s << "section: aliases\n";
 		for (CMNameMap::const_iterator index = aliases.begin();
 								index != aliases.end(); ++index) {
 			if (index->first != screen) {
 				screen = index->first;
-				s << "\t" << screen.c_str() << ":" << std::endl;
+                s << "\t" << screen.c_str() << ":\n";
 			}
-			s << "\t\t" << index->second.c_str() << std::endl;
+            s << "\t\t" << index->second.c_str() << "\n";
 		}
-		s << "end" << std::endl;
+        s << "end\n";
 	}
 
 	// options section
-	s << "section: options" << std::endl;
+    s << "section: options\n";
 	const Config::ScreenOptions* options = config.getOptions("");
 	if (options != NULL && options->size() > 0) {
 		for (Config::ScreenOptions::const_iterator
@@ -1824,16 +1824,16 @@ operator<<(std::ostream& s, const Config& config)
 			const char* name = Config::getOptionName(option->first);
             std::string value = Config::getOptionValue(option->first, option->second);
 			if (name != NULL && !value.empty()) {
-				s << "\t" << name << " = " << value << std::endl;
+                s << "\t" << name << " = " << value << "\n";
 			}
 		}
 	}
 	if (config.m_barrierAddress.isValid()) {
 		s << "\taddress = " <<
-			config.m_barrierAddress.getHostname().c_str() << std::endl;
+            config.m_barrierAddress.getHostname().c_str() << "\n";
 	}
 	s << config.m_inputFilter.format("\t");
-	s << "end" << std::endl;
+    s << "end\n";
 
 	return s;
 }


### PR DESCRIPTION
std::endl is "\n" followed by a flush. We only need flushing in certain circumstances.