### PR TITLE
Fix qli file download location. Add deps on gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ CMakeCache.txt
 # Transient in-project-directory dependencies
 /deps/
 /out/build/x64-Debug
+/azure-pipelines/deps

--- a/azure-pipelines/download_install_qt.ps1
+++ b/azure-pipelines/download_install_qt.ps1
@@ -2,12 +2,13 @@ $ErrorActionPreference = "Stop"
 
 $qli_install_version = '2019.05.26.1'
 $qt_version = '5.13.0'
+$qli_path = $(Split-Path -Parent $PSCommandPath) + '\deps\qli-installer.zip'
 
 New-Item -Force -ItemType Directory -Path ".\deps\"
 
 Write-Output 'Downloading QLI Installer'
 $Wc = New-Object System.Net.WebClient
-$Wc.DownloadFile("https://github.com/nelsonjchen/qli-installer/archive/v$qli_install_version.zip", '.\deps\qli-installer.zip') ;
+$Wc.DownloadFile("https://github.com/nelsonjchen/qli-installer/archive/v$qli_install_version.zip", $qli_path) ;
 Write-Output 'Downloaded QLI Installer'
 
 Write-Output 'Extracting QLI Installer'

--- a/azure-pipelines/download_install_qt.ps1
+++ b/azure-pipelines/download_install_qt.ps1
@@ -2,13 +2,13 @@ $ErrorActionPreference = "Stop"
 
 $qli_install_version = '2019.05.26.1'
 $qt_version = '5.13.0'
-$qli_path = $(Split-Path -Parent $PSCommandPath) + '\deps\qli-installer.zip'
+$qli_path = "$(Split-Path -Parent $PSCommandPath)\deps\qli-installer.zip"
 
 New-Item -Force -ItemType Directory -Path ".\deps\"
 
 Write-Output 'Downloading QLI Installer'
 $Wc = New-Object System.Net.WebClient
-$Wc.DownloadFile("https://github.com/nelsonjchen/qli-installer/archive/v$qli_install_version.zip", $qli_path) ;
+$Wc.DownloadFile("https://github.com/nelsonjchen/qli-installer/archive/v$qli_install_version.zip", "$qli_path") ;
 Write-Output 'Downloaded QLI Installer'
 
 Write-Output 'Extracting QLI Installer'


### PR DESCRIPTION
Building on windows 10 encountered some problems. 
The current folder could not be issued with the known "." but rather, it needed to be added as a full path.

Deps folder was not part of the gitignore folder so i took the liberty to add them too.