### PR TITLE
Add JP specific key mappings

### DIFF
--- a/src/lib/platform/MSWindowsKeyState.cpp
+++ b/src/lib/platform/MSWindowsKeyState.cpp
@@ -62,11 +62,11 @@ const KeyID				MSWindowsKeyState::s_virtualKey[] =
 	/* 0x013 */ { kKeyPause },		// VK_PAUSE
 	/* 0x014 */ { kKeyCapsLock },	// VK_CAPITAL
 	/* 0x015 */ { kKeyNone },		// undefined
-	/* 0x016 */ { kKeyKana },		// VK_HANGUL, VK_KANA
+	/* 0x016 */ { kKeyKana },		// VK_HANGUL, VK_KANA, VK_IME_ON
 	/* 0x017 */ { kKeyNone },		// VK_JUNJA
 	/* 0x018 */ { kKeyNone },		// VK_FINAL
 	/* 0x019 */ { kKeyKanzi },		// VK_HANJA, VK_KANJI
-	/* 0x01a */ { kKeyNone },		// undefined
+	/* 0x01a */ { kKeyEisuToggle },	// VK_IME_OFF
 	/* 0x01b */ { kKeyEscape },		// VK_ESCAPE
 	/* 0x01c */ { kKeyHenkan },		// VK_CONVERT
 	/* 0x01d */ { kKeyMuhenkan },	// VK_NONCONVERT

--- a/src/lib/platform/MSWindowsKeyState.cpp
+++ b/src/lib/platform/MSWindowsKeyState.cpp
@@ -61,8 +61,8 @@ const KeyID				MSWindowsKeyState::s_virtualKey[] =
 	/* 0x012 */ { kKeyAlt_L },		// VK_MENU
 	/* 0x013 */ { kKeyPause },		// VK_PAUSE
 	/* 0x014 */ { kKeyCapsLock },	// VK_CAPITAL
-	/* 0x015 */ { kKeyKana },		// VK_HANGUL, VK_KANA
-	/* 0x016 */ { kKeyNone },		// undefined
+	/* 0x015 */ { kKeyNone },		// undefined
+	/* 0x016 */ { kKeyKana },		// VK_HANGUL, VK_KANA
 	/* 0x017 */ { kKeyNone },		// VK_JUNJA
 	/* 0x018 */ { kKeyNone },		// VK_FINAL
 	/* 0x019 */ { kKeyKanzi },		// VK_HANJA, VK_KANJI

--- a/src/lib/platform/OSXKeyState.cpp
+++ b/src/lib/platform/OSXKeyState.cpp
@@ -43,6 +43,9 @@ static const UInt32 s_launchpadVK = 131;
 
 static const UInt32 s_osxNumLock = 1 << 16;
 
+static const UInt32 s_int4VK = 0x8a; // international4
+static const UInt32 s_int5VK = 0x8b; // international5
+
 struct KeyEntry {
 public:
     KeyID                m_keyID;
@@ -126,7 +129,10 @@ static const KeyEntry    s_controlKeys[] = {
 
     // JIS keyboards only
     { kKeyEisuToggle, kVK_JIS_Eisu },
-    { kKeyKana, kVK_JIS_Kana }
+    { kKeyKana, kVK_JIS_Kana },
+    { kKeyMuhenkan, s_int5VK },
+    { kKeyHenkan, s_int4VK },
+    { kKeyZenkaku, kVK_ANSI_Grave }
 };
 
 


### PR DESCRIPTION
This request adds key mappings for Japanese keyboards.

- Add `IME on` and `IME off` key entries to Windows. These keys are recently [introduced](https://docs.microsoft.com/en-US/windows-hardware/design/component-guidelines/keyboard-japan-ime#hid-usage-ps2-scan-code-and-virtual-key-code-for-imeon-key--imeoff-key). Note that these key codes are same as `Kana` and `EisuToggle` keys in macOS, respectively.
  - I also fixed the code for `VK_KANA` (0x016 is correct).
- Add `Henkan`, `Muhenkan` and `Zenkaku` key entries to macOS. Although these keys are not provided in mac keyboards, they can be sent from Windows barrier servers.
  - I declare the key codes for `Henkan` and `Muhenkan` by myself because I did not find the declarations of these key codes.
  - I found that these keys are sometimes referred as `international4` and `international5`, respectively (e.g., [search result in Github](https://github.com/search?q=international4+keycode+henkan&type=code)).