### PR TITLE
Restore dpiAwareness

### DIFF
--- a/doc/newsfragments/restore-dpiawareness.bugfix
+++ b/doc/newsfragments/restore-dpiawareness.bugfix
@@ -1,0 +1,1 @@
+Fixed a regression in 2.4.0 that caused Barrier to not support scaling other than 100% (https://github.com/debauchee/barrier/issues/1462).

--- a/src/cmd/barrierc/CMakeLists.txt
+++ b/src/cmd/barrierc/CMakeLists.txt
@@ -21,7 +21,9 @@ set(sources
 if (WIN32)
     file(GLOB arch_headers "MSWindows*.h")
     file(GLOB arch_sources "MSWindows*.cpp")
-    list(APPEND sources barrierc.rc)
+    list(APPEND sources
+        barrierc.rc
+        barrierc.exe.manifest)
 elseif (APPLE)
     file(GLOB arch_headers "OSX*.h")
     file(GLOB arch_sources "OSX*.cpp")

--- a/src/cmd/barrierc/barrierc.exe.manifest
+++ b/src/cmd/barrierc/barrierc.exe.manifest
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+        <security>
+            <requestedPrivileges>
+                <requestedExecutionLevel level="asInvoker" uiAccess="false"></requestedExecutionLevel>
+            </requestedPrivileges>
+        </security>
+    </trustInfo>
+    <application xmlns="urn:schemas-microsoft-com:asm.v3">
+        <windowsSettings>
+            <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+            <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitor</dpiAwareness>
+        </windowsSettings>
+    </application>
+</assembly>

--- a/src/cmd/barriers/CMakeLists.txt
+++ b/src/cmd/barriers/CMakeLists.txt
@@ -21,7 +21,9 @@ set(sources
 if (WIN32)
     file(GLOB arch_headers "MSWindows*.h")
     file(GLOB arch_sources "MSWindows*.cpp")
-    list(APPEND sources barriers.rc)
+    list(APPEND sources
+        barriers.rc
+        barriers.exe.manifest)
 elseif (APPLE)
     file(GLOB arch_headers "OSX*.h")
     file(GLOB arch_sources "OSX*.cpp")

--- a/src/cmd/barriers/barriers.exe.manifest
+++ b/src/cmd/barriers/barriers.exe.manifest
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+        <security>
+            <requestedPrivileges>
+                <requestedExecutionLevel level="asInvoker" uiAccess="false"></requestedExecutionLevel>
+            </requestedPrivileges>
+        </security>
+    </trustInfo>
+    <application xmlns="urn:schemas-microsoft-com:asm.v3">
+        <windowsSettings>
+            <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+            <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitor</dpiAwareness>
+        </windowsSettings>
+    </application>
+</assembly>


### PR DESCRIPTION
Fixes regression from #304
Fixes #1462, possibly others.

## Contributor Checklist:

* [x] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
