### PR TITLE
github: Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,3 @@
+## Contributor Checklist:
+
+* [ ] I have created a file in the `doc/newsfragments` directory (and read the `README.md` in that directory)


### PR DESCRIPTION
We track release notes by newsfragments and essentially all PRs need one. 