### PR TITLE
Enable encryption by default

### DIFF
--- a/doc/newsfragments/enable-crypto-by-default.feature
+++ b/doc/newsfragments/enable-crypto-by-default.feature
@@ -1,0 +1,2 @@
+The `--enable-crypto` command line option has been made the default to reduce chances of accidental security mishaps when configuring Barrier from command line.
+A new `--disable-crypto` command line option has been added to explicitly disable encryption.

--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -516,8 +516,8 @@ void MainWindow::startBarrier()
 
 #endif
 
-    if (m_AppConfig->getCryptoEnabled()) {
-        args << "--enable-crypto";
+    if (!m_AppConfig->getCryptoEnabled()) {
+        args << "--disable-crypto";
     }
 
 #if defined(Q_OS_WIN)

--- a/src/lib/barrier/App.h
+++ b/src/lib/barrier/App.h
@@ -166,7 +166,8 @@ private:
     "  -l  --log <file>         write log messages to file.\n" \
     "      --no-tray            disable the system tray icon.\n" \
     "      --enable-drag-drop   enable file drag & drop.\n" \
-    "      --enable-crypto      enable the crypto (ssl) plugin.\n" \
+    "      --enable-crypto      enable the crypto (ssl) plugin (default, deprecated).\n" \
+    "      --disable-crypto     disable the crypto (ssl) plugin.\n" \
     "      --profile-dir <path> use named profile directory instead.\n" \
     "      --drop-dir <path>    use named drop target directory instead.\n"
 

--- a/src/lib/barrier/ArgParser.cpp
+++ b/src/lib/barrier/ArgParser.cpp
@@ -282,7 +282,10 @@ ArgParser::parseGenericArgs(int argc, const char* const* argv, int& i)
         argsBase().m_dropTarget = argv[++i];
     }
     else if (isArg(i, argc, argv, NULL, "--enable-crypto")) {
-        argsBase().m_enableCrypto = true;
+        LOG((CLOG_INFO "--enable-crypto is used by default. The option is deprecated."));
+    }
+    else if (isArg(i, argc, argv, NULL, "--disable-crypto")) {
+        argsBase().m_enableCrypto = false;
     }
     else if (isArg(i, argc, argv, NULL, "--profile-dir", 1)) {
         argsBase().m_profileDirectory = argv[++i];

--- a/src/lib/barrier/ArgsBase.cpp
+++ b/src/lib/barrier/ArgsBase.cpp
@@ -42,7 +42,7 @@ m_enableDragDrop(false),
 m_dropTarget(""),
 m_shouldExit(false),
 m_barrierAddress(),
-m_enableCrypto(false),
+    m_enableCrypto(true),
 m_profileDirectory(""),
 m_pluginDirectory("")
 {


### PR DESCRIPTION
This PR changes the command-line tool option so that encrypted connections is enabled by default and an additional flag is needed to disable it.