### PR TITLE
Include openssl applink shim into Windows builds

### DIFF
--- a/src/lib/net/SecureUtils.cpp
+++ b/src/lib/net/SecureUtils.cpp
@@ -57,6 +57,12 @@
 #include <cstring>
 #include <stdexcept>
 
+#if SYSAPI_WIN32
+// Windows builds require a shim that makes it possible to link to different
+// versions of the Win32 C runtime. See OpenSSL FAQ.
+#include <openssl/applink.c>
+#endif
+
 namespace barrier {
 
 namespace {


### PR DESCRIPTION
This unbreaks Windows builds that were broken since we started generating fingerprints ourselves instead of using the openssl tool.