### PR TITLE
Map more X11 clipboard MIME types to corresponding converters

### DIFF
--- a/doc/newsfragments/fix-x11-paste.bugfix
+++ b/doc/newsfragments/fix-x11-paste.bugfix
@@ -1,0 +1,1 @@
+ Map more X11 clipboard MIME types to corresponding converters (https://github.com/debauchee/barrier/issues/344).

--- a/src/lib/platform/XWindowsClipboard.cpp
+++ b/src/lib/platform/XWindowsClipboard.cpp
@@ -84,9 +84,13 @@ XWindowsClipboard::XWindowsClipboard(IXWindowsImpl* impl, Display* display,
     // add converters, most desired first
     m_converters.push_back(new XWindowsClipboardHTMLConverter(m_display,
                                 "text/html"));
+    m_converters.push_back(new XWindowsClipboardHTMLConverter(m_display,
+                                "application/x-moz-nativehtml"));
     m_converters.push_back(new XWindowsClipboardBMPConverter(m_display));
     m_converters.push_back(new XWindowsClipboardUTF8Converter(m_display,
                                 "text/plain;charset=UTF-8"));
+    m_converters.push_back(new XWindowsClipboardUTF8Converter(m_display,
+                                "text/plain;charset=utf-8"));
     m_converters.push_back(new XWindowsClipboardUTF8Converter(m_display,
                                 "UTF8_STRING"));
     m_converters.push_back(new XWindowsClipboardUCS2Converter(m_display,


### PR DESCRIPTION
The following logs are extracted from pasting texts to Firefox's address bar and a Google Doc page in Firefox, respectively.
```
[2021-05-16T00:03:14] DEBUG1: request for clipboard 342, target text/plain;charset=utf-8 (600) by 0x03000044 (property=GDK_SELECTION (511))

[2021-05-16T00:03:22] DEBUG1: request for clipboard 342, target application/x-moz-nativehtml (603) by 0x03000044 (property=GDK_SELECTION (511))
```
Inspired by https://github.com/debauchee/barrier/pull/461. Should fix pasting unicode on X11 https://github.com/debauchee/barrier/issues/344.