### PR TITLE
Add support on MacOS to detect when the accessibility permission is removed

### DIFF
--- a/doc/newsfragments/mac-accessibility-permission.feature
+++ b/doc/newsfragments/mac-accessibility-permission.feature
@@ -1,0 +1,1 @@
++ Add support to detect when the accessibility permission has been removed on MacOS and terminate the application.

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -21,6 +21,7 @@ set(GUI_COMMON_HEADER_FILES
 
 set(GUI_SOURCE_FILES
     src/AboutDialog.cpp
+    src/AccessibilityPermissionObserver.cpp
     src/ActionDialog.cpp
     src/AddClientDialog.cpp
     src/AppConfig.cpp
@@ -61,6 +62,7 @@ set(GUI_SOURCE_FILES
 
 set(GUI_HEADER_FILES
     src/AboutDialog.h
+    src/AccessibilityPermissionObserver.h
     src/ActionDialog.h
     src/AddClientDialog.h
     src/AppConfig.h

--- a/src/gui/src/AccessibilityPermissionObserver.cpp
+++ b/src/gui/src/AccessibilityPermissionObserver.cpp
@@ -1,0 +1,53 @@
+/*
+ * barrier -- mouse and keyboard sharing utility
+ * Copyright (C) 2022 Duncan Cunningham
+ *
+ * This package is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * found in the file LICENSE that should have accompanied this file.
+ *
+ * This package is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AccessibilityPermissionObserver.h"
+
+#include <QApplication>
+#include <QDebug>
+#include <QTimer>
+
+#if defined(Q_OS_MAC)
+#include <Carbon/Carbon.h>
+#endif
+
+AccessibilityPermissionObserver::AccessibilityPermissionObserver(QObject* parent)
+    : QObject(parent)
+{
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 1090 // mavericks
+    m_pTimer = new QTimer(this);
+
+    connect(m_pTimer, SIGNAL(timeout()), this, SLOT(checkAccessibilityPermissions()));
+#endif
+}
+
+void AccessibilityPermissionObserver::start()
+{
+    if (m_pTimer) {
+        m_pTimer->start(1000);
+    }
+}
+
+void AccessibilityPermissionObserver::checkAccessibilityPermissions()
+{
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 1090 // mavericks
+    // There's no API to be notified when this permission changes, so we have to poll it.
+    if (!AXIsProcessTrusted()) {
+        QApplication::quit();
+    }
+#endif
+}

--- a/src/gui/src/AccessibilityPermissionObserver.cpp
+++ b/src/gui/src/AccessibilityPermissionObserver.cpp
@@ -18,7 +18,6 @@
 #include "AccessibilityPermissionObserver.h"
 
 #include <QApplication>
-#include <QDebug>
 #include <QTimer>
 
 #if defined(Q_OS_MAC)

--- a/src/gui/src/AccessibilityPermissionObserver.h
+++ b/src/gui/src/AccessibilityPermissionObserver.h
@@ -1,0 +1,34 @@
+/*
+ * barrier -- mouse and keyboard sharing utility
+ * Copyright (C) 2022 Duncan Cunningham
+ *
+ * This package is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * found in the file LICENSE that should have accompanied this file.
+ *
+ * This package is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QObject>
+
+class QTimer;
+
+class AccessibilityPermissionObserver: public QObject
+{
+    Q_OBJECT
+public:
+    explicit AccessibilityPermissionObserver(QObject* parent = nullptr);
+    void start();
+public slots:
+    void checkAccessibilityPermissions();
+private:
+    QTimer* m_pTimer;
+};

--- a/src/gui/src/MainWindow.h
+++ b/src/gui/src/MainWindow.h
@@ -53,6 +53,7 @@ class QTemporaryFile;
 class QMessageBox;
 class QAbstractButton;
 
+class AccessibilityPermissionObserver;
 class LogDialog;
 class QBarrierApplication;
 class SetupWizard;
@@ -198,6 +199,7 @@ public slots:
         SslCertificate* m_pSslCertificate;
         QStringList m_PendingClientNames;
         LogWindow *m_pLogWindow;
+        AccessibilityPermissionObserver* m_pAccessibilityPermissionObserver;
 
         bool m_fingerprint_expanded = false;
 


### PR DESCRIPTION
On macOS if you are running the barrier server and you remove the accessibility permission in System Preferences, your computer becomes unusable. You are able to move the mouse pointer around, but no clicks go through and none of the keyboard input either. I had to manually restart my computer using the power button. I guess what happens is that barrier continues to capture the input, but can't forward it on as the accessibility permission has been removed.

My fix is to periodically check if the accessibility permission is enabled and if not, terminate the application. MacOS provides no API to be notified when this permission changes, so we have to basically poll it. The fix currently checks every second, but only when barrier is started.

## Contributor Checklist:

* [x] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
