### PR TITLE
Clarify PR template with regards to user-visible changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,4 @@
 ## Contributor Checklist:
 
-* [ ] I have created a file in the `doc/newsfragments` directory (and read the `README.md` in that directory)
+* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
+      user-visible change (and make sure to read the `README.md` in that directory) 


### PR DESCRIPTION
I've made the PR template clarify the need for the newsfragment to be created **if** the PR is a user-visible change. For example, I had made a PR that modified the CI configuration. GIven this isn't a user-visible change, @p12tic gave feedback that the template should make that clear.

Therefore, this PR addresses that feedback.

## Contributor Checklist:

* [x] I have created a file in the `doc/newsfragments` directory (and read the `README.md` in that directory)
