### PR TITLE
github: Don't automatically add labels to bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,5 @@
 name: Bug Report
 description: File a bug report (for questions, ideas & support, use the Discussions tab, or IRC for quick answers, but make sure to stay on the channel!)
-labels: [bug, triage]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Many bug reports are not about bugs (e.g. just hard to understand behavior and so on) and some of the remaining are not about bugs in our project.

It's up to the person doing bug triage to mark whether one believes this is really a bug or no. Adding "bug" label to everything just introduces noise.

cc @shymega 