### PR TITLE
add macOS 12/SDK version check (M1 fix)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,9 +344,9 @@ elseif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
             ${OPENSSL_ROOT}/lib/libcrypto.a
             z
         )
-    elseif (IS_DIRECTORY /usr/local/opt/openssl AND BREW_PROGRAM)
+    elseif (BREW_PROGRAM)
         # brew
-        set (OPENSSL_ROOT /usr/local/opt/openssl)
+        exec_program(brew ARGS "--prefix openssl" OUTPUT_VARIABLE OPENSSL_ROOT)
 
         include_directories (BEFORE SYSTEM ${OPENSSL_ROOT}/include)
 

--- a/clean_build.sh
+++ b/clean_build.sh
@@ -14,7 +14,16 @@ if [ "$(uname)" = "Darwin" ]; then
     # OSX needs a lot of extra help, poor thing
     # run the osx_environment.sh script to fix paths
     . ./osx_environment.sh
-    B_CMAKE_FLAGS="-DCMAKE_OSX_SYSROOT=$(xcode-select --print-path)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 $B_CMAKE_FLAGS"
+
+    # default to 12.0, fallback to 10.9
+    OSX_DEPLOY_TARGET="12.0"
+    [ ! "$OSTYPE" == "darwin21"* ] && OSX_DEPLOY_TARGET="10.9"
+
+    # prefer newest MacOSX.sdk
+    OSX_SYSROOT="$(xcode-select --print-path)/SDKs/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
+    [ ! -d "$OSX_SYSROOT" ] && OSX_SYSROOT="$(xcode-select --print-path)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
+
+    B_CMAKE_FLAGS="-DCMAKE_OSX_SYSROOT=$OSX_SYSROOT -DCMAKE_OSX_DEPLOYMENT_TARGET=$OSX_DEPLOY_TARGET $B_CMAKE_FLAGS"
 fi
 # allow local customizations to build environment
 [ -r ./build_env.sh ] && . ./build_env.sh


### PR DESCRIPTION
Build was breaking on 12.x or with the new Xcode -- 

- Incorporated a change to use brew to get the openssl path
- Added tests for 12.x with a fallback to 10.9 deploy target (must match openssl deploy target)
- Added tests for new MacOS.sdk location with fallback to old
- Built and tested with: export B_BUILD_TYPE=Release ./clean_build.sh 
- Self-signed with: codesign --force --deep --sign - /Applications/Barrier.app

This shouldn't change anything user-facing, i.e. break compatibility with older versions, but I have not tested that yet.  This works on my M1 MacBook Air as a native Apple Silicon app.

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
