### PR TITLE
Some tweaks to make build work with GCC on macOS

### DIFF
--- a/src/lib/common/basic_types.h
+++ b/src/lib/common/basic_types.h
@@ -18,7 +18,9 @@
 
 #pragma once
 
+#ifdef __cpluplus
 #include <cstdint>
+#endif
 
 //
 // make typedefs

--- a/src/lib/platform/CMakeLists.txt
+++ b/src/lib/platform/CMakeLists.txt
@@ -46,4 +46,9 @@ endif()
 if (APPLE)
     find_library(COCOA_LIBRARY Cocoa)
     target_link_libraries(platform ${COCOA_LIBRARY})
+    target_compile_options(platform PRIVATE
+        $<$<COMPILE_LANGUAGE:C>:-fobjc-exceptions>
+        $<$<COMPILE_LANGUAGE:C>:-xobjective-c>
+        $<$<COMPILE_LANGUAGE:CXX>:-fobjc-exceptions>
+    )
 endif()

--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -324,14 +324,14 @@ OSXScreen::registerHotKey(KeyID key, KeyModifierMask mask)
 		return 0;
 	}
 
-	// choose hotkey id
-	UInt32 id;
+	// choose hotkey kid
+	UInt32 kid;
 	if (!m_oldHotKeyIDs.empty()) {
-		id = m_oldHotKeyIDs.back();
+		kid = m_oldHotKeyIDs.back();
 		m_oldHotKeyIDs.pop_back();
 	}
 	else {
-		id = m_hotKeys.size() + 1;
+		kid = m_hotKeys.size() + 1;
 	}
 
 	// if this hot key has modifiers only then we'll handle it specially
@@ -343,37 +343,37 @@ OSXScreen::registerHotKey(KeyID key, KeyModifierMask mask)
 			okay = false;
 		}
 		else {
-			m_modifierHotKeys[mask] = id;
+			m_modifierHotKeys[mask] = kid;
 			okay = true;
 		}
 	}
 	else {
-		EventHotKeyID hkid = { 'SNRG', (UInt32)id };
+		EventHotKeyID hkid = { 'SNRG', (UInt32)kid };
 		OSStatus status = RegisterEventHotKey(macKey, macMask, hkid,
 								GetApplicationEventTarget(), 0,
 								&ref);
 		okay = (status == noErr);
-		m_hotKeyToIDMap[HotKeyItem(macKey, macMask)] = id;
+		m_hotKeyToIDMap[HotKeyItem(macKey, macMask)] = kid;
 	}
 
 	if (!okay) {
-		m_oldHotKeyIDs.push_back(id);
+		m_oldHotKeyIDs.push_back(kid);
 		m_hotKeyToIDMap.erase(HotKeyItem(macKey, macMask));
 		LOG((CLOG_WARN "failed to register hotkey %s (id=%04x mask=%04x)", barrier::KeyMap::formatKey(key, mask).c_str(), key, mask));
 		return 0;
 	}
 
-	m_hotKeys.insert(std::make_pair(id, HotKeyItem(ref, macKey, macMask)));
+	m_hotKeys.insert(std::make_pair(kid, HotKeyItem(ref, macKey, macMask)));
 
-	LOG((CLOG_DEBUG "registered hotkey %s (id=%04x mask=%04x) as id=%d", barrier::KeyMap::formatKey(key, mask).c_str(), key, mask, id));
-	return id;
+	LOG((CLOG_DEBUG "registered hotkey %s (id=%04x mask=%04x) as id=%d", barrier::KeyMap::formatKey(key, mask).c_str(), key, mask, kid));
+	return kid;
 }
 
 void
-OSXScreen::unregisterHotKey(UInt32 id)
+OSXScreen::unregisterHotKey(UInt32 kid)
 {
 	// look up hotkey
-	HotKeyMap::iterator i = m_hotKeys.find(id);
+	HotKeyMap::iterator i = m_hotKeys.find(kid);
 	if (i == m_hotKeys.end()) {
 		return;
 	}
@@ -388,7 +388,7 @@ OSXScreen::unregisterHotKey(UInt32 id)
 		// XXX -- this is inefficient
 		for (ModifierHotKeyMap::iterator j = m_modifierHotKeys.begin();
 								j != m_modifierHotKeys.end(); ++j) {
-			if (j->second == id) {
+			if (j->second == kid) {
 				m_modifierHotKeys.erase(j);
 				okay = true;
 				break;
@@ -396,17 +396,17 @@ OSXScreen::unregisterHotKey(UInt32 id)
 		}
 	}
 	if (!okay) {
-		LOG((CLOG_WARN "failed to unregister hotkey id=%d", id));
+		LOG((CLOG_WARN "failed to unregister hotkey id=%d", kid));
 	}
 	else {
-		LOG((CLOG_DEBUG "unregistered hotkey id=%d", id));
+		LOG((CLOG_DEBUG "unregistered hotkey id=%d", kid));
 	}
 
 	// discard hot key from map and record old id for reuse
 	m_hotKeyToIDMap.erase(i->second);
 	m_hotKeys.erase(i);
-	m_oldHotKeyIDs.push_back(id);
-	if (m_activeModifierHotKey == id) {
+	m_oldHotKeyIDs.push_back(kid);
+	if (m_activeModifierHotKey == kid) {
 		m_activeModifierHotKey     = 0;
 		m_activeModifierHotKeyMask = 0;
 	}
@@ -1445,8 +1445,8 @@ OSXScreen::getScrollSpeed() const
 							kCFPreferencesCurrentUser,
 							kCFPreferencesAnyHost);
 	if (pref != NULL) {
-		CFTypeID id = CFGetTypeID(pref);
-		if (id == CFNumberGetTypeID()) {
+		CFTypeID tid = CFGetTypeID(pref);
+		if (tid == CFNumberGetTypeID()) {
 			CFNumberRef value = static_cast<CFNumberRef>(pref);
 			if (CFNumberGetValue(value, kCFNumberDoubleType, &scaling)) {
 				if (scaling < 0.0) {


### PR DESCRIPTION
These are part of needed changes for the build to work with gcc.

In addition, https://github.com/debauchee/barrier/pull/1886 is required. Also I had to revert several `.mm` files back to `.m`. This is not included in this PR, so it is not sufficient to fix the build with gcc, AFAICT.