### PR TITLE
add header encoding="UTF-8" in plist

### DIFF
--- a/src/gui/res/mac/Info.plist
+++ b/src/gui/res/mac/Info.plist
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>


### PR DESCRIPTION
needed for plistlib

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
