### PR TITLE
Fix wrong encoding for text copied between linux and windows

### DIFF
--- a/doc/newsfragments/fix-wrong-encoding-for-text-copied-between-linux-and-windows.bugfix
+++ b/doc/newsfragments/fix-wrong-encoding-for-text-copied-between-linux-and-windows.bugfix
@@ -1,0 +1,2 @@
+Fix wrong encoding for text copied between Linux and Windows
+(https://github.com/debauchee/barrier/issues/1037, https://github.com/debauchee/barrier/issues/1137).

--- a/src/lib/platform/XWindowsClipboardHTMLConverter.cpp
+++ b/src/lib/platform/XWindowsClipboardHTMLConverter.cpp
@@ -56,10 +56,17 @@ XWindowsClipboardHTMLConverter::getDataSize() const
 
 std::string XWindowsClipboardHTMLConverter::fromIClipboard(const std::string& data) const
 {
-    return Unicode::UTF8ToUTF16(data);
+    return data;
 }
 
 std::string XWindowsClipboardHTMLConverter::toIClipboard(const std::string& data) const
 {
-    return Unicode::UTF16ToUTF8(data);
+    // Older Firefox [1] and possibly other applications use UTF-16 for text/html - handle both
+    // [1] https://bugzilla.mozilla.org/show_bug.cgi?id=1497580
+    if (Unicode::isUTF8(data)) {
+        return data;
+    } else {
+        return Unicode::UTF16ToUTF8(data);
+    }
+    return data;
 }


### PR DESCRIPTION
Copied from https://github.com/symless/synergy-core/pull/7029. I don't
include the application/x-moz-nativehtml part in that patch as I already
added it in https://github.com/debauchee/barrier/pull/1164.

Fixes https://github.com/debauchee/barrier/issues/1037
Fixes https://github.com/debauchee/barrier/issues/1137