### PR TITLE
Fix window icon in wayland

### DIFF
--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -97,6 +97,8 @@ int main(int argc, char* argv[])
 
 	QApplication::setQuitOnLastWindowClosed(false);
 
+    QApplication::setDesktopFileName(QStringLiteral("barrier"));  // For showing window icon in wayland.
+
 	QSettings settings;
 	AppConfig appConfig (&settings);
 


### PR DESCRIPTION
This assigns a desktop filename (barrier.desktop without the extension), from which the Icon is read to set window icon in KDE Wayland. See https://community.kde.org/Guidelines_and_HOWTOs/Wayland_Porting_Notes#Application_Icon