### PR TITLE
Use Qt6 instead of Qt5

### DIFF
--- a/doc/newsfragments/support_qt6.md
+++ b/doc/newsfragments/support_qt6.md
@@ -1,0 +1,3 @@
+# Support Qt6
+
+Allow to compile barrier with Qt6

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required (VERSION 3.4)
 
-find_package (Qt5 REQUIRED COMPONENTS Core Widgets Network)
+find_package (Qt6 REQUIRED COMPONENTS Core Widgets Network Core5Compat)
 set (CMAKE_AUTOMOC ON)
 set (CMAKE_AUTORCC ON)
 set (CMAKE_AUTOUIC ON)
@@ -131,7 +131,7 @@ add_executable (barrier WIN32
 
 include_directories (./src)
 
-target_link_libraries(barrier net base io Qt5::Core Qt5::Widgets Qt5::Network ${OPENSSL_LIBS})
+target_link_libraries(barrier net base io Qt6::Core Qt6::Widgets Qt6::Network Qt6::Core5Compat ${OPENSSL_LIBS})
 target_compile_definitions (barrier PRIVATE -DBARRIER_VERSION_STAGE="${BARRIER_VERSION_STAGE}")
 target_compile_definitions (barrier PRIVATE -DBARRIER_REVISION="${BARRIER_REVISION}")
 
@@ -177,5 +177,5 @@ if (BARRIER_BUILD_TESTS)
     add_test(guiunittests guiunittests)
 
     target_include_directories(guiunittests PUBLIC ../../ext)
-    target_link_libraries(guiunittests gtest gmock Qt5::Core Qt5::Widgets Qt5::Network ${libs})
+    target_link_libraries(guiunittests gtest gmock Qt6::Core Qt6::Widgets Qt6::Network ${libs})
 endif()

--- a/src/gui/src/AboutDialog.cpp
+++ b/src/gui/src/AboutDialog.cpp
@@ -38,7 +38,7 @@ AboutDialog::AboutDialog(QWidget* parent, const QString& barrierApp) :
 
 	QString buildDateString = QString::fromLocal8Bit(__DATE__).simplified();
 	QDate buildDate = QLocale("en_US").toDate(buildDateString, "MMM d yyyy");
-	m_pLabelBuildDate->setText(buildDate.toString(Qt::SystemLocaleLongDate));
+	m_pLabelBuildDate->setText(buildDate.toString(Qt::ISODate));
 
 	// change default size based on os
 #if defined(Q_OS_MAC)

--- a/src/gui/src/BarrierLocale.cpp
+++ b/src/gui/src/BarrierLocale.cpp
@@ -41,7 +41,7 @@ void BarrierLocale::loadLanguages()
             throw std::exception();
         }
 
-        if (xml.name() == "language" && token == QXmlStreamReader::StartElement)
+        if (xml.name() == QString("language") && token == QXmlStreamReader::StartElement)
         {
             QXmlStreamAttributes attributes = xml.attributes();
             addLanguage(

--- a/src/gui/src/KeySequence.cpp
+++ b/src/gui/src/KeySequence.cpp
@@ -191,7 +191,7 @@ QString KeySequence::keyToString(int key)
         {
             case Qt::LeftButton: return "1";
             case Qt::RightButton: return "2";
-            case Qt::MidButton: return "3";
+            case Qt::MiddleButton: return "3";
         }
 
         return "4"; // qt only knows three mouse buttons, so assume it's an unknown fourth one

--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -45,7 +45,7 @@
 #include <QMessageBox>
 #include <QFileDialog>
 #include <QDesktopServices>
-#include <QDesktopWidget>
+#include <QRegExp>
 
 #if defined(Q_OS_MAC)
 #include <ApplicationServices/ApplicationServices.h>
@@ -352,7 +352,7 @@ void MainWindow::logOutput()
     if (m_pBarrier)
     {
         QString text(m_pBarrier->readAllStandardOutput());
-        for (QString line : text.split(QRegExp("\r|\n|\r\n"))) {
+        for (QString line : QRegExp("\r|\n|\r\n").splitString(text)) {
             if (!line.isEmpty())
             {
                 appendLogRaw(line);
@@ -389,7 +389,7 @@ void MainWindow::appendLogError(const QString& text)
 
 void MainWindow::appendLogRaw(const QString& text)
 {
-    for (QString line : text.split(QRegExp("\r|\n|\r\n"))) {
+    for (QString line : QRegExp("\r|\n|\r\n").splitString(text)) {
         if (!line.isEmpty()) {
             m_pLogWindow->appendRaw(line);
             updateFromLogLine(line);

--- a/src/gui/src/NewScreenWidget.cpp
+++ b/src/gui/src/NewScreenWidget.cpp
@@ -40,7 +40,7 @@ void NewScreenWidget::mousePressEvent(QMouseEvent* event)
 
     QDrag* pDrag = new QDrag(this);
     pDrag->setMimeData(pMimeData);
-    pDrag->setPixmap(*pixmap());
+    pDrag->setPixmap(pixmap());
     pDrag->setHotSpot(event->pos());
 
     pDrag->exec(Qt::CopyAction, Qt::CopyAction);

--- a/src/gui/src/QUtility.cpp
+++ b/src/gui/src/QUtility.cpp
@@ -24,6 +24,8 @@
 #include <QProcess>
 #endif
 
+#include <QRegExp>
+
 #if defined(Q_OS_WIN)
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>

--- a/src/gui/src/Screen.cpp
+++ b/src/gui/src/Screen.cpp
@@ -91,19 +91,19 @@ void Screen::saveSettings(QSettings& settings) const
 
 QTextStream& Screen::writeScreensSection(QTextStream& outStream) const
 {
-    outStream << "\t" << name() << ":" << endl;
+    outStream << "\t" << name() << ":" << Qt::endl;
 
     for (int i = 0; i < modifiers().size(); i++) {
         auto mod = static_cast<Modifier>(i);
         if (modifier(mod) != mod) {
             outStream << "\t\t" << modifierName(mod) << " = " << modifierName(modifier(mod))
-                      << endl;
+                      << Qt::endl;
         }
     }
 
     for (int i = 0; i < fixes().size(); i++) {
         auto fix = static_cast<Fix>(i);
-        outStream << "\t\t" << fixName(fix) << " = " << (fixes()[i] ? "true" : "false") << endl;
+        outStream << "\t\t" << fixName(fix) << " = " << (fixes()[i] ? "true" : "false") << Qt::endl;
     }
 
     outStream << "\t\t" << "switchCorners = none ";
@@ -112,9 +112,9 @@ QTextStream& Screen::writeScreensSection(QTextStream& outStream) const
             outStream << "+" << switchCornerName(static_cast<SwitchCorner>(i)) << " ";
         }
     }
-    outStream << endl;
+    outStream << Qt::endl;
 
-    outStream << "\t\t" << "switchCornerSize = " << switchCornerSize() << endl;
+    outStream << "\t\t" << "switchCornerSize = " << switchCornerSize() << Qt::endl;
 
     return outStream;
 }
@@ -123,10 +123,10 @@ QTextStream& Screen::writeAliasesSection(QTextStream& outStream) const
 {
     if (!aliases().isEmpty())
     {
-        outStream << "\t" << name() << ":" << endl;
+        outStream << "\t" << name() << ":" << Qt::endl;
 
         for (const QString& alias : aliases()) {
-            outStream << "\t\t" << alias << endl;
+            outStream << "\t\t" << alias << Qt::endl;
         }
     }
 

--- a/src/gui/src/ScreenSettingsDialog.cpp
+++ b/src/gui/src/ScreenSettingsDialog.cpp
@@ -22,8 +22,9 @@
 #include <QtCore>
 #include <QtGui>
 #include <QMessageBox>
+#include <QRegularExpression>
 
-static const QRegExp ValidScreenName("[a-z0-9\\._-]{,255}", Qt::CaseInsensitive);
+static const QRegularExpression ValidScreenName("[a-z0-9\\._-]{,255}", QRegularExpression::CaseInsensitiveOption);
 
 static QString check_name_param(QString name)
 {
@@ -31,7 +32,7 @@ static QString check_name_param(QString name)
     // be translated with spaces (or other chars). let's replace the spaces
     // with dashes and just give up if that doesn't pass the regexp
     name.replace(' ', '-');
-    if (ValidScreenName.exactMatch(name))
+    if (ValidScreenName.match(name).hasMatch())
         return name;
     return "";
 }
@@ -44,10 +45,10 @@ ScreenSettingsDialog::ScreenSettingsDialog(QWidget* parent, Screen* pScreen) :
     setupUi(this);
 
     m_pLineEditName->setText(check_name_param(m_pScreen->name()));
-    m_pLineEditName->setValidator(new QRegExpValidator(ValidScreenName, m_pLineEditName));
+    m_pLineEditName->setValidator(new QRegularExpressionValidator(ValidScreenName, m_pLineEditName));
     m_pLineEditName->selectAll();
 
-    m_pLineEditAlias->setValidator(new QRegExpValidator(ValidScreenName, m_pLineEditName));
+    m_pLineEditAlias->setValidator(new QRegularExpressionValidator(ValidScreenName, m_pLineEditName));
 
     for (int i = 0; i < m_pScreen->aliases().count(); i++)
         new QListWidgetItem(m_pScreen->aliases()[i], m_pListAliases);

--- a/src/gui/src/ScreenSetupModel.cpp
+++ b/src/gui/src/ScreenSetupModel.cpp
@@ -66,7 +66,7 @@ QVariant ScreenSetupModel::data(const QModelIndex& index, int role) const
 Qt::ItemFlags ScreenSetupModel::flags(const QModelIndex& index) const
 {
     if (!index.isValid() || index.row() >= m_NumRows || index.column() >= m_NumColumns)
-        return 0;
+        return Qt::NoItemFlags;
 
     if (!screen(index).isNull())
         return Qt::ItemIsEnabled | Qt::ItemIsDragEnabled | Qt::ItemIsSelectable | Qt::ItemIsDropEnabled;

--- a/src/gui/src/ScreenSetupView.cpp
+++ b/src/gui/src/ScreenSetupView.cpp
@@ -216,12 +216,10 @@ void ScreenSetupView::startDrag(Qt::DropActions)
     }
 }
 
-QStyleOptionViewItem ScreenSetupView::viewOptions() const
-{
-    QStyleOptionViewItem option = QTableView::viewOptions();
-    option.showDecorationSelected = true;
-    option.decorationPosition = QStyleOptionViewItem::Top;
-    option.displayAlignment = Qt::AlignCenter;
-    option.textElideMode = Qt::ElideMiddle;
-    return option;
+void ScreenSetupView::initViewItemOption(QStyleOptionViewItem *option) const{
+    QTableView::initViewItemOption(option);
+    option->showDecorationSelected = true;
+    option->decorationPosition = QStyleOptionViewItem::Top;
+    option->displayAlignment = Qt::AlignCenter;
+    option->textElideMode = Qt::ElideMiddle;
 }

--- a/src/gui/src/ScreenSetupView.h
+++ b/src/gui/src/ScreenSetupView.h
@@ -50,7 +50,7 @@ class ScreenSetupView : public QTableView
         void dragEnterEvent(QDragEnterEvent* event) override;
         void dragMoveEvent(QDragMoveEvent* event) override;
         void startDrag(Qt::DropActions supportedActions) override;
-        QStyleOptionViewItem viewOptions() const override;
+        void initViewItemOption(QStyleOptionViewItem *option) const override;
         void scrollTo(const QModelIndex&, ScrollHint) override {}
     private:
         void enter(const QModelIndex&);

--- a/src/gui/src/ServerConfig.cpp
+++ b/src/gui/src/ServerConfig.cpp
@@ -210,56 +210,56 @@ int ServerConfig::adjacentScreenIndex(int idx, int deltaColumn, int deltaRow) co
 
 QTextStream& operator<<(QTextStream& outStream, const ServerConfig& config)
 {
-    outStream << "section: screens" << endl;
+    outStream << "section: screens" << Qt::endl;
 
     for (const Screen& s : config.screens()) {
         if (!s.isNull())
             s.writeScreensSection(outStream);
     }
 
-    outStream << "end" << endl << endl;
+    outStream << "end" << Qt::endl << Qt::endl;
 
-    outStream << "section: aliases" << endl;
+    outStream << "section: aliases" << Qt::endl;
 
     for (const Screen& s : config.screens()) {
         if (!s.isNull())
             s.writeAliasesSection(outStream);
     }
 
-    outStream << "end" << endl << endl;
+    outStream << "end" << Qt::endl << Qt::endl;
 
-    outStream << "section: links" << endl;
+    outStream << "section: links" << Qt::endl;
 
     for (int i = 0; i < config.screens().size(); i++)
         if (!config.screens()[i].isNull())
         {
-            outStream << "\t" << config.screens()[i].name() << ":" << endl;
+            outStream << "\t" << config.screens()[i].name() << ":" << Qt::endl;
 
             for (unsigned int j = 0; j < sizeof(neighbourDirs) / sizeof(neighbourDirs[0]); j++)
             {
                 int idx = config.adjacentScreenIndex(i, neighbourDirs[j].x, neighbourDirs[j].y);
                 if (idx != -1 && !config.screens()[idx].isNull())
-                    outStream << "\t\t" << neighbourDirs[j].name << " = " << config.screens()[idx].name() << endl;
+                    outStream << "\t\t" << neighbourDirs[j].name << " = " << config.screens()[idx].name() << Qt::endl;
             }
         }
 
-    outStream << "end" << endl << endl;
+    outStream << "end" << Qt::endl << Qt::endl;
 
-    outStream << "section: options" << endl;
+    outStream << "section: options" << Qt::endl;
 
     if (config.hasHeartbeat())
-        outStream << "\t" << "heartbeat = " << config.heartbeat() << endl;
+        outStream << "\t" << "heartbeat = " << config.heartbeat() << Qt::endl;
 
-    outStream << "\t" << "relativeMouseMoves = " << (config.relativeMouseMoves() ? "true" : "false") << endl;
-    outStream << "\t" << "screenSaverSync = " << (config.screenSaverSync() ? "true" : "false") << endl;
-    outStream << "\t" << "win32KeepForeground = " << (config.win32KeepForeground() ? "true" : "false") << endl;
-    outStream << "\t" << "clipboardSharing = " << (config.clipboardSharing() ? "true" : "false") << endl;
+    outStream << "\t" << "relativeMouseMoves = " << (config.relativeMouseMoves() ? "true" : "false") << Qt::endl;
+    outStream << "\t" << "screenSaverSync = " << (config.screenSaverSync() ? "true" : "false") << Qt::endl;
+    outStream << "\t" << "win32KeepForeground = " << (config.win32KeepForeground() ? "true" : "false") << Qt::endl;
+    outStream << "\t" << "clipboardSharing = " << (config.clipboardSharing() ? "true" : "false") << Qt::endl;
 
     if (config.hasSwitchDelay())
-        outStream << "\t" << "switchDelay = " << config.switchDelay() << endl;
+        outStream << "\t" << "switchDelay = " << config.switchDelay() << Qt::endl;
 
     if (config.hasSwitchDoubleTap())
-        outStream << "\t" << "switchDoubleTap = " << config.switchDoubleTap() << endl;
+        outStream << "\t" << "switchDoubleTap = " << config.switchDoubleTap() << Qt::endl;
 
     outStream << "\t" << "switchCorners = none ";
     for (int i = 0; i < config.switchCorners().size(); i++) {
@@ -268,15 +268,15 @@ QTextStream& operator<<(QTextStream& outStream, const ServerConfig& config)
             outStream << "+" << config.switchCornerName(corner) << " ";
         }
     }
-    outStream << endl;
+    outStream << Qt::endl;
 
-    outStream << "\t" << "switchCornerSize = " << config.switchCornerSize() << endl;
+    outStream << "\t" << "switchCornerSize = " << config.switchCornerSize() << Qt::endl;
 
     for (const Hotkey& hotkey : config.hotkeys()) {
         outStream << hotkey;
     }
 
-    outStream << "end" << endl << endl;
+    outStream << "end" << Qt::endl << Qt::endl;
 
     return outStream;
 }

--- a/src/gui/src/VersionChecker.cpp
+++ b/src/gui/src/VersionChecker.cpp
@@ -23,6 +23,7 @@
 #include <QNetworkReply>
 #include <QProcess>
 #include <QLocale>
+#include <QRegExp>
 
 #define VERSION_REGEX "(\\d+\\.\\d+\\.\\d+)"
 //#define VERSION_URL "http://www.TODO.com/"
@@ -67,11 +68,11 @@ int VersionChecker::compareVersions(const QString& left, const QString& right)
     if (left.compare(right) == 0)
         return 0; // versions are same.
 
-    QStringList leftSplit = left.split(QRegExp("\\."));
+    QStringList leftSplit = QRegExp("\\.").splitString(left);
     if (leftSplit.size() != 3)
         return 1; // assume right wins.
 
-    QStringList rightSplit = right.split(QRegExp("\\."));
+    QStringList rightSplit = QRegExp("\\.").splitString(right);
     if (rightSplit.size() != 3)
         return -1; // assume left wins.
 


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 

I was curious if barrier can be compiled with Qt6. So far I crudely fixed all the compile errors by Qt6 alternatives. I seems to be running, however, I have not yet tried to connect to another PC.

Is anybody interested in a port to Qt6? If so, I could extend the PR to support both Qt5 and Qt6.

I have opened it here as a PR because as an issue I could only report a bug but not request a feature. 

