### PR TITLE
Check Carriage Return from Unix

### DIFF
--- a/src/lib/platform/MSWindowsClipboardAnyTextConverter.cpp
+++ b/src/lib/platform/MSWindowsClipboardAnyTextConverter.cpp
@@ -104,7 +104,7 @@ std::string MSWindowsClipboardAnyTextConverter::convertLinefeedToWin32(const std
     // copy string, converting newlines
     n = (UInt32)src.size();
     for (const char* scan = src.c_str(); n > 0; ++scan, --n) {
-        if (scan[0] == '\n') {
+        if (scan[0] == '\n' && dst.back() != '\r') {
             dst += '\r';
         }
         dst += scan[0];


### PR DESCRIPTION
In my environment(Ubuntu 20.04)
when I copy multi lines at gnome terminal, all lines are added an additional newline.

I think it's because of the carriage return from Unix.
It's a solution that ignores the carriage return.
