### PR TITLE
add quickstart instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ Compatibility. We use more than one operating system and you probably do, too. W
 
 Communication. Everything we do is in the open. Our issue tracker will let you see if others are having the same problem you're having and will allow you to add additional information. You will also be able to see when progress is made and how the issue gets resolved.
 
+### Usage
+
+Install and run barrier on each machine that will be sharing.
+On the machine with the keyboard and mouse, make it the server.
+
+Click the "Configure server" button and drag a new screen onto the grid for each client machine.
+Ensure the "screen name" matches exactly (case-sensitive) for each configured screen -- the clients' barrier windows will tell you their screen names (just above the server IP).
+
+On the client(s), put in the server machine's IP address (or use Bonjour/auto configuration when prompted) and "start" them.
+You should see `Barrier is running` on both server and clients.
+You should now be able to move the mouse between all the screens as if they were the same machine.
+
+Note that if the keyboard's Scroll Lock is active then this will prevent the mouse from switching screens.
+
 ### Contact & support
 
 Please be aware that the *only* way to draw our attention to a bug is to create a new issue in [the issue tracker](https://github.com/debauchee/barrier/issues). Write a clear, concise, detailed report and you will get a clear, concise, detailed response. Priority is always given to issues that affect a wider range of users.


### PR DESCRIPTION
I had to google for how to set things up, I figured it'd be helpful to have some quickstart instructions in the readme.