### PR TITLE
Update azure-pipelines.yml to use multiple Ubuntu versions

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,9 +63,17 @@ jobs:
         artifactName: Windows Release Installer
 
 - job: LinuxBuild
+  strategy:
+    matrix:
+      ubuntu-16.04:
+        imageName: 'ubuntu-16.04'
+      ubuntu-18.04:
+        imageName: 'ubuntu-18.04'
+      ubuntu-20.04:
+        imageName: 'ubuntu-20.04'
   displayName: Linux Build
   pool:
-    vmImage: 'ubuntu-20.04'
+    vmImage: $(imageName)
   steps:
     - script: sudo apt-get update -y
     - script: sudo apt-get install -y libxtst-dev qtdeclarative5-dev libavahi-compat-libdnssd-dev libcurl4-openssl-dev

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,7 +65,7 @@ jobs:
 - job: LinuxBuild
   displayName: Linux Build
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-20.04'
   steps:
     - script: sudo apt-get update -y
     - script: sudo apt-get install -y libxtst-dev qtdeclarative5-dev libavahi-compat-libdnssd-dev libcurl4-openssl-dev


### PR DESCRIPTION
This request is to use Ubuntu 20.04 for Azure Pipelines.
Ubuntu 16.04 is already [end of standard support](https://wiki.ubuntu.com/Releases).
