### PR TITLE
README: Switch IRC contact info to libera network

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ and a [snap](https://snapcraft.io/barrier).
 
 ### Contact info:
 
-- `#barrier` on freenode
+- `#barrier` on libera IRC network
 
 #### CI Build Status
 


### PR DESCRIPTION
Most users moved to #barrier on libera, so let's switch the official channel to there too. 