### PR TITLE
Fix issue with generation of new certificate

### DIFF
--- a/src/lib/net/SecureUtils.cpp
+++ b/src/lib/net/SecureUtils.cpp
@@ -190,7 +190,7 @@ void generate_pem_self_signed_cert(const std::string& path)
 
     X509_sign(cert, private_key, EVP_sha256());
 
-    auto fp = fopen_utf8_path(path.c_str(), "r");
+    auto fp = fopen_utf8_path(path.c_str(), "w");
     if (!fp) {
         throw std::runtime_error("Could not open certificate output path");
     }


### PR DESCRIPTION
Barrier did not create a new certificate when testing a fresh install of v2.4 on a Windows VM. There are several issues reported on the same. After inspecting the code, it seems to me the abvious reason is that the file handle supplied to `PEM_write_PrivateKey` is opened for read-only.

Related:
https://github.com/debauchee/barrier/issues/1377#issuecomment-965129129

## Contributor Checklist:

* [x] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 