### PR TITLE
Hotkey on active screen only

### DIFF
--- a/doc/newsfragments/keystrokes-on-active-screen-only.feature
+++ b/doc/newsfragments/keystrokes-on-active-screen-only.feature
@@ -1,0 +1,12 @@
+Added the ability to perform keystroke actions on a specific screen only, by adding the flag `activeScreenOnly` to the action (after the screens parameter) e.g.
+
+`keystroke(Control) = keystroke(Super,Mac-Mini,activeScreenOnly)`
+
+This works for both server and clients, with the exception being for keystroke actions intended for the server where the keystroke matches the condition (for instance, adding a custom action on a client, but preserving the original keystroke on the server) e.g.
+
+`keystroke(Control) = keystroke(Super,Mac-Mini,activeScreenOnly), keystroke(Alt,Server,activeScreenOnly)` // This works
+`keystroke(Control) = keystroke(Super,Mac-Mini,activeScreenOnly), keystroke(Control,Server,activeScreenOnly)` // This does not work
+
+Since Barrier registers a hotkey for the keystroke condition on the server, this prevents the ability to specify the original keystroke as an action for the server. For this, a new option for the condition allows disabling hotkey registration. This allows the original keystroke to be performed on the primary when it is in focus i.e.
+
+`keystroke(Control,disableGlobalHotkeyRegister) = keystroke(Super,Rajveer-Mac-Mini,activeScreenOnly)` // This allows the original keystroke to perform on the server

--- a/src/lib/barrier/IKeyState.cpp
+++ b/src/lib/barrier/IKeyState.cpp
@@ -43,6 +43,7 @@ IKeyState::KeyInfo::alloc(KeyID id,
     info->m_mask             = mask;
     info->m_button           = button;
     info->m_count            = count;
+    info->m_activeScreenOnly = false;
     info->m_screens          = NULL;
     info->m_screensBuffer[0] = '\0';
     return info;
@@ -51,7 +52,7 @@ IKeyState::KeyInfo::alloc(KeyID id,
 IKeyState::KeyInfo*
 IKeyState::KeyInfo::alloc(KeyID id,
                 KeyModifierMask mask, KeyButton button, SInt32 count,
-                const std::set<String>& destinations)
+                const std::set<String>& destinations, bool activeScreenOnly)
 {
     String screens = join(destinations);
 
@@ -61,6 +62,7 @@ IKeyState::KeyInfo::alloc(KeyID id,
     info->m_mask    = mask;
     info->m_button  = button;
     info->m_count   = count;
+    info->m_activeScreenOnly = activeScreenOnly;
     info->m_screens = info->m_screensBuffer;
     strcpy(info->m_screensBuffer, screens.c_str());
     return info;
@@ -75,6 +77,7 @@ IKeyState::KeyInfo::alloc(const KeyInfo& x)
     info->m_mask    = x.m_mask;
     info->m_button  = x.m_button;
     info->m_count   = x.m_count;
+    info->m_activeScreenOnly = x.m_activeScreenOnly;
     info->m_screens = x.m_screens ? info->m_screensBuffer : NULL;
     strcpy(info->m_screensBuffer, x.m_screensBuffer);
     return info;

--- a/src/lib/barrier/IKeyState.h
+++ b/src/lib/barrier/IKeyState.h
@@ -44,7 +44,7 @@ public:
     public:
         static KeyInfo* alloc(KeyID, KeyModifierMask, KeyButton, SInt32 count);
         static KeyInfo* alloc(KeyID, KeyModifierMask, KeyButton, SInt32 count,
-                            const std::set<String>& destinations);
+                            const std::set<String>& destinations, bool activeScreenOnly);
         static KeyInfo* alloc(const KeyInfo&);
 
         static bool isDefault(const char* screens);
@@ -58,6 +58,7 @@ public:
         KeyModifierMask    m_mask;
         KeyButton        m_button;
         SInt32            m_count;
+        bool            m_activeScreenOnly;
         char*            m_screens;
         char            m_screensBuffer[1];
     };

--- a/src/lib/barrier/IPlatformScreen.h
+++ b/src/lib/barrier/IPlatformScreen.h
@@ -155,8 +155,8 @@ public:
     // IPrimaryScreen overrides
     virtual void        reconfigure(UInt32 activeSides) = 0;
     virtual void        warpCursor(SInt32 x, SInt32 y) = 0;
-    virtual UInt32        registerHotKey(KeyID key, KeyModifierMask mask) = 0;
-    virtual void        unregisterHotKey(UInt32 id) = 0;
+    virtual UInt32        registerHotKey(KeyID key, KeyModifierMask mask, bool registerGlobalHotkey) = 0;
+    virtual void        unregisterHotKey(UInt32 id, bool unregisterGlobalHotkey) = 0;
     virtual void        fakeInputBegin() = 0;
     virtual void        fakeInputEnd() = 0;
     virtual SInt32        getJumpZoneSize() const = 0;

--- a/src/lib/barrier/IPrimaryScreen.h
+++ b/src/lib/barrier/IPrimaryScreen.h
@@ -111,13 +111,13 @@ public:
     the modifiers in any order or to require the user to press the given key
     last.
     */
-    virtual UInt32        registerHotKey(KeyID key, KeyModifierMask mask) = 0;
+    virtual UInt32        registerHotKey(KeyID key, KeyModifierMask mask, bool registerGlobalHotkey) = 0;
 
     //! Unregister a system hotkey
     /*!
     Unregisters a previously registered hot key.
     */
-    virtual void        unregisterHotKey(UInt32 id) = 0;
+    virtual void        unregisterHotKey(UInt32 id, bool unregisterGlobalHotkey) = 0;
 
     //! Prepare to synthesize input on primary screen
     /*!

--- a/src/lib/barrier/PlatformScreen.h
+++ b/src/lib/barrier/PlatformScreen.h
@@ -44,8 +44,8 @@ public:
     virtual void        reconfigure(UInt32 activeSides) = 0;
     virtual void        warpCursor(SInt32 x, SInt32 y) = 0;
     virtual UInt32        registerHotKey(KeyID key,
-                            KeyModifierMask mask) = 0;
-    virtual void        unregisterHotKey(UInt32 id) = 0;
+                            KeyModifierMask mask, bool registerGlobalHotkey) = 0;
+    virtual void        unregisterHotKey(UInt32 id, bool unregisterGlobalHotkey) = 0;
     virtual void        fakeInputBegin() = 0;
     virtual void        fakeInputEnd() = 0;
     virtual SInt32        getJumpZoneSize() const = 0;

--- a/src/lib/barrier/Screen.cpp
+++ b/src/lib/barrier/Screen.cpp
@@ -330,15 +330,15 @@ Screen::setSequenceNumber(UInt32 seqNum)
 }
 
 UInt32
-Screen::registerHotKey(KeyID key, KeyModifierMask mask)
+Screen::registerHotKey(KeyID key, KeyModifierMask mask, bool registerGlobalHotkey)
 {
-    return m_screen->registerHotKey(key, mask);
+    return m_screen->registerHotKey(key, mask, registerGlobalHotkey);
 }
 
 void
-Screen::unregisterHotKey(UInt32 id)
+Screen::unregisterHotKey(UInt32 id, bool unregisterGlobalHotkey)
 {
-    m_screen->unregisterHotKey(id);
+    m_screen->unregisterHotKey(id, unregisterGlobalHotkey);
 }
 
 void

--- a/src/lib/barrier/Screen.h
+++ b/src/lib/barrier/Screen.h
@@ -198,13 +198,13 @@ public:
     Registers a system-wide hotkey for key \p key with modifiers \p mask.
     Returns an id used to unregister the hotkey.
     */
-    UInt32                registerHotKey(KeyID key, KeyModifierMask mask);
+    UInt32                registerHotKey(KeyID key, KeyModifierMask mask, bool registerGlobalHotkey);
 
     //! Unregister a system hotkey
     /*!
     Unregisters a previously registered hot key.
     */
-    void                unregisterHotKey(UInt32 id);
+    void                unregisterHotKey(UInt32 id, bool unregisterGlobalHotkey);
 
     //! Prepare to synthesize input on primary screen
     /*!

--- a/src/lib/platform/MSWindowsScreen.cpp
+++ b/src/lib/platform/MSWindowsScreen.cpp
@@ -548,7 +548,7 @@ void MSWindowsScreen::saveMousePosition(SInt32 x, SInt32 y) {
 }
 
 UInt32
-MSWindowsScreen::registerHotKey(KeyID key, KeyModifierMask mask)
+MSWindowsScreen::registerHotKey(KeyID key, KeyModifierMask mask, bool registerGlobalHotkey)
 {
     // only allow certain modifiers
     if ((mask & ~(KeyModifierShift | KeyModifierControl |
@@ -599,12 +599,12 @@ MSWindowsScreen::registerHotKey(KeyID key, KeyModifierMask mask)
     }
 
     // if this hot key has modifiers only then we'll handle it specially
-    bool err;
+    bool err = false;
     if (key == kKeyNone) {
         // check if already registered
         err = (m_hotKeyToIDMap.count(HotKeyItem(vk, modifiers)) > 0);
     }
-    else {
+    else if (registerGlobalHotkey) {
         // register with OS
         err = (RegisterHotKey(NULL, id, modifiers, vk) == 0);
     }
@@ -625,7 +625,7 @@ MSWindowsScreen::registerHotKey(KeyID key, KeyModifierMask mask)
 }
 
 void
-MSWindowsScreen::unregisterHotKey(UInt32 id)
+MSWindowsScreen::unregisterHotKey(UInt32 id, bool unregisterGlobalHotkey)
 {
     // look up hotkey
     HotKeyMap::iterator i = m_hotKeys.find(id);
@@ -634,12 +634,9 @@ MSWindowsScreen::unregisterHotKey(UInt32 id)
     }
 
     // unregister with OS
-    bool err;
-    if (i->second.getVirtualKey() != 0) {
+    bool err = false;
+    if (unregisterGlobalHotkey && i->second.getVirtualKey() != 0) {
         err = !UnregisterHotKey(NULL, id);
-    }
-    else {
-        err = false;
     }
     if (err) {
         LOG((CLOG_WARN "failed to unregister hotkey id=%d", id));

--- a/src/lib/platform/MSWindowsScreen.h
+++ b/src/lib/platform/MSWindowsScreen.h
@@ -80,8 +80,8 @@ public:
     virtual void        reconfigure(UInt32 activeSides);
     virtual void        warpCursor(SInt32 x, SInt32 y);
     virtual UInt32        registerHotKey(KeyID key,
-                            KeyModifierMask mask);
-    virtual void        unregisterHotKey(UInt32 id);
+                            KeyModifierMask mask, bool registerGlobalHotkey);
+    virtual void        unregisterHotKey(UInt32 id, bool unregisterGlobalHotkey);
     virtual void        fakeInputBegin();
     virtual void        fakeInputEnd();
     virtual SInt32        getJumpZoneSize() const;

--- a/src/lib/platform/OSXScreen.h
+++ b/src/lib/platform/OSXScreen.h
@@ -68,8 +68,8 @@ public:
     // IPrimaryScreen overrides
     virtual void        reconfigure(UInt32 activeSides);
     virtual void        warpCursor(SInt32 x, SInt32 y);
-    virtual UInt32        registerHotKey(KeyID key, KeyModifierMask mask);
-    virtual void        unregisterHotKey(UInt32 id);
+    virtual UInt32        registerHotKey(KeyID key, KeyModifierMask mask, bool registerGlobalHotkey);
+    virtual void        unregisterHotKey(UInt32 id, bool unregisterGlobalHotkey);
     virtual void        fakeInputBegin();
     virtual void        fakeInputEnd();
     virtual SInt32        getJumpZoneSize() const;

--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -336,7 +336,7 @@ OSXScreen::registerHotKey(KeyID key, KeyModifierMask mask, bool registerGlobalHo
 
 	// if this hot key has modifiers only then we'll handle it specially
 	EventHotKeyRef ref = NULL;
-	bool okay;
+	bool okay = true;
 	if (key == kKeyNone) {
 		if (m_modifierHotKeys.count(mask) > 0) {
 			// already registered
@@ -381,9 +381,11 @@ OSXScreen::unregisterHotKey(UInt32 id, bool unregisterGlobalHotkey)
 	}
 
 	// unregister with OS
-	bool okay;
-	if (unregisterGlobalHotkey && i->second.getRef() != NULL) {
-		okay = (UnregisterEventHotKey(i->second.getRef()) == noErr);
+	bool okay = true;
+	if (i->second.getRef() != NULL) {
+        if (unregisterGlobalHotkey) {
+            okay = (UnregisterEventHotKey(i->second.getRef()) == noErr);
+        }
 	}
 	else {
 		okay = false;

--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -315,7 +315,7 @@ OSXScreen::getCursorCenter(SInt32& x, SInt32& y) const
 }
 
 UInt32
-OSXScreen::registerHotKey(KeyID key, KeyModifierMask mask)
+OSXScreen::registerHotKey(KeyID key, KeyModifierMask mask, bool registerGlobalHotkey)
 {
 	// get mac virtual key and modifier mask matching barrier key and mask
 	UInt32 macKey, macMask;
@@ -348,11 +348,13 @@ OSXScreen::registerHotKey(KeyID key, KeyModifierMask mask)
 		}
 	}
 	else {
-		EventHotKeyID hkid = { 'SNRG', (UInt32)id };
-		OSStatus status = RegisterEventHotKey(macKey, macMask, hkid,
-								GetApplicationEventTarget(), 0,
-								&ref);
-		okay = (status == noErr);
+        if (registerGlobalHotkey) {
+		    EventHotKeyID hkid = { 'SNRG', (UInt32)id };
+		    OSStatus status = RegisterEventHotKey(macKey, macMask, hkid,
+								    GetApplicationEventTarget(), 0,
+								    &ref);
+		    okay = (status == noErr);
+        }
 		m_hotKeyToIDMap[HotKeyItem(macKey, macMask)] = id;
 	}
 
@@ -370,7 +372,7 @@ OSXScreen::registerHotKey(KeyID key, KeyModifierMask mask)
 }
 
 void
-OSXScreen::unregisterHotKey(UInt32 id)
+OSXScreen::unregisterHotKey(UInt32 id, bool unregisterGlobalHotkey)
 {
 	// look up hotkey
 	HotKeyMap::iterator i = m_hotKeys.find(id);
@@ -380,7 +382,7 @@ OSXScreen::unregisterHotKey(UInt32 id)
 
 	// unregister with OS
 	bool okay;
-	if (i->second.getRef() != NULL) {
+	if (unregisterGlobalHotkey && i->second.getRef() != NULL) {
 		okay = (UnregisterEventHotKey(i->second.getRef()) == noErr);
 	}
 	else {

--- a/src/lib/platform/XWindowsScreen.h
+++ b/src/lib/platform/XWindowsScreen.h
@@ -53,8 +53,8 @@ public:
     // IPrimaryScreen overrides
     virtual void        reconfigure(UInt32 activeSides);
     virtual void        warpCursor(SInt32 x, SInt32 y);
-    virtual UInt32        registerHotKey(KeyID key, KeyModifierMask mask);
-    virtual void        unregisterHotKey(UInt32 id);
+    virtual UInt32        registerHotKey(KeyID key, KeyModifierMask mask, bool registerGlobalHotkey);
+    virtual void        unregisterHotKey(UInt32 id, bool unregisterGlobalHotkey);
     virtual void        fakeInputBegin();
     virtual void        fakeInputEnd();
     virtual SInt32        getJumpZoneSize() const;

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -1029,13 +1029,19 @@ InputFilter::Condition* Config::parseCondition(ConfigReadContext& s, const std::
                                                const std::vector<std::string>& args)
 {
 	if (name == "keystroke") {
-		if (args.size() != 1) {
-			throw XConfigRead(s, "syntax for condition: keystroke(modifiers+key)");
+		if (args.size() < 1 || args.size() > 2) {
+			throw XConfigRead(s, "syntax for condition: keystroke(modifiers+key[,options])");
 		}
 
 		IPlatformScreen::KeyInfo* keyInfo = s.parseKeystroke(args[0]);
+        bool disableGlobalHotkeyRegister = false;
 
-		return new InputFilter::KeystrokeCondition(m_events, keyInfo);
+        if (args.size() > 1)
+        {
+            parseKeystrokeConditionOptions(s, args[1], disableGlobalHotkeyRegister);
+        }
+
+		return new InputFilter::KeystrokeCondition(m_events, keyInfo, disableGlobalHotkeyRegister);
 	}
 
 	if (name == "mousebutton") {
@@ -1291,6 +1297,19 @@ void Config::parseScreens(ConfigReadContext& c, const std::string& s,
 		// next
 		i = j + 1;
 	}
+}
+
+void Config::parseKeystrokeConditionOptions(ConfigReadContext& c, const std::string& s,
+                                            bool& disableGlobalHotkeyRegister) const
+{
+    if (s == "disableGlobalHotkeyRegister")
+    {
+        disableGlobalHotkeyRegister = true;
+    }
+    else
+    {
+        disableGlobalHotkeyRegister = false;
+    }
 }
 
 void Config::parseKeystrokeActionOptions(ConfigReadContext& c, const std::string& s,

--- a/src/lib/server/Config.h
+++ b/src/lib/server/Config.h
@@ -453,6 +453,8 @@ private:
 
     void parseScreens(ConfigReadContext&, const std::string&, std::set<std::string>& screens) const;
 
+    void parseKeystrokeActionOptions(ConfigReadContext& c, const std::string& s, bool& activeScreenOnly) const;
+
     static const char*    getOptionName(OptionID);
     static std::string getOptionValue(OptionID, OptionValue);
 
@@ -497,6 +499,9 @@ public:
     IPlatformScreen::KeyInfo* parseKeystroke(const std::string& keystroke) const;
     IPlatformScreen::KeyInfo* parseKeystroke(const std::string& keystroke,
                                              const std::set<std::string>& screens) const;
+    IPlatformScreen::KeyInfo* parseKeystroke(const std::string& keystroke,
+                                             const std::set<std::string>& screens,
+                                             const bool& activeScreenOnly) const;
     IPlatformScreen::ButtonInfo* parseMouse(const std::string& mouse) const;
     KeyModifierMask parseModifier(const std::string& modifiers) const;
 

--- a/src/lib/server/Config.h
+++ b/src/lib/server/Config.h
@@ -453,6 +453,7 @@ private:
 
     void parseScreens(ConfigReadContext&, const std::string&, std::set<std::string>& screens) const;
 
+    void parseKeystrokeConditionOptions(ConfigReadContext& c, const std::string& s, bool& activeScreenOnly) const;
     void parseKeystrokeActionOptions(ConfigReadContext& c, const std::string& s, bool& activeScreenOnly) const;
 
     static const char*    getOptionName(OptionID);

--- a/src/lib/server/InputFilter.cpp
+++ b/src/lib/server/InputFilter.cpp
@@ -53,21 +53,23 @@ InputFilter::Condition::disablePrimary(PrimaryClient*)
 }
 
 InputFilter::KeystrokeCondition::KeystrokeCondition(
-        IEventQueue* events, IPlatformScreen::KeyInfo* info) :
+        IEventQueue* events, IPlatformScreen::KeyInfo* info, bool disableGlobalHotkeyRegister) :
     m_id(0),
     m_key(info->m_key),
     m_mask(info->m_mask),
-    m_events(events)
+    m_events(events),
+    m_disableGlobalHotkeyRegister(disableGlobalHotkeyRegister)
 {
     free(info);
 }
 
 InputFilter::KeystrokeCondition::KeystrokeCondition(
-        IEventQueue* events, KeyID key, KeyModifierMask mask) :
+        IEventQueue* events, KeyID key, KeyModifierMask mask, bool disableGlobalHotkeyRegister) :
     m_id(0),
     m_key(key),
     m_mask(mask),
-    m_events(events)
+    m_events(events),
+    m_disableGlobalHotkeyRegister(disableGlobalHotkeyRegister)
 {
     // do nothing
 }
@@ -92,7 +94,7 @@ InputFilter::KeystrokeCondition::getMask() const
 InputFilter::Condition*
 InputFilter::KeystrokeCondition::clone() const
 {
-    return new KeystrokeCondition(m_events, m_key, m_mask);
+    return new KeystrokeCondition(m_events, m_key, m_mask, m_disableGlobalHotkeyRegister);
 }
 
 std::string InputFilter::KeystrokeCondition::format() const
@@ -131,13 +133,13 @@ InputFilter::KeystrokeCondition::match(const Event& event)
 void
 InputFilter::KeystrokeCondition::enablePrimary(PrimaryClient* primary)
 {
-    m_id = primary->registerHotKey(m_key, m_mask);
+    m_id = primary->registerHotKey(m_key, m_mask, !m_disableGlobalHotkeyRegister);
 }
 
 void
 InputFilter::KeystrokeCondition::disablePrimary(PrimaryClient* primary)
 {
-    primary->unregisterHotKey(m_id);
+    primary->unregisterHotKey(m_id, !m_disableGlobalHotkeyRegister);
     m_id = 0;
 }
 

--- a/src/lib/server/InputFilter.h
+++ b/src/lib/server/InputFilter.h
@@ -57,8 +57,8 @@ public:
     // KeystrokeCondition
     class KeystrokeCondition : public Condition {
     public:
-        KeystrokeCondition(IEventQueue* events, IPlatformScreen::KeyInfo*);
-        KeystrokeCondition(IEventQueue* events, KeyID key, KeyModifierMask mask);
+        KeystrokeCondition(IEventQueue* events, IPlatformScreen::KeyInfo*, bool disableGlobalHotkeyRegister);
+        KeystrokeCondition(IEventQueue* events, KeyID key, KeyModifierMask mask, bool disableGlobalHotkeyRegister);
         virtual ~KeystrokeCondition();
 
         KeyID                    getKey() const;
@@ -76,6 +76,7 @@ public:
         KeyID                    m_key;
         KeyModifierMask            m_mask;
         IEventQueue*            m_events;
+        bool                      m_disableGlobalHotkeyRegister;
     };
 
     // MouseButtonCondition

--- a/src/lib/server/PrimaryClient.cpp
+++ b/src/lib/server/PrimaryClient.cpp
@@ -49,15 +49,15 @@ PrimaryClient::reconfigure(UInt32 activeSides)
 }
 
 UInt32
-PrimaryClient::registerHotKey(KeyID key, KeyModifierMask mask)
+PrimaryClient::registerHotKey(KeyID key, KeyModifierMask mask, bool registerGlobalHotkey)
 {
-    return m_screen->registerHotKey(key, mask);
+    return m_screen->registerHotKey(key, mask, registerGlobalHotkey);
 }
 
 void
-PrimaryClient::unregisterHotKey(UInt32 id)
+PrimaryClient::unregisterHotKey(UInt32 id, bool unregisterGlobalHotkey)
 {
-    m_screen->unregisterHotKey(id);
+    m_screen->unregisterHotKey(id, unregisterGlobalHotkey);
 }
 
 void

--- a/src/lib/server/PrimaryClient.cpp
+++ b/src/lib/server/PrimaryClient.cpp
@@ -187,11 +187,7 @@ void
 PrimaryClient::keyDown(KeyID key, KeyModifierMask mask, KeyButton button)
 {
     if (m_fakeInputCount > 0) {
-// XXX -- don't forward keystrokes to primary screen for now
-        (void)key;
-        (void)mask;
-        (void)button;
-//        m_screen->keyDown(key, mask, button);
+        m_screen->keyDown(key, mask, button);
     }
 }
 
@@ -205,11 +201,7 @@ void
 PrimaryClient::keyUp(KeyID key, KeyModifierMask mask, KeyButton button)
 {
     if (m_fakeInputCount > 0) {
-// XXX -- don't forward keystrokes to primary screen for now
-        (void)key;
-        (void)mask;
-        (void)button;
-//        m_screen->keyUp(key, mask, button);
+        m_screen->keyUp(key, mask, button);
     }
 }
 

--- a/src/lib/server/PrimaryClient.h
+++ b/src/lib/server/PrimaryClient.h
@@ -55,13 +55,13 @@ public:
     Registers a system-wide hotkey for key \p key with modifiers \p mask.
     Returns an id used to unregister the hotkey.
     */
-    virtual UInt32        registerHotKey(KeyID key, KeyModifierMask mask);
+    virtual UInt32        registerHotKey(KeyID key, KeyModifierMask mask, bool registerGlobalHotkey);
 
     //! Unregister a system hotkey
     /*!
     Unregisters a previously registered hot key.
     */
-    virtual void        unregisterHotKey(UInt32 id);
+    virtual void        unregisterHotKey(UInt32 id, bool unregisterGlobalHotkey);
 
     //! Prepare to synthesize input on primary screen
     /*!

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -293,7 +293,7 @@ Server::setConfig(const Config& config)
 	if (!m_config->hasLockToScreenAction()) {
 		IPlatformScreen::KeyInfo* key =
 			IPlatformScreen::KeyInfo::alloc(kKeyScrollLock, 0, 0, 0);
-		InputFilter::Rule rule(new InputFilter::KeystrokeCondition(m_events, key));
+		InputFilter::Rule rule(new InputFilter::KeystrokeCondition(m_events, key, true));
 		rule.adoptAction(new InputFilter::LockCursorToScreenAction(m_events), true);
 		m_inputFilter->addFilterRule(rule);
 	}

--- a/src/lib/server/Server.h
+++ b/src/lib/server/Server.h
@@ -322,9 +322,9 @@ private:
                             ClipboardID id, UInt32 seqNum);
     void                onScreensaver(bool activated);
     void                onKeyDown(KeyID, KeyModifierMask, KeyButton,
-                            const char* screens);
+                            const char* screens, bool activeScreenOnly);
     void                onKeyUp(KeyID, KeyModifierMask, KeyButton,
-                            const char* screens);
+                            const char* screens, bool activeScreenOnly);
     void                onKeyRepeat(KeyID, KeyModifierMask, SInt32, KeyButton);
     void                onMouseDown(ButtonID);
     void                onMouseUp(ButtonID);


### PR DESCRIPTION
### What this PR does

This PR allows keystroke actions to be performed on only the active screen of specified screens.

### Current  behaviour

Currently keystroke actions behave as such:

`keystroke(Control) = keystroke(Super)` - performs on the active screen only, but with no way to have custom keystrokes for different screens
`keystroke(Control) = keystroke(Super,Mac-Mini)` - always performs on the specified screens, regardless of whether they are active, and no way to target a specific one

### New behaviour (`activeScreenOnly` option)

This PR adds a new optional setting `activeScreenOnly` to keystroke actions, used as such:

`keystroke(Control) = keystroke(Super,Mac-Mini,activeScreenOnly)` - performs on `Mac-Mini`, and only when it is active

As normal, keystroke actions can be chained, meaning that we can have different shortcuts for different screens, and only when those screens are active:

`keystroke(Control) = keystroke(Super,Mac-Mini:Mac-Pro,activeScreenOnly),keystroke(Alt,Laptop,activeScreenOnly)` - changes `Control->Super` on `Mac-Mini` and `Mac-Pro`, and `Control->Alt` on `Laptop`, and only on the one that is active

### Windows and macOS server specifics (`disableGlobalHotkeyRegister` option)

On Windows and macOS this works for both server and clients, with the exception being for keystroke actions intended for the server where the keystroke matches the condition (for instance, adding a custom action on a client, but preserving the original keystroke on the server) e.g.

`keystroke(Control) = keystroke(Super,Mac-Mini,activeScreenOnly), keystroke(Alt,Server,activeScreenOnly)` - this works on Server
`keystroke(Control) = keystroke(Super,Mac-Mini,activeScreenOnly), keystroke(Control,Server,activeScreenOnly)` - this does not work on Server

Since Barrier registers a hotkey for the keystroke condition on the server, this prevents the ability to specify the original keystroke as an action for the server. For this, a new option `disableGlobalHotkeyRegister` for the condition allows disabling hotkey registration with the OS. This allows the original keystroke to be performed on the server when it is in focus i.e.

`keystroke(Control,disableGlobalHotkeyRegister) = keystroke(Super,Rajveer-Mac-Mini,activeScreenOnly)` - this allows the original keystroke to perform on the server, akin to if we also had `keystroke(Control,Server,activeScreenOnly)`

### Linux server specifics

On Linux, keystroke actions currently don't seem to work on the server at all. However, using `disableGlobalHotkeyRegister` at least allows us to achieve the same as in the above example (i.e. the server can perform the default keybind whilst clients have custom keybinds)

`keystroke(Left) = keystroke(Right)` - this works on Windows and macOS when focusing the server, but not Linux
`keystroke(Left) = keystroke(Left)` - this doesn't work on any server (but works on all when using `disableGlobalHotkeyRegister`)
`keystroke(Left,disableGlobalHotkeyRegister) = keystroke(Right,Mac-Mini,activeScreenOnly)` - but at least this allows a custom hotkey on `Mac-Mini` whilst still allowing the default keystroke to perform on a server on any platform

### A real-world example

I want to control my Mac computers from my Windows machine, and want them to work with Windows keybinds (e.g. Ctrl+C to copy). On macOS I use Karabiner-Elements for this, but this doesn't work with Barrier. I now use the below configuration to achieve the same effect when running a Windows server:

```
section: screens
	Rajveer-Desktop:
		halfDuplexCapsLock = false
		halfDuplexNumLock = false
		halfDuplexScrollLock = false
		xtestIsXineramaUnaware = false
		preserveFocus = false
		switchCorners = none
		switchCornerSize = 0
	Rajveer-Mac-Mini:
		ctrl = super
		alt = ctrl
		super = alt
		halfDuplexCapsLock = false
		halfDuplexNumLock = false
		halfDuplexScrollLock = false
		xtestIsXineramaUnaware = false
		preserveFocus = false
		switchCorners = none
		switchCornerSize = 0
	rajveer-mp:
		ctrl = super
		alt = ctrl
		super = alt
		halfDuplexCapsLock = false
		halfDuplexNumLock = false
		halfDuplexScrollLock = false
		xtestIsXineramaUnaware = false
		preserveFocus = false
		switchCorners = none
		switchCornerSize = 0
end

section: aliases
end

section: links
	Rajveer-Desktop:
		right = Rajveer-Mac-Mini
		left = rajveer-mp
	Rajveer-Mac-Mini:
		left = Rajveer-Desktop
	rajveer-mp:
		right = Rajveer-Desktop
end

section: options
	relativeMouseMoves = false
	screenSaverSync = true
	win32KeepForeground = false
	clipboardSharing = true
	switchCorners = none 
	switchCornerSize = 0
	keystroke(Control+Left,disableGlobalHotkeyRegister) = keystroke(Super+Left,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Control+Right,disableGlobalHotkeyRegister) = keystroke(Super+Right,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Control+Up,disableGlobalHotkeyRegister) = keystroke(Super+Up,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Control+Down,disableGlobalHotkeyRegister) = keystroke(Super+Down,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Control+Backspace,disableGlobalHotkeyRegister) = keystroke(Super+Backspace,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Control+Delete,disableGlobalHotkeyRegister) = keystroke(Super+Delete,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Control+Tab,disableGlobalHotkeyRegister) = keystroke(Super+Tab,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Control+Shift+Left,disableGlobalHotkeyRegister) = keystroke(Super+Shift+Left,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Control+Shift+Right,disableGlobalHotkeyRegister) = keystroke(Super+Shift+Right,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Control+Shift+Up,disableGlobalHotkeyRegister) = keystroke(Super+Shift+Up,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Control+Shift+Down,disableGlobalHotkeyRegister) = keystroke(Super+Shift+Down,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Control+Shift+Backspace,disableGlobalHotkeyRegister) = keystroke(Super+Shift+Backspace,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Control+Shift+Delete,disableGlobalHotkeyRegister) = keystroke(Super+Shift+Delete,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Control+Shift+Tab,disableGlobalHotkeyRegister) = keystroke(Super+Shift+Tab,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Super+Left,disableGlobalHotkeyRegister) = keystroke(Alt+Left,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Super+Right,disableGlobalHotkeyRegister) = keystroke(Alt+Right,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Super+Up,disableGlobalHotkeyRegister) = keystroke(Alt+Up,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Super+Down,disableGlobalHotkeyRegister) = keystroke(Alt+Down,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Super+Delete,disableGlobalHotkeyRegister) = keystroke(Alt+Delete,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Super+Tab,disableGlobalHotkeyRegister) = keystroke(Alt+Tab,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Super+Shift+Left,disableGlobalHotkeyRegister) = keystroke(Alt+Shift+Left,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Super+Shift+Right,disableGlobalHotkeyRegister) = keystroke(Alt+Shift+Right,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Super+Shift+Up,disableGlobalHotkeyRegister) = keystroke(Alt+Shift+Up,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Super+Shift+Down,disableGlobalHotkeyRegister) = keystroke(Alt+Shift+Down,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Super+Shift+Backspace,disableGlobalHotkeyRegister) = keystroke(Alt+Shift+Backspace,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Super+Shift+Delete,disableGlobalHotkeyRegister) = keystroke(Alt+Shift+Delete,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Super+Shift+Tab,disableGlobalHotkeyRegister) = keystroke(Alt+Shift+Tab,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Alt+Left,disableGlobalHotkeyRegister) = keystroke(Control+Left,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Alt+Right,disableGlobalHotkeyRegister) = keystroke(Control+Right,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Alt+Up,disableGlobalHotkeyRegister) = keystroke(Control+Up,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Alt+Down,disableGlobalHotkeyRegister) = keystroke(Control+Down,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Alt+Delete,disableGlobalHotkeyRegister) = keystroke(Control+Delete,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Alt+Tab,disableGlobalHotkeyRegister) = keystroke(Control+Tab,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Alt+Shift+Left,disableGlobalHotkeyRegister) = keystroke(Control+Shift+Left,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Alt+Shift+Right,disableGlobalHotkeyRegister) = keystroke(Control+Shift+Right,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Alt+Shift+Up,disableGlobalHotkeyRegister) = keystroke(Control+Shift+Up,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Alt+Shift+Down,disableGlobalHotkeyRegister) = keystroke(Control+Shift+Down,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Alt+Shift+Backspace,disableGlobalHotkeyRegister) = keystroke(Control+Shift+Backspace,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Alt+Shift+Delete,disableGlobalHotkeyRegister) = keystroke(Control+Shift+Delete,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
	keystroke(Alt+Shift+Tab,disableGlobalHotkeyRegister) = keystroke(Control+Shift+Tab,Rajveer-Mac-Mini:rajveer-mp,activeScreenOnly)
end


```

## Contributor Checklist:

* [*] I have created a file in the `doc/newsfragments` directory *IF* it is a
      user-visible change (and make sure to read the `README.md` in that directory) 
