### PR TITLE
Allow changing screens from non-rectangular multi-monitor setups

### DIFF
--- a/src/lib/barrier/Display.h
+++ b/src/lib/barrier/Display.h
@@ -1,0 +1,12 @@
+#include <Carbon/Carbon.h>
+/**
+ * Platform-independent display.
+ */
+class Display {
+  public:
+    UInt32 displayId;
+    SInt32 x;
+    SInt32 y;
+    SInt32 width;
+    SInt32 height;
+};

--- a/src/lib/barrier/IScreen.h
+++ b/src/lib/barrier/IScreen.h
@@ -22,6 +22,7 @@
 #include "base/Event.h"
 #include "base/EventTypes.h"
 #include "common/IInterface.h"
+#include "Display.h"
 
 class IClipboard;
 
@@ -66,6 +67,8 @@ public:
     Return the current position of the cursor in \c x and \c y.
     */
     virtual void        getCursorPos(SInt32& x, SInt32& y) const = 0;
+
+    virtual std::vector<Display*> getDisplays() const = 0;
 
     //@}
 };

--- a/src/lib/barrier/PlatformScreen.h
+++ b/src/lib/barrier/PlatformScreen.h
@@ -2,11 +2,11 @@
  * barrier -- mouse and keyboard sharing utility
  * Copyright (C) 2012-2016 Symless Ltd.
  * Copyright (C) 2004 Chris Schoeneman
- * 
+ *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * found in the file LICENSE that should have accompanied this file.
- * 
+ *
  * This package is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -97,7 +97,7 @@ public:
     virtual void        setOptions(const OptionsList& options) = 0;
     virtual void        setSequenceNumber(UInt32) = 0;
     virtual bool        isPrimary() const = 0;
-    
+
     virtual void        fakeDraggingFiles(DragFileList fileList) { throw std::runtime_error("fakeDraggingFiles not implemented"); }
     virtual const String&
                         getDropTarget() const { throw std::runtime_error("getDropTarget not implemented"); }

--- a/src/lib/barrier/Screen.cpp
+++ b/src/lib/barrier/Screen.cpp
@@ -562,4 +562,9 @@ Screen::leaveSecondary()
     m_screen->fakeAllKeysUp();
 }
 
+std::vector<Display*>
+Screen::getDisplays() const {
+  return m_screen->getDisplays();
+}
+
 }

--- a/src/lib/barrier/Screen.h
+++ b/src/lib/barrier/Screen.h
@@ -301,6 +301,7 @@ public:
     virtual void        getShape(SInt32& x, SInt32& y,
                             SInt32& width, SInt32& height) const;
     virtual void        getCursorPos(SInt32& x, SInt32& y) const;
+    virtual std::vector<Display*> getDisplays() const;
 
     IPlatformScreen*    getPlatformScreen() { return m_screen; }
 

--- a/src/lib/client/Client.cpp
+++ b/src/lib/client/Client.cpp
@@ -234,6 +234,12 @@ Client::getShape(SInt32& x, SInt32& y, SInt32& w, SInt32& h) const
     m_screen->getShape(x, y, w, h);
 }
 
+std::vector<Display*>
+Client::getDisplays() const
+{
+    // TODO(vjpr):
+}
+
 void
 Client::getCursorPos(SInt32& x, SInt32& y) const
 {

--- a/src/lib/client/Client.h
+++ b/src/lib/client/Client.h
@@ -139,6 +139,7 @@ public:
     virtual void        getShape(SInt32& x, SInt32& y,
                             SInt32& width, SInt32& height) const;
     virtual void        getCursorPos(SInt32& x, SInt32& y) const;
+    virtual std::vector<Display*> getDisplays() const;
 
     // IClient overrides
     virtual void        enter(SInt32 xAbs, SInt32 yAbs,

--- a/src/lib/platform/OSXScreen.h
+++ b/src/lib/platform/OSXScreen.h
@@ -24,6 +24,7 @@
 #include "base/EventTypes.h"
 #include "common/stdmap.h"
 #include "common/stdvector.h"
+#import "barrier/Display.h"
 
 #include <bitset>
 #include <Carbon/Carbon.h>
@@ -53,6 +54,9 @@ class Mutex;
 //! Implementation of IPlatformScreen for OS X
 class OSXScreen : public PlatformScreen {
 public:
+    // TODO(vjpr): make private.
+    std::vector<Display*> m_displays;
+
     OSXScreen(IEventQueue* events, bool isPrimary, bool autoShowHideCursor=true);
     virtual ~OSXScreen();
 
@@ -64,6 +68,7 @@ public:
     virtual void        getShape(SInt32& x, SInt32& y,
                             SInt32& width, SInt32& height) const;
     virtual void        getCursorPos(SInt32& x, SInt32& y) const;
+    virtual std::vector<Display*> getDisplays() const;
 
     // IPrimaryScreen overrides
     virtual void        reconfigure(UInt32 activeSides);

--- a/src/lib/server/BaseClientProxy.h
+++ b/src/lib/server/BaseClientProxy.h
@@ -63,6 +63,7 @@ public:
     virtual bool        getClipboard(ClipboardID id, IClipboard*) const = 0;
     virtual void        getShape(SInt32& x, SInt32& y,
                             SInt32& width, SInt32& height) const = 0;
+    virtual std::vector<Display*> getDisplays() const = 0;
     virtual void        getCursorPos(SInt32& x, SInt32& y) const = 0;
 
     // IClient overrides

--- a/src/lib/server/ClientProxy1_0.cpp
+++ b/src/lib/server/ClientProxy1_0.cpp
@@ -500,3 +500,12 @@ ClientProxy1_0::ClientClipboard::ClientClipboard() :
 {
     // do nothing
 }
+
+std::vector<Display*>
+ClientProxy1_0::getDisplays() const {
+
+  // TODO(vjpr):
+  std::vector<Display*> vec;
+  return vec;
+
+}

--- a/src/lib/server/ClientProxy1_0.h
+++ b/src/lib/server/ClientProxy1_0.h
@@ -37,6 +37,7 @@ public:
     virtual void        getShape(SInt32& x, SInt32& y,
                             SInt32& width, SInt32& height) const;
     virtual void        getCursorPos(SInt32& x, SInt32& y) const;
+    virtual std::vector<Display*> getDisplays() const;
 
     // IClient overrides
     virtual void        enter(SInt32 xAbs, SInt32 yAbs,

--- a/src/lib/server/ClientProxy1_6.cpp
+++ b/src/lib/server/ClientProxy1_6.cpp
@@ -99,3 +99,11 @@ ClientProxy1_6::recvClipboard()
 
     return true;
 }
+
+std::vector<Display*> getDisplays() {
+
+  // TODO(vjpr):
+  std::vector<Display*> vec;
+  return vec;
+
+}

--- a/src/lib/server/ClientProxy1_6.h
+++ b/src/lib/server/ClientProxy1_6.h
@@ -31,6 +31,7 @@ public:
 
     virtual void        setClipboard(ClipboardID id, const IClipboard* clipboard);
     virtual bool        recvClipboard();
+    //virtual std::vector<Display*> getDisplays();
 
 private:
     void                handleClipboardSendingEvent(const Event&, void*);

--- a/src/lib/server/PrimaryClient.cpp
+++ b/src/lib/server/PrimaryClient.cpp
@@ -21,6 +21,7 @@
 #include "barrier/Screen.h"
 #include "barrier/Clipboard.h"
 #include "base/Log.h"
+#include "platform/OSXScreen.h"
 
 //
 // PrimaryClient
@@ -271,4 +272,15 @@ void
 PrimaryClient::setOptions(const OptionsList& options)
 {
     m_screen->setOptions(options);
+}
+
+std::vector<Display*>
+PrimaryClient::getDisplays() const {
+
+  // TODO(vjpr): Only works for osx!
+  IPlatformScreen* screen = m_screen->getPlatformScreen();
+  OSXScreen* platformScreen = dynamic_cast<OSXScreen*>(screen);
+  std::vector<Display*> displays = platformScreen->m_displays;
+  return displays;
+
 }

--- a/src/lib/server/PrimaryClient.h
+++ b/src/lib/server/PrimaryClient.h
@@ -122,6 +122,7 @@ public:
     virtual void        getShape(SInt32& x, SInt32& y,
                             SInt32& width, SInt32& height) const;
     virtual void        getCursorPos(SInt32& x, SInt32& y) const;
+    virtual std::vector<Display*> getDisplays() const;
 
     // IClient overrides
     virtual void        enter(SInt32 xAbs, SInt32 yAbs,

--- a/src/lib/server/Server.h
+++ b/src/lib/server/Server.h
@@ -232,7 +232,7 @@ private:
     // cross multiple screens.  if there is no suitable screen then
     // return NULL and x,y are not modified.
     BaseClientProxy*    mapToNeighbor(BaseClientProxy*, EDirection,
-                            SInt32& x, SInt32& y) const;
+                            SInt32& x, SInt32& y, Display*) const;
 
     // adjusts x and y or neither to avoid ending up in a jump zone
     // after entering the client in the given direction.


### PR DESCRIPTION
## Status

This is an incomplete draft.

Currently only implemented for up/down from a macOS primary display (my setup).

## Reference

#1112

## Todo

- [ ] Create a new protocol version to allow sending information about display dimensions and origins.
- [ ] Implement and test left/right.
- [ ] Implement Windows and Linux display retrieval code.
- [ ] Remove hard-coded macos-specific code from `Server.cpp`.
- [ ] Extract display detection code into separate functions/files.

## Related Features

- [ ] Allow setting the positioning of one screen's displays relative to another screen's
   This is possible with range config setting but only for percentages at the moment.
   See links (https://symless.com/help-articles/creating-text-config-files).

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
