### PR TITLE
Enhance Windows CI builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,14 +9,28 @@ trigger:
 jobs:
 - job: WinBuild
   displayName: Windows Build
-  pool:
-    vmImage: 'vs2017-win2016'
   strategy:
     matrix:
-      Debug:
-        CI_ENV_BUILD_TYPE: Debug
-      Release with Release Installer:
-        CI_ENV_BUILD_TYPE: Release
+#        windows-2022-Debug:
+#            imageName: "windows-2022"
+#            CI_ENV_BUILD_TYPE: Debug
+#        windows-2022-Release:
+#            imageName: "windows-2022"
+#            CI_ENV_BUILD_TYPE: Release
+#        windows-2019-Debug:
+#            imageName: "windows-2019"
+#            CI_ENV_BUILD_TYPE: Debug
+#        windows-2019-Release:
+#            imageName: "windows-2019"
+#            CI_ENV_BUILD_TYPE: Release
+        windows-2016-Debug:
+            CI_ENV_BUILD_TYPE: Debug
+            imageName: "vs2017-win2016"
+        windows-2016-Release:
+            CI_ENV_BUILD_TYPE: Release
+            imageName: "vs2017-win2016"
+  pool:
+    vmImage: $(imageName)
   steps:
     # Gather Dependencies
     - task: PowerShell@2


### PR DESCRIPTION
This PR adds support for the Windows Server 2022 build agent. This isn't based on Windows 11, but rather Windows 10. I added 2022, 2019, and 2016 to a build matrix. Currently, 2022 and 2016 are disabled.

I had to do that because currently they fail to build, as the BATCH script has the VS SDK path hardcoded. Until we fix that, the aforementioned build agents will remain disabled.

`##` Contributor Checklist:

* [x] I have created a file in the `doc/newsfragments` directory (and read the `README.md` in that directory)
