### PR TITLE
Fix osx_environment.sh for Homebrew

### DIFF
--- a/dist/macos/bundle/build_dist.sh.in
+++ b/dist/macos/bundle/build_dist.sh.in
@@ -48,7 +48,7 @@ fi
 # Check for macdeployqt on Homebrew
 if which -s brew ; then
     info "Homebrew found, searching for macdeployqt"
-    DEPLOYQT="$(brew list qt | grep --only '/.*macdeployqt' | head -1)"
+    DEPLOYQT="$(brew list qt@5 | grep --only '/.*macdeployqt' | head -1)"
     if [ ! -x "$DEPLOYQT" ]; then
         error Please install package qt
         exit 1

--- a/osx_environment.sh
+++ b/osx_environment.sh
@@ -29,7 +29,7 @@ if [ ! $BARRIER_BUILD_ENV ]; then
 
     elif command -v brew; then
         printf "Detected Homebrew\n"
-        QT_PATH=$(brew --prefix qt)
+        QT_PATH=$(brew --prefix qt@5)
         OPENSSL_PATH=$(brew --prefix openssl)
 
         check_dir_exists "$QT_PATH" 'qt'


### PR DESCRIPTION
This request fixes the following error during `./clean_build.sh` on macOSX:

```console
$ ./clean_build.sh
...
CMake Error at src/gui/CMakeLists.txt:3 (find_package):
  By not providing "FindQt5.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "Qt5", but
  CMake did not find one.

  Could not find a package configuration file provided by "Qt5" with any of
  the following names:

    Qt5Config.cmake
    qt5-config.cmake

  Add the installation prefix of "Qt5" to CMAKE_PREFIX_PATH or set "Qt5_DIR"
  to a directory containing one of the above files.  If "Qt5" provides a
  separate development package or SDK, be sure it has been installed.
...
```

The cause of this error is that `brew --prefix qt` returns the latest Qt directory that may be Qt 6 rather than Qt 5.
This request fixes it by specifying Qt 5 directory explicitly.