### PR TITLE
azure-pipelines: Use Invoke-WebRequest to download files

### DIFF
--- a/azure-pipelines/download_install_bonjour_sdk_like.ps1
+++ b/azure-pipelines/download_install_bonjour_sdk_like.ps1
@@ -1,8 +1,7 @@
 $ErrorActionPreference = "Stop"
 
 New-Item -Force -ItemType Directory -Path ".\deps\"
-$Wc = New-Object System.Net.WebClient
-$Wc.DownloadFile('https://github.com/nelsonjchen/mDNSResponder/releases/download/v2019.05.08.1/x64_RelWithDebInfo.zip', 'deps\BonjourSDKLike.zip') ;
+Invoke-WebRequest 'https://github.com/nelsonjchen/mDNSResponder/releases/download/v2019.05.08.1/x64_RelWithDebInfo.zip' -OutFile 'deps\BonjourSDKLike.zip' ;
 Write-Output 'Downloaded BonjourSDKLike Zip'
 Write-Output 'Unzipping BonjourSDKLike Zip'
 Remove-Item -Recurse -Force -ErrorAction Ignore .\deps\BonjourSDKLike

--- a/azure-pipelines/download_install_qt.ps1
+++ b/azure-pipelines/download_install_qt.ps1
@@ -6,8 +6,7 @@ $qt_version = '5.13.0'
 New-Item -Force -ItemType Directory -Path ".\deps\"
 
 Write-Output 'Downloading QLI Installer'
-$Wc = New-Object System.Net.WebClient
-$Wc.DownloadFile("https://github.com/nelsonjchen/qli-installer/archive/v$qli_install_version.zip", '.\deps\qli-installer.zip') ;
+Invoke-WebRequest "https://github.com/nelsonjchen/qli-installer/archive/v$qli_install_version.zip" -OutFile '.\deps\qli-installer.zip' ;
 Write-Output 'Downloaded QLI Installer'
 
 Write-Output 'Extracting QLI Installer'


### PR DESCRIPTION
When running System.Net.WebClient locally it results in a non-descriptive "An exception occurred during a WebClient request" error message. Invoke-WebRequest is an alternative that works so switch to that.

I haven't investigated the reason for the error.