### PR TITLE
Restoring terminal settings after daemonizing.

### DIFF
--- a/src/lib/arch/unix/ArchDaemonUnix.cpp
+++ b/src/lib/arch/unix/ArchDaemonUnix.cpp
@@ -20,6 +20,7 @@
 
 #include "arch/unix/XArchUnix.h"
 #include "base/Log.h"
+#include "barrier/App.h"
 
 #include <unistd.h>
 #include <sys/types.h>
@@ -86,6 +87,8 @@ ArchDaemonUnix::daemonize(const char* name, DaemonFunc func)
         break;
 
     default:
+		// first restore terminal settings
+		App::instance().getEvents()->restoreTerminal();
         // parent exits
         exit(0);
     }

--- a/src/lib/base/EventQueue.h
+++ b/src/lib/base/EventQueue.h
@@ -63,6 +63,7 @@ public:
     virtual Event::Type getRegisteredType(const std::string& name) const;
     void*                getSystemTarget();
     virtual void        waitForReady() const;
+	virtual void        restoreTerminal() const { m_parentStream.restoreTerminal(); }
 
 private:
     UInt32                saveEvent(const Event& event);

--- a/src/lib/base/IEventQueue.h
+++ b/src/lib/base/IEventQueue.h
@@ -184,6 +184,11 @@ public:
     be added.
     */
     virtual void        waitForReady() const = 0;
+    //! Restore the terminal settings
+    /*!
+    Called to restore the terminal settings after daemonizing.
+    */
+	virtual void        restoreTerminal() const = 0;
 
     //@}
     //! @name accessors

--- a/src/lib/base/NonBlockingStream.cpp
+++ b/src/lib/base/NonBlockingStream.cpp
@@ -57,4 +57,10 @@ bool NonBlockingStream::try_read_char(char &ch) const
     return false;
 }
 
+void NonBlockingStream::restoreTerminal() const
+{
+    tcsetattr(_fd, TCSANOW, _p_ta_previous);
+    fcntl(_fd, F_SETFL, _cntl_previous);
+}
+
 #endif // !defined(_WIN32)

--- a/src/lib/base/NonBlockingStream.h
+++ b/src/lib/base/NonBlockingStream.h
@@ -39,6 +39,7 @@ public:
     ~NonBlockingStream();
 
     bool try_read_char(char &ch) const;
+	void restoreTerminal(void) const;
 
 private:
     int _fd;

--- a/src/test/mock/barrier/MockEventQueue.h
+++ b/src/test/mock/barrier/MockEventQueue.h
@@ -64,4 +64,5 @@ public:
     MOCK_METHOD0(forClipboard, ClipboardEvents&());
     MOCK_METHOD0(forFile, FileEvents&());
     MOCK_CONST_METHOD0(waitForReady, void());
+    MOCK_CONST_METHOD0(restoreTerminal, void());
 };


### PR DESCRIPTION
This change solves the problem with misconfigured terminal after starting a daemon. This has been reported as Issue #200 "Executing barrierc makes terminal line invisible #200".
The problem is that the parent process just calls exit(0) after starting the child process. The terminal settings have to be restored before exit.