### PR TITLE
Add missing cstddef includes for NULL

### DIFF
--- a/doc/newsfragments/gcc-11-build.bugfix
+++ b/doc/newsfragments/gcc-11-build.bugfix
@@ -1,0 +1,1 @@
+Fixed build on GCC 11.2 (https://github.com/debauchee/barrier/issues/1366).

--- a/src/lib/base/Event.h
+++ b/src/lib/base/Event.h
@@ -21,6 +21,8 @@
 #include "common/basic_types.h"
 #include "common/stdmap.h"
 
+#include <cstddef>
+
 class EventData {
 public:
     EventData() { }


### PR DESCRIPTION
This fixes the build with GCC 11.2. There are probably loads more instances of this, but only this one prevented the build from working.