### PR TITLE
Fix unquoted windows service image path

### DIFF
--- a/dist/inno/barrier.iss.in
+++ b/dist/inno/barrier.iss.in
@@ -54,7 +54,7 @@ Name: "{commondesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: 
 ; to avoid duplicate entries remove the existing rule (fails if it doesn't exist) before adding
 Filename: {sys}\netsh.exe; Parameters: "advfirewall firewall delete rule name=""{#MyAppListenerDesc}"""; Flags: runhidden
 Filename: {sys}\netsh.exe; Parameters: "advfirewall firewall add rule name=""{#MyAppListenerDesc}"" protocol=TCP dir=in localport=24800 action=allow"; Flags: runhidden
-Filename: {sys}\sc.exe; Parameters: "create {#MyAppServiceName} start= auto binPath= ""{app}\{#MyAppServiceExe}"""; Flags: runhidden
+Filename: {sys}\sc.exe; Parameters: "create {#MyAppServiceName} start= auto binPath= ""\""{app}\{#MyAppServiceExe}\"""""; Flags: runhidden
 Filename: {sys}\sc.exe; Parameters: "description {#MyAppServiceName} ""{#MyAppServiceDesc}"""; Flags: runhidden
 Filename: {sys}\sc.exe; Parameters: "start {#MyAppServiceName}"; Flags: runhidden
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent

--- a/doc/newsfragments/windows-service-path.bugfix
+++ b/doc/newsfragments/windows-service-path.bugfix
@@ -1,0 +1,1 @@
+Fixed incorrect setup of Barrier service path on Windows.


### PR DESCRIPTION
Currently, in Windows, if barrier is installed in a path with spaces, the Services Manager may find the wrong bin file.
For example, if installed in `C:\Program Files\Barrier\`, in the same time there is also a file of pathname `C:\Program`, Services Manager will try to execute `C:\Program`.

Reference
- https://stackoverflow.com/questions/8911608/mysql-not-a-valid-win32-application
- https://stackoverflow.com/questions/34336982/how-to-create-a-path-with-arguments-to-a-service

