### PR TITLE
System tray improvements

### DIFF
--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -1277,7 +1277,8 @@ void MainWindow::bonjourInstallFinished()
 
 void MainWindow::windowStateChanged()
 {
-    if (windowState() == Qt::WindowMinimized && appConfig().getMinimizeToTray())
+    // If we are minimising and minimise to tray is enabled and system tray is available then hide the window
+    if (windowState() == Qt::WindowMinimized && appConfig().getMinimizeToTray() && QSystemTrayIcon::isSystemTrayAvailable())
         hide();
 }
 

--- a/src/gui/src/MainWindow.h
+++ b/src/gui/src/MainWindow.h
@@ -25,6 +25,7 @@
 #include <QSettings>
 #include <QProcess>
 #include <QThread>
+#include <QTimer>
 
 #include "ui_MainWindowBase.h"
 
@@ -201,11 +202,13 @@ public slots:
         SslCertificate* m_pSslCertificate;
         QStringList m_PendingClientNames;
         LogWindow *m_pLogWindow;
+        QTimer m_OpenHiddenTrayTimer;
 
 private slots:
     void on_m_pCheckBoxAutoConfig_toggled(bool checked);
     void on_m_pComboServerList_currentIndexChanged(QString );
     void on_m_pButtonReload_clicked();
+    void on_m_OpenHiddenTrayTimer_triggered();
     void installBonjour();
 
 };

--- a/src/gui/src/QBarrierApplication.cpp
+++ b/src/gui/src/QBarrierApplication.cpp
@@ -29,6 +29,12 @@ QBarrierApplication::QBarrierApplication(int& argc, char** argv) :
     m_Translator(NULL)
 {
     s_Instance = this;
+
+    // By default do not quit when the last window is closed as we minimise
+    // to the system tray, but listen for the lastWindow closing so that
+    // if the system tray is not available we can quit.
+    setQuitOnLastWindowClosed(false);
+    connect(this, &QApplication::lastWindowClosed, this, &QBarrierApplication::onLastWindowClosed);
 }
 
 QBarrierApplication::~QBarrierApplication()
@@ -68,4 +74,13 @@ void QBarrierApplication::setTranslator(QTranslator* translator)
 {
     m_Translator = translator;
     installTranslator(m_Translator);
+}
+
+void QBarrierApplication::onLastWindowClosed()
+{
+    // If there is no system tray available then quit when the last window is closed
+    if (!QSystemTrayIcon::isSystemTrayAvailable())
+    {
+        quit();
+    }
 }

--- a/src/gui/src/QBarrierApplication.h
+++ b/src/gui/src/QBarrierApplication.h
@@ -37,6 +37,9 @@ class QBarrierApplication : public QApplication
 
         static QBarrierApplication* getInstance();
 
+    private Q_SLOTS:
+        void onLastWindowClosed();
+
     private:
         QTranslator* m_Translator;
 

--- a/src/gui/src/SettingsDialog.cpp
+++ b/src/gui/src/SettingsDialog.cpp
@@ -52,6 +52,10 @@ SettingsDialog::SettingsDialog(QWidget* parent, AppConfig& config) :
     m_pCheckBoxMinimizeToTray->setChecked(appConfig().getMinimizeToTray());
     m_pCheckBoxEnableCrypto->setChecked(m_appConfig.getCryptoEnabled());
 
+    // Don't allow auto hide or minimise to tray if it's not available
+    m_pCheckBoxAutoHide->setEnabled(QSystemTrayIcon::isSystemTrayAvailable());
+    m_pCheckBoxMinimizeToTray->setEnabled(QSystemTrayIcon::isSystemTrayAvailable());
+
 #if defined(Q_OS_WIN)
     m_pComboElevate->setCurrentIndex(static_cast<int>(appConfig().elevateMode()));
 #else

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -88,8 +88,6 @@ int main(int argc, char* argv[])
 	}
 #endif
 
-	QApplication::setQuitOnLastWindowClosed(false);
-
 	QSettings settings;
 	AppConfig appConfig (&settings);
 

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -91,13 +91,6 @@ int main(int argc, char* argv[])
 	QSettings settings;
 	AppConfig appConfig (&settings);
 
-	if (appConfig.getAutoHide() && !QSystemTrayIcon::isSystemTrayAvailable())
-	{
-		// force auto hide to false - otherwise there is no way to get the GUI back
-		fprintf(stdout, "System tray not available, force disabling auto hide!\n");
-		appConfig.setAutoHide(false);
-	}
-
 	app.switchTranslator(appConfig.language());
 
 	MainWindow mainWindow(settings, appConfig);


### PR DESCRIPTION
  * Do not block at startup for a period of time when there is no system tray
  * if there is no system tray, quit when the last window closes
  * If there is no system tray, disable the settings for autohide / minimise to tray

I have changed how the timer works for ensuring that the user does not get stuck with a hidden window. Instead of always waiting for the system tray to become available before deciding if to disable autohide or show the window. Now we perform showing the window or starting hidden. If we start hidden and the systemtray was not available, we then wait a period of time to check it's not being slow at becoming available, then we force the window to show.

As you can see in the table below this removes the potential for waiting at startup from the 4 different startup procedures to just 1. And this use case is an unlikely scenario now that the settings are disabled if the system tray isn't available (the user would have had to enable autohide when the system tray was available and then disable the system tray on their system).

| Scenario  | Before | After |
| ------------- | ------------- | ------------- |
| autohide=false, systemtray=true  | Wait for system tray to become available (success), then show the window | Show the window |
| autohide=true, systemtray=true | Wait for system tray to become available (success), then start with hidden window | Start with hidden window |
| autohide=false, systemtray=false | Wait for system tray to become available (fails), then show the window | Show the window |
| autohide=true, systemtray=false | Wait for system tray to become available (fails), then show the window | Start with the window hidden, wait a period of time to check if the system tray becomes available (fails), then show the window |