### PR TITLE
barriers: add headless mode

### DIFF
--- a/src/lib/barrier/App.h
+++ b/src/lib/barrier/App.h
@@ -168,7 +168,10 @@ private:
     "      --enable-drag-drop   enable file drag & drop.\n" \
     "      --enable-crypto      enable the crypto (ssl) plugin.\n" \
     "      --profile-dir <path> use named profile directory instead.\n" \
-    "      --drop-dir <path>    use named drop target directory instead.\n"
+    "      --drop-dir <path>    use named drop target directory instead.\n" \
+    "      --headless-mode      when any client connected, if server screen is\n" \
+    "                             holding the input focus, server will actively\n" \
+    "                             switch input focus to the client.\n"
 
 #define HELP_COMMON_INFO_2 \
     "  -h, --help               display this help and exit.\n" \

--- a/src/lib/barrier/ArgParser.cpp
+++ b/src/lib/barrier/ArgParser.cpp
@@ -269,6 +269,9 @@ ArgParser::parseGenericArgs(int argc, const char* const* argv, int& i)
     else if (isArg(i, argc, argv, NULL, "--plugin-dir", 1)) {
         argsBase().m_pluginDirectory = argv[++i];
     }
+    else if (isArg(i, argc, argv, NULL, "--headless-mode")) {
+        argsBase().m_headlessMode = true;
+    }
     else {
         // option not supported here
         return false;

--- a/src/lib/barrier/ArgsBase.cpp
+++ b/src/lib/barrier/ArgsBase.cpp
@@ -44,7 +44,8 @@ m_shouldExit(false),
 m_barrierAddress(),
 m_enableCrypto(false),
 m_profileDirectory(""),
-m_pluginDirectory("")
+m_pluginDirectory(""),
+m_headlessMode(false)
 {
 }
 

--- a/src/lib/barrier/ArgsBase.h
+++ b/src/lib/barrier/ArgsBase.h
@@ -52,4 +52,5 @@ public:
     bool                m_enableCrypto;
     String                m_profileDirectory;
     String                m_pluginDirectory;
+    bool                m_headlessMode;
 };

--- a/src/lib/barrier/ServerApp.cpp
+++ b/src/lib/barrier/ServerApp.cpp
@@ -267,6 +267,18 @@ ServerApp::handleClientConnected(const Event&, void* vlistener)
     if (client != NULL) {
         m_server->adoptClient(client);
         updateStatus();
+        if( args().m_headlessMode && m_server->isServerHoldFocus() ) {
+            std::string screen = args().m_config->getCanonicalName(client->getName());
+            if (screen.empty()) {
+                screen = client->getName();
+            }
+            if(screen.empty()) return;
+            // send event
+            Server::SwitchToScreenInfo* info =
+                Server::SwitchToScreenInfo::alloc(screen);
+            m_events->addEvent(Event(m_events->forServer().switchToScreen(),
+                                     args().m_config->getInputFilter(), info));
+        }
     }
 }
 

--- a/src/lib/server/Server.h
+++ b/src/lib/server/Server.h
@@ -179,6 +179,10 @@ public:
     //! Return fake drag file list
     DragFileList        getFakeDragFileList() { return m_fakeDragFileList; }
 
+    //! Return true if fucus in primary clinet
+    bool                isServerHoldFocus() { return (m_active ==
+                            (BaseClientProxy*) m_primaryClient); }
+
     //@}
 
 private:


### PR DESCRIPTION
New feature for issue https://github.com/debauchee/barrier/issues/1135
Run barriers server with option `--headless-mode`, when any client connected, if server screen is holding the input focus, server will actively switch the input focus to the client.
This will make easier to use a headless box.