### PR TITLE
azure-pipelines: Download from official qt source

### DIFF
--- a/azure-pipelines/download_install_qt.ps1
+++ b/azure-pipelines/download_install_qt.ps1
@@ -21,6 +21,6 @@ Write-Output 'Installed QLI Installer Dependencies'
 
 Write-Output 'Starting QT Installer'
 $Env:QLI_OUT_DIR = ".\deps\Qt\Qt$qt_version"
-$Env:QLI_BASE_URL = "http://mirrors.ocf.berkeley.edu/qt/online/qtsdkrepository/"
+$Env:QLI_BASE_URL = "https://download.qt.io/online/qtsdkrepository/"
 python .\deps\qli-installer\qli-installer.py $qt_version windows desktop win64_msvc2017_64
 Write-Output 'Installed QT Installer'


### PR DESCRIPTION
The previous source seems to be rate-limited and otherwise not properly
available which causes Windows builds to time out.