### PR TITLE
Fix link to Linux drag and drop issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ specific packages.
 
 **Q: Does drag and drop work on linux?**
 
-> A: No *(see [#855](https://github.com/debauchee/barrier/issues/544) if you'd like to change that)*
+> A: No *(see [#855](https://github.com/debauchee/barrier/issues/855) if you'd like to change that)*
 
 
 **Q: What OSes are supported?**

--- a/doc/newsfragments/linux-drag-drop-faq.doc
+++ b/doc/newsfragments/linux-drag-drop-faq.doc
@@ -1,0 +1,1 @@
+Fixed FAQ link to Linux drag and drop issue.


### PR DESCRIPTION
The README FAQ links the wrong issue for drag and drop on Linux.

## Contributor Checklist:

* [x] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
