### PR TITLE
Fix `Fix Preserve Focus` option not working on Linux servers

### DIFF
--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -324,7 +324,7 @@ XWindowsScreen::leave()
     m_impl->XGetInputFocus(m_display, &m_lastFocus, &m_lastFocusRevert);
 
 	// take focus
-	if (m_isPrimary || !m_preserveFocus) {
+	if (!m_preserveFocus) {
         m_impl->XSetInputFocus(m_display, m_window, RevertToPointerRoot, CurrentTime);
 	}
 


### PR DESCRIPTION
Fixes #1066.

I'm not sure why this check was here in the first place, but the preserve focus setting should take effect whether the code runs on the server (primary) or the client. This change and a subsequent local build shows that the issue is fixed for me.