### PR TITLE
Use screen name instead of IP address to announce server through zeroconf

### DIFF
--- a/src/gui/src/ZeroconfService.cpp
+++ b/src/gui/src/ZeroconfService.cpp
@@ -124,27 +124,6 @@ void ZeroconfService::errorHandle(DNSServiceErrorType errorCode)
         tr("Error code: %1.").arg(errorCode));
 }
 
-QString ZeroconfService::getLocalIPAddresses()
-{
-    QStringList addresses;
-    for (const QHostAddress& address : QNetworkInterface::allAddresses()) {
-        if (address.protocol() == QAbstractSocket::IPv4Protocol &&
-            address != QHostAddress(QHostAddress::LocalHost)) {
-            addresses.append(address.toString());
-        }
-    }
-
-    for (const QString& preferedIP : preferedIPAddress) {
-        for (const QString& address : addresses) {
-            if (address.startsWith(preferedIP)) {
-                return address;
-            }
-        }
-    }
-
-    return "";
-}
-
 bool ZeroconfService::registerService(bool server)
 {
     bool result = true;
@@ -159,19 +138,10 @@ bool ZeroconfService::registerService(bool server)
         else {
             m_pZeroconfRegister = new ZeroconfRegister(this);
             if (server) {
-                QString localIP = getLocalIPAddresses();
-                if (localIP.isEmpty()) {
-                    QMessageBox::warning(m_pMainWindow, tr("Barrier"),
-                        tr("Failed to get local IP address. "
-                           "Please manually type in server address "
-                           "on your clients"));
-                }
-                else {
-                    m_pZeroconfRegister->registerService(
-                        ZeroconfRecord(tr("%1").arg(localIP),
-                        QLatin1String(m_ServerServiceName), QString()),
-                        m_zeroconfServer.serverPort());
-                }
+                m_pZeroconfRegister->registerService(
+                    ZeroconfRecord(tr("%1").arg(m_pMainWindow->getScreenName()),
+                    QLatin1String(m_ServerServiceName), QString()),
+                    m_zeroconfServer.serverPort());
             }
             else {
                 m_pZeroconfRegister->registerService(

--- a/src/gui/src/ZeroconfService.h
+++ b/src/gui/src/ZeroconfService.h
@@ -42,7 +42,6 @@ private slots:
     void errorHandle(DNSServiceErrorType errorCode);
 
 private:
-    QString getLocalIPAddresses();
     bool registerService(bool server);
 
 private:


### PR DESCRIPTION
Same way it is done for client.

See https://github.com/symless/synergy-core/pull/6679/commits/f2cc582f9fe2db2834d25920f11d736d79b01d9c from myself.