### PR TITLE
gui: Use range-based for loop instead of foreach macro

### DIFF
--- a/src/gui/src/ActionDialog.cpp
+++ b/src/gui/src/ActionDialog.cpp
@@ -58,7 +58,7 @@ ActionDialog::ActionDialog(QWidget* parent, ServerConfig& config, Hotkey& hotkey
     m_pGroupBoxScreens->setChecked(m_Action.haveScreens());
 
     int idx = 0;
-    foreach(const Screen& screen, serverConfig().screens())
+    for (const Screen& screen : serverConfig().screens()) {
         if (!screen.isNull())
         {
             QListWidgetItem *pListItem = new QListWidgetItem(screen.name());
@@ -72,6 +72,7 @@ ActionDialog::ActionDialog(QWidget* parent, ServerConfig& config, Hotkey& hotkey
 
             idx++;
         }
+    }
 }
 
 void ActionDialog::accept()
@@ -84,8 +85,9 @@ void ActionDialog::accept()
     m_Action.setHaveScreens(m_pGroupBoxScreens->isChecked());
 
     m_Action.clearTypeScreenNames();
-    foreach(const QListWidgetItem* pItem, m_pListScreens->selectedItems())
+    for (const QListWidgetItem* pItem : m_pListScreens->selectedItems()) {
         m_Action.appendTypeScreenName(pItem->text());
+    }
 
     m_Action.setSwitchScreenName(m_pComboSwitchToScreen->currentText());
     m_Action.setSwitchDirection(m_pComboSwitchInDirection->currentIndex());

--- a/src/gui/src/Fingerprint.cpp
+++ b/src/gui/src/Fingerprint.cpp
@@ -66,8 +66,7 @@ bool Fingerprint::fileExists() const
 bool Fingerprint::isTrusted(const QString& fingerprintText)
 {
     QStringList list = readList();
-    foreach (QString trusted, list)
-    {
+    for (QString trusted : list) {
         if (trusted == fingerprintText) {
             return true;
         }

--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -335,8 +335,7 @@ void MainWindow::logOutput()
     if (m_pBarrier)
     {
         QString text(m_pBarrier->readAllStandardOutput());
-        foreach(QString line, text.split(QRegExp("\r|\n|\r\n")))
-        {
+        for (QString line : text.split(QRegExp("\r|\n|\r\n"))) {
             if (!line.isEmpty())
             {
                 appendLogRaw(line);
@@ -373,7 +372,7 @@ void MainWindow::appendLogError(const QString& text)
 
 void MainWindow::appendLogRaw(const QString& text)
 {
-    foreach(QString line, text.split(QRegExp("\r|\n|\r\n"))) {
+    for (QString line : text.split(QRegExp("\r|\n|\r\n"))) {
         if (!line.isEmpty()) {
             m_pLogWindow->appendRaw(line);
             updateFromLogLine(line);

--- a/src/gui/src/QBarrierApplication.cpp
+++ b/src/gui/src/QBarrierApplication.cpp
@@ -38,8 +38,7 @@ QBarrierApplication::~QBarrierApplication()
 
 void QBarrierApplication::commitData(QSessionManager&)
 {
-    foreach(QWidget* widget, topLevelWidgets())
-    {
+    for (QWidget* widget : topLevelWidgets()) {
         MainWindow* mainWindow = qobject_cast<MainWindow*>(widget);
         if (mainWindow)
             mainWindow->saveSettings();

--- a/src/gui/src/QUtility.cpp
+++ b/src/gui/src/QUtility.cpp
@@ -52,8 +52,7 @@ QString hash(const QString& string)
 QString getFirstMacAddress()
 {
     QString mac;
-    foreach (const QNetworkInterface &interface,  QNetworkInterface::allInterfaces())
-    {
+    for (const QNetworkInterface &interface : QNetworkInterface::allInterfaces()) {
         mac = interface.hardwareAddress();
         if (mac.size() != 0)
         {

--- a/src/gui/src/Screen.cpp
+++ b/src/gui/src/Screen.cpp
@@ -125,8 +125,9 @@ QTextStream& Screen::writeAliasesSection(QTextStream& outStream) const
     {
         outStream << "\t" << name() << ":" << endl;
 
-        foreach (const QString& alias, aliases())
+        for (const QString& alias : aliases()) {
             outStream << "\t\t" << alias << endl;
+        }
     }
 
     return outStream;

--- a/src/gui/src/ScreenSetupModel.cpp
+++ b/src/gui/src/ScreenSetupModel.cpp
@@ -91,9 +91,10 @@ QMimeData* ScreenSetupModel::mimeData(const QModelIndexList& indexes) const
 
     QDataStream stream(&encodedData, QIODevice::WriteOnly);
 
-    foreach (const QModelIndex& index, indexes)
+    for (const QModelIndex& index : indexes) {
         if (index.isValid())
             stream << index.column() << index.row() << screen(index);
+    }
 
     pMimeData->setData(m_MimeType, encodedData);
 

--- a/src/gui/src/ServerConfig.cpp
+++ b/src/gui/src/ServerConfig.cpp
@@ -212,17 +212,19 @@ QTextStream& operator<<(QTextStream& outStream, const ServerConfig& config)
 {
     outStream << "section: screens" << endl;
 
-    foreach (const Screen& s, config.screens())
+    for (const Screen& s : config.screens()) {
         if (!s.isNull())
             s.writeScreensSection(outStream);
+    }
 
     outStream << "end" << endl << endl;
 
     outStream << "section: aliases" << endl;
 
-    foreach (const Screen& s, config.screens())
+    for (const Screen& s : config.screens()) {
         if (!s.isNull())
             s.writeAliasesSection(outStream);
+    }
 
     outStream << "end" << endl << endl;
 
@@ -270,8 +272,9 @@ QTextStream& operator<<(QTextStream& outStream, const ServerConfig& config)
 
     outStream << "\t" << "switchCornerSize = " << config.switchCornerSize() << endl;
 
-    foreach(const Hotkey& hotkey, config.hotkeys())
+    for (const Hotkey& hotkey : config.hotkeys()) {
         outStream << hotkey;
+    }
 
     outStream << "end" << endl << endl;
 
@@ -282,9 +285,10 @@ int ServerConfig::numScreens() const
 {
     int rval = 0;
 
-    foreach(const Screen& s, screens())
+    for (const Screen& s : screens()) {
         if (!s.isNull())
             rval++;
+    }
 
     return rval;
 }

--- a/src/gui/src/ServerConfigDialog.cpp
+++ b/src/gui/src/ServerConfigDialog.cpp
@@ -60,8 +60,9 @@ ServerConfigDialog::ServerConfigDialog(QWidget* parent, ServerConfig& config, co
 
     m_pCheckBoxEnableClipboard->setChecked(serverConfig().clipboardSharing());
 
-    foreach(const Hotkey& hotkey, serverConfig().hotkeys())
+    for (const Hotkey& hotkey : serverConfig().hotkeys()) {
         m_pListHotkeys->addItem(hotkey.text());
+    }
 
     m_pScreenSetupView->setModel(&m_ScreenSetupModel);
 
@@ -168,8 +169,9 @@ void ServerConfigDialog::on_m_pListHotkeys_itemSelectionChanged()
         Q_ASSERT(idx >= 0 && idx < serverConfig().hotkeys().size());
 
         const Hotkey& hotkey = serverConfig().hotkeys()[idx];
-        foreach(const Action& action, hotkey.actions())
+        for (const Action& action : hotkey.actions()) {
             m_pListActions->addItem(action.text());
+        }
     }
 }
 

--- a/src/gui/src/ZeroconfService.cpp
+++ b/src/gui/src/ZeroconfService.cpp
@@ -101,7 +101,7 @@ ZeroconfService::~ZeroconfService()
 
 void ZeroconfService::serverDetected(const QList<ZeroconfRecord>& list)
 {
-    foreach (ZeroconfRecord record, list) {
+    for (ZeroconfRecord record : list) {
         registerService(false);
         m_pMainWindow->appendLogInfo(tr("zeroconf server detected: %1").arg(
             record.serviceName));
@@ -111,7 +111,7 @@ void ZeroconfService::serverDetected(const QList<ZeroconfRecord>& list)
 
 void ZeroconfService::clientDetected(const QList<ZeroconfRecord>& list)
 {
-    foreach (ZeroconfRecord record, list) {
+    for (ZeroconfRecord record : list) {
         m_pMainWindow->appendLogInfo(tr("zeroconf client detected: %1").arg(
             record.serviceName));
         m_pMainWindow->autoAddScreen(record.serviceName);
@@ -127,15 +127,15 @@ void ZeroconfService::errorHandle(DNSServiceErrorType errorCode)
 QString ZeroconfService::getLocalIPAddresses()
 {
     QStringList addresses;
-    foreach (const QHostAddress& address, QNetworkInterface::allAddresses()) {
+    for (const QHostAddress& address : QNetworkInterface::allAddresses()) {
         if (address.protocol() == QAbstractSocket::IPv4Protocol &&
             address != QHostAddress(QHostAddress::LocalHost)) {
             addresses.append(address.toString());
         }
     }
 
-    foreach (const QString& preferedIP, preferedIPAddress) {
-        foreach (const QString& address, addresses) {
+    for (const QString& preferedIP : preferedIPAddress) {
+        for (const QString& address : addresses) {
             if (address.startsWith(preferedIP)) {
                 return address;
             }


### PR DESCRIPTION
The foreach macro is no longer needed when we have C++11 range-based for loop.