### PR TITLE
Enable use of keyboard to modify screens

### DIFF
--- a/doc/newsfragments/gui-keyboard-enabled-screen-layout.feature
+++ b/doc/newsfragments/gui-keyboard-enabled-screen-layout.feature
@@ -1,0 +1,1 @@
+Made it possible to use keyboard instead of mouse to modify screen layout.

--- a/src/gui/src/ScreenSetupModel.cpp
+++ b/src/gui/src/ScreenSetupModel.cpp
@@ -71,7 +71,7 @@ Qt::ItemFlags ScreenSetupModel::flags(const QModelIndex& index) const
     if (!screen(index).isNull())
         return Qt::ItemIsEnabled | Qt::ItemIsDragEnabled | Qt::ItemIsSelectable | Qt::ItemIsDropEnabled;
 
-    return Qt::ItemIsDropEnabled;
+    return Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsDropEnabled;
 }
 
 Qt::DropActions ScreenSetupModel::supportedDropActions() const

--- a/src/gui/src/ScreenSetupView.h
+++ b/src/gui/src/ScreenSetupView.h
@@ -44,6 +44,7 @@ class ScreenSetupView : public QTableView
 
     protected:
         void mouseDoubleClickEvent(QMouseEvent*) override;
+        void keyPressEvent(QKeyEvent*) override;
         void setTableSize();
         void resizeEvent(QResizeEvent*) override;
         void dragEnterEvent(QDragEnterEvent* event) override;
@@ -51,6 +52,9 @@ class ScreenSetupView : public QTableView
         void startDrag(Qt::DropActions supportedActions) override;
         QStyleOptionViewItem viewOptions() const override;
         void scrollTo(const QModelIndex&, ScrollHint) override {}
+    private:
+        void enter(const QModelIndex&);
+        void remove(const QModelIndex&);
 };
 
 #endif


### PR DESCRIPTION
This change enables the use of keyboard to modify screen layout.

Existing version relies on drag&drop mouse operation only. I think adding the possibility to use keyboard navigation is a nice addition, and for [some](https://github.com/debauchee/barrier/issues/1030) it is even a requirement to be able to use the application properly.

With this you can do the following in the "Server Configuration" dialog's "Screen and links" tab:
- Press tab key to get into the screen grid, and tab again to get focus out from the grid again.
- Press arrow keys, page up/down, home/end, ctrl+home/end, etc to move within the screen grid.
- Press enter key to open screen settings for existing screen in current cell, or insert new if cell is empty.
- Press delete key to delete the screen in current cell.
- Hold control while pressing arrow keys to move/swap screens with adjacent ones.

Hopefully this fixes https://github.com/debauchee/barrier/issues/1030, but there might be other changes that are needed as well for it to be 100% covered..