### PR TITLE
Fix #1531: Revert control key remapping from grave/tilde to zenkaku

### DIFF
--- a/doc/newsfragments/1531_remove_zenkaku_remapping.bugfix
+++ b/doc/newsfragments/1531_remove_zenkaku_remapping.bugfix
@@ -1,0 +1,1 @@
+macOS servers can send the grave accent and the tilde to clients.

--- a/doc/newsfragments/1531_zenkaku_remapping.removal
+++ b/doc/newsfragments/1531_zenkaku_remapping.removal
@@ -1,0 +1,1 @@
+Removed remapping from the grave accent to the zenkaku.

--- a/src/lib/platform/OSXKeyState.cpp
+++ b/src/lib/platform/OSXKeyState.cpp
@@ -131,8 +131,7 @@ static const KeyEntry    s_controlKeys[] = {
     { kKeyEisuToggle, kVK_JIS_Eisu },
     { kKeyKana, kVK_JIS_Kana },
     { kKeyMuhenkan, s_int5VK },
-    { kKeyHenkan, s_int4VK },
-    { kKeyZenkaku, kVK_ANSI_Grave }
+    { kKeyHenkan, s_int4VK }
 };
 
 


### PR DESCRIPTION
The bug was introduced in the pull request #1214, and even in the description of the request it had been acknowledged that there is no such key on mac keyboards.

As a consequence, it led to inability to transfer the grave accent and and the tilde, at least from macOS to Windows on default "ABC" keyboard layout.

Unfortunately, I don't have a JIS keyboard, nor understand how to use it. The only thing I can suggest now is to revert the controversial remapping.

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
