### PR TITLE
Fix file descriptor leak on incomplete connections [SECURITY VULNERABILITY CVE-2021-42075]

### DIFF
--- a/doc/newsfragments/close-failed-handshake-connections.bugfix
+++ b/doc/newsfragments/close-failed-handshake-connections.bugfix
@@ -1,0 +1,6 @@
+SECURITY ISSUE
+
+Barrier will now correctly close connections when the app-level handshake fails (fixes CVE-2021-42075).
+
+Previously repeated failing connections would leak file descriptors leading to Barrier being unable
+to receive new connections from clients.

--- a/src/lib/server/ClientListener.cpp
+++ b/src/lib/server/ClientListener.cpp
@@ -194,6 +194,11 @@ ClientListener::handleUnknownClient(const Event&, void* vclient)
                             new TMethodEventJob<ClientListener>(this,
                                 &ClientListener::handleClientDisconnected,
                                 client));
+    } else {
+        auto* stream = unknownClient->getStream();
+        if (stream) {
+            stream->close();
+        }
     }
 
     // now finished with unknown client


### PR DESCRIPTION
There was a quite simple bug of not closing file descriptors if app-level handshake fails. This leads to inability to accept further connections once the file descriptors are exhausted.

This PR fixes the following security vulnerability:

 - CVE-2021-42075 DoS via file descriptor exhaustion

The issue has been reported by Matthias Gerstner mgerstner@suse.de @mgerstner. Matthias also provided insights into how best to fix the issues, precise reproduction steps and any used tools and made the maintainer's life as pleasant as possible. Thank you!