### PR TITLE
Fix out-of-bounds access in XWindowsScreen::updateButtons

### DIFF
--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -1941,15 +1941,15 @@ XWindowsScreen::updateButtons()
 	}
 
 	// allocate button array
-	m_buttons.resize(maxButton);
+	m_buttons.resize(maxButton + 1);
 
 	// fill in button array values.  m_buttons[i] is the physical
-	// button number for logical button i+1.
-	for (UInt32 i = 0; i < numButtons; ++i) {
+	// button number for logical button i.
+	for (UInt32 i = 0; i < maxButton + 1; ++i) {
 		m_buttons[i] = 0;
 	}
 	for (UInt32 i = 0; i < numButtons; ++i) {
-		m_buttons[tmpButtons[i] - 1] = i + 1;
+		m_buttons[tmpButtons[i]] = i;
 	}
 
 	// clean up

--- a/src/lib/platform/XWindowsScreen.h
+++ b/src/lib/platform/XWindowsScreen.h
@@ -228,7 +228,7 @@ private:
     bool                m_screensaverNotify;
 
     // logical to physical button mapping.  m_buttons[i] gives the
-    // physical button for logical button i+1.
+    // physical button for logical button i.
     std::vector<unsigned char>    m_buttons;
 
     // true if global auto-repeat was enabled before we turned it off


### PR DESCRIPTION
This code triggers an assertion in gcc's std_vector.h on my system due to a logical button 0 causing a write to m_buttons[-1], and a SIGABRT.

I've tried to make this code do what it seems to be intended to do, but m_buttons isn't actually read from anywhere anyway.

## Contributor Checklist:

* [ ] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
