### PR TITLE
Refactoring of CI configurations and build scripts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,22 +79,22 @@ jobs:
     - script: sh -x ./clean_build.sh
       displayName: Clean Build
 
-- job: MacBuild
-  displayName: Mac Build
+- job: macOStests
+  displayName: macOS Tests
   strategy:
     matrix:
-      big-sur-Release:
+      big-sur:
           imageName: "macOS-11"
-          B_BUILD_TYPE: Release
-          BARRIER_VERSION_STAGE: Release
+          B_BUILD_TYPE: Debug
+          BARRIER_VERSION_STAGE: Debug
       catalina-Release:
           imageName: "macOS-10.15"
-          B_BUILD_TYPE: Release
-          BARRIER_VERSION_STAGE: Release
+          B_BUILD_TYPE: Debug
+          BARRIER_VERSION_STAGE: Debug
       mojave-Release:
           imageName: "macOS-10.14"
-          B_BUILD_TYPE: Release
-          BARRIER_VERSION_STAGE: Release
+          B_BUILD_TYPE: Debug
+          BARRIER_VERSION_STAGE: Debug
   pool:
     vmImage: $(imageName)
   variables:
@@ -109,9 +109,28 @@ jobs:
       displayName: Install Qt5 and pkg-config prereqs
     - script: sh -x ./clean_build.sh
       displayName: Clean Build
+
+- job: macOSRelease
+  displayName: macOS Universal Binary Release Builds
+  pool:
+    vmImage: "macOS-11"
+  variables:
+    VERBOSE: 1
+    TERM: xterm-256color
+    B_BUILD_TYPE: Release
+    BARRIER_VERSION_STAGE: Release
+  steps:
+    - script: rm -rf /usr/local/opt/openssl
+      displayName: Remove incompatible OpenSSL 1.0.2t from macOS-10.14 vmImage
+    - script: brew reinstall openssl
+      displayName: Installed newer OpenSSL 1.1.x
+    - script: brew install pkg-config qt5
+      displayName: Install Qt5 and pkg-config prereqs
+    - script: sh -x ./clean_build.sh
+      displayName: Clean Build
     - task: PublishBuildArtifacts@1
       displayName: Publish Release DMG
       condition: eq(variables['B_BUILD_TYPE'], 'Release')
       inputs:
         pathtoPublish: build/bundle
-        artifactName: Mac Release Disk Image and App $(imageName)
+        artifactName: Universal Binary for macOS

--- a/clean_build.sh
+++ b/clean_build.sh
@@ -1,32 +1,77 @@
 #!/bin/sh
+
 cd "$(dirname "$0")" || exit 1
+
 # some environments have cmake v2 as 'cmake' and v3 as 'cmake3'
 # check for cmake3 first then fallback to just cmake
-B_CMAKE=`type cmake3 2>/dev/null`
-if [ $? -eq 0 ]; then
-    B_CMAKE=`echo "$B_CMAKE" | cut -d' ' -f3`
+
+B_CMAKE=$(command -v cmake3 2>/dev/null)
+if [ "$?" -eq 0 ]; then
+    # Continue, cmake3 exists in $PATH.
+    continue
 else
-    B_CMAKE=cmake
+    # OK, so cmake3 isn't in path, so let's test to see if `cmake` itself exists, before proceeding.
+    if command -v cmake 2>/dev/null; then
+        B_CMAKE=$(command -v cmake)
+        # We have a cmake executable available, now let's proceed!
+    else
+        # As self-explanatory, the cmake executable isn't available, so we should fail here.
+        echo "ERROR: CMake not in $PATH, cannot build! Please install CMake, or if this persists, file a bug report."
+        exit 1
+    fi
 fi
-# default build configuration
+
+# Set default build type, but in CI, this is set to Release.
+# For downstream distributions, our recommendation is to set this type in your build scripts to Release, and supply Debug build types in your debug packages.
+
 B_BUILD_TYPE=${B_BUILD_TYPE:-Debug}
+
 if [ "$(uname)" = "Darwin" ]; then
-    # OSX needs a lot of extra help, poor thing
-    # run the osx_environment.sh script to fix paths
-    . ./osx_environment.sh
-    B_CMAKE_FLAGS="-DCMAKE_OSX_SYSROOT=$(xcode-select --print-path)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 $B_CMAKE_FLAGS"
+    # macOS needs a little help, so we source this environment script to fix paths.
+    if [ ! -e "./macOS_environment.sh" ]; then
+        echo "macOS environment script not found, this isn't meant to happen!"
+        exit 1
+    else
+        . ./macOS_environment.sh
+    fi
+
+    # We build a Universal macOS Binary, which supports M1 and Intel processors (64-bit)
+    CMAKE_OSX_ARCHITECTURES="arm64;x86_64"
+
+    B_CMAKE_FLAGS="-DCMAKE_OSX_SYSROOT=$(xcode-select --print-path)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 ${B_CMAKE_FLAGS:-}"
 fi
-# allow local customizations to build environment
-[ -r ./build_env.sh ] && . ./build_env.sh
+
+# Source local build variables to the environment, if available.
+# If not, continue as normal, and silently.
+if [ -e "./build_env.sh" ]; then
+    . "./build_env.sh"
+fi
 
 # Initialise Git submodules
 git submodule update --init --recursive
 
-B_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=$B_BUILD_TYPE $B_CMAKE_FLAGS"
-rm -rf build
-mkdir build || exit 1
-cd build || exit 1
-echo "Starting Barrier $B_BUILD_TYPE build..."
-$B_CMAKE $B_CMAKE_FLAGS .. || exit 1
-make || exit 1
-echo "Build completed successfully"
+B_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=${B_BUILD_TYPE} ${B_CMAKE_FLAGS:-}"
+
+# Clear build directory, but do a conditional first!
+
+if [ -d "./build" ]; then
+    rm -rf ./build
+fi
+
+# Previous versions of this script created the build directory, and CD'd into it - CMake allows us to do this another way...
+
+# Note: If you use Ninja (i.e, cmake -GNinja -B build), run Ninja like: "ninja -C build", just like you would with Meson.
+
+$B_CMAKE "$B_CMAKE_FLAGS" -B build || exit 1
+
+
+echo "INFO: Now commencing Barrier build process..."
+echo "INFO: We're building an $B_BUILD_TYPE output type."
+$(command -v make) -C build || exit 1
+
+# Implictly, we assume the build was successful due to no exits.
+# Later revisions of this script should do conditionals. TODO.
+
+echo "INFO: Success! The build completed successfully!"
+
+exit

--- a/doc/newsfragments/enhance-ci-builds-and-add-macos-universal-binaries-builds.feature
+++ b/doc/newsfragments/enhance-ci-builds-and-add-macos-universal-binaries-builds.feature
@@ -1,0 +1,1 @@
+Refactor CI builds, and build scripts to be more resilient, and effective

--- a/macOS_environment.sh
+++ b/macOS_environment.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Checks if directory exists, otherwise asks to install package.
+check_dir_exists() {
+    local path=$1
+    local package=$2
+
+    if [ ! -d "$path" ]; then
+        echo "Please install $package"
+        exit 1
+    fi
+}
+
+if [ -z "$BARRIER_BUILD_ENV" ]; then
+    check_dir_exists '/Applications/Xcode.app' 'Xcode'
+
+    printf "Modifying environment for Barrier build...\n"
+
+    if command -v port; then
+        printf "Detected Macports\n"
+
+        check_dir_exists '/opt/local/lib/cmake/Qt5' 'qt5-qtbase port'
+
+        export BARRIER_BUILD_MACPORTS=1
+        export CMAKE_PREFIX_PATH="/opt/local/lib/cmake/Qt5:$CMAKE_PREFIX_PATH"
+        export LD_LIBRARY_PATH="/opt/local/lib:$LD_LIBRARY_PATH"
+        export CPATH="/opt/local/include:$CPATH"
+        export PKG_CONFIG_PATH="/opt/local/libexec/qt5/lib/pkgconfig:$PKG_CONFIG_PATH"
+
+    elif command -v brew; then
+        printf "Detected Homebrew\n"
+        QT_PATH=$(brew --prefix qt@5)
+
+        check_dir_exists "$QT_PATH" 'qt5'
+
+        export BARRIER_BUILD_BREW=1
+        export CMAKE_PREFIX_PATH="/opt/procursus:$QT_PATH:$CMAKE_PREFIX_PATH"
+        export LD_LIBRARY_PATH="/opt/procursus/lib:$LD_LIBRARY_PATH"
+        export CPATH="/opt/procursus/include:$CPATH"
+        export PKG_CONFIG_PATH="/opt/procursus/lib/pkgconfig:$PKG_CONFIG_PATH"
+    else
+        printf "Neither Homebrew nor Macports is installed. Can't get dependency paths\n"
+        exit 1
+    fi
+
+    export BARRIER_BUILD_ENV=1
+
+    printf "done\n"
+fi


### PR DESCRIPTION
Now, CI builds for macOS involve three separate builds for a range of macOS versions, and a final Universal macOS Binary made on Big Sur. It should work with the M1 chip and x86_64 Intel Macs.

I have also renamed osx_environment->macOS_environment.sh to reflect the new name change of Apple's desktop OS.

In terms of the clean_builds.sh script, this has also been refactored to be more resilient, and efficient (marginally).

Signed-off-by: Dom Rodriguez <shymega@shymega.org.uk>

## Contributor Checklist:

* [x] I have created a file in the `doc/newsfragments` directory (and read the `README.md` in that directory)
