### PR TITLE
Remove #if defined(LIBRESSL_VERSION_NUMBER) path

### DIFF
--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -829,7 +829,7 @@ SecureSocket::showSecureCipherInfo()
         showCipherStackDesc(sStack);
     }
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	// m_ssl->m_ssl->session->ciphers is not forward compatable,
 	// In future release of OpenSSL, it's not visible,
     STACK_OF(SSL_CIPHER) * cStack = m_ssl->m_ssl->session->ciphers;


### PR DESCRIPTION
The SSL_get_client_ciphers API has been available since LibreSSL 2.9.1
and is thus present in all supported versions (3.2.x and 3.3.x). In
the upcoming LibreSSL 3.4.x release the SSL_CIPHER struct will become
opaque hence the build will break.