### PR TITLE
test: TailscaleUtil CGNAT range unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build-and-test:
+    name: Build & Test (Ubuntu)
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y \
+            libxtst-dev \
+            qtdeclarative5-dev \
+            libavahi-compat-libdnssd-dev \
+            libcurl4-openssl-dev \
+            libssl-dev \
+            cmake \
+            make
+
+      - name: Configure
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBARRIER_BUILD_TESTS=ON
+
+      - name: Build
+        run: cmake --build build --parallel $(nproc)
+
+      - name: Run unit tests
+        run: ctest --test-dir build --output-on-failure -R unittests

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ CMakeCache.txt
 # Transient in-project-directory dependencies
 /deps/
 /out/build/x64-Debug
+/build-test
 
 # Beads / Dolt files (added by bd init)
 .dolt/

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,8 @@ CMakeCache.txt
 # Transient in-project-directory dependencies
 /deps/
 /out/build/x64-Debug
+
+# Beads / Dolt files (added by bd init)
+.dolt/
+*.db
+.beads-credential-key

--- a/src/gui/src/AppConfig.cpp
+++ b/src/gui/src/AppConfig.cpp
@@ -158,6 +158,7 @@ void AppConfig::loadSettings()
     m_ElevateMode = static_cast<ElevateMode>(elevateMode.toInt());
     m_AutoConfigPrompted = settings().value("autoConfigPrompted", false).toBool();
     m_CryptoEnabled = settings().value("cryptoEnabled", true).toBool();
+    m_TailscaleMode = settings().value("tailscaleMode", false).toBool();
     // TODO: set default value of requireClientCertificate to true on Barrier 2.5.0
     m_RequireClientCertificate = settings().value("requireClientCertificate", false).toBool();
     m_AutoHide = settings().value("autoHide", false).toBool();
@@ -183,6 +184,7 @@ void AppConfig::saveSettings()
     settings().setValue("elevateModeEnum", static_cast<int>(m_ElevateMode));
     settings().setValue("autoConfigPrompted", m_AutoConfigPrompted);
     settings().setValue("cryptoEnabled", m_CryptoEnabled);
+    settings().setValue("tailscaleMode", m_TailscaleMode);
     settings().setValue("requireClientCertificate", m_RequireClientCertificate);
     settings().setValue("autoHide", m_AutoHide);
     settings().setValue("autoStart", m_AutoStart);
@@ -227,6 +229,10 @@ ElevateMode AppConfig::elevateMode() { return m_ElevateMode; }
 void AppConfig::setCryptoEnabled(bool e) { m_CryptoEnabled = e; }
 
 bool AppConfig::getCryptoEnabled() const { return m_CryptoEnabled; }
+
+void AppConfig::setTailscaleMode(bool e) { m_TailscaleMode = e; }
+
+bool AppConfig::getTailscaleMode() const { return m_TailscaleMode; }
 
 void AppConfig::setRequireClientCertificate(bool e) { m_RequireClientCertificate = e; }
 

--- a/src/gui/src/AppConfig.h
+++ b/src/gui/src/AppConfig.h
@@ -138,7 +138,7 @@ protected:
         ElevateMode m_ElevateMode;
         bool m_AutoConfigPrompted;
         bool m_CryptoEnabled;
-        bool m_TailscaleMode;
+        bool m_TailscaleMode = false;
         bool m_RequireClientCertificate = false;
         bool m_AutoHide;
         bool m_AutoStart;

--- a/src/gui/src/AppConfig.h
+++ b/src/gui/src/AppConfig.h
@@ -91,6 +91,9 @@ class AppConfig: public QObject
         void setCryptoEnabled(bool e);
         bool getCryptoEnabled() const;
 
+        void setTailscaleMode(bool e);
+        bool getTailscaleMode() const;
+
         void setRequireClientCertificate(bool e);
         bool getRequireClientCertificate() const;
 
@@ -135,6 +138,7 @@ protected:
         ElevateMode m_ElevateMode;
         bool m_AutoConfigPrompted;
         bool m_CryptoEnabled;
+        bool m_TailscaleMode;
         bool m_RequireClientCertificate = false;
         bool m_AutoHide;
         bool m_AutoStart;

--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -548,7 +548,9 @@ void MainWindow::startBarrier()
 
 #endif
 
-    if (!m_AppConfig->getCryptoEnabled()) {
+    if (m_AppConfig->getTailscaleMode()) {
+        args << "--tailscale-mode";
+    } else if (!m_AppConfig->getCryptoEnabled()) {
         args << "--disable-crypto";
     }
 

--- a/src/gui/src/SettingsDialog.cpp
+++ b/src/gui/src/SettingsDialog.cpp
@@ -52,6 +52,9 @@ SettingsDialog::SettingsDialog(QWidget* parent, AppConfig& config) :
     m_pCheckBoxMinimizeToTray->setChecked(appConfig().getMinimizeToTray());
     m_pCheckBoxEnableCrypto->setChecked(m_appConfig.getCryptoEnabled());
     checkbox_require_client_certificate->setChecked(m_appConfig.getRequireClientCertificate());
+    m_pCheckBoxTailscaleMode->setChecked(m_appConfig.getTailscaleMode());
+    // Set initial enabled state of SSL controls to match Tailscale checkbox
+    on_m_pCheckBoxTailscaleMode_stateChanged(m_appConfig.getTailscaleMode() ? 2 : 0);
 
 #if defined(Q_OS_WIN)
     m_pComboElevate->setCurrentIndex(static_cast<int>(appConfig().elevateMode()));
@@ -69,6 +72,7 @@ void SettingsDialog::accept()
     m_appConfig.setNetworkInterface(m_pLineEditInterface->text());
     m_appConfig.setCryptoEnabled(m_pCheckBoxEnableCrypto->isChecked());
     m_appConfig.setRequireClientCertificate(checkbox_require_client_certificate->isChecked());
+    m_appConfig.setTailscaleMode(m_pCheckBoxTailscaleMode->isChecked());
     m_appConfig.setLogLevel(m_pComboLogLevel->currentIndex());
     m_appConfig.setLogToFile(m_pCheckBoxLogToFile->isChecked());
     m_appConfig.setLogFilename(m_pLineEditLogFilename->text());
@@ -119,6 +123,14 @@ void SettingsDialog::on_m_pCheckBoxLogToFile_stateChanged(int i)
 
     m_pLineEditLogFilename->setEnabled(checked);
     m_pButtonBrowseLog->setEnabled(checked);
+}
+
+void SettingsDialog::on_m_pCheckBoxTailscaleMode_stateChanged(int i)
+{
+    // When Tailscale is active it owns encryption; SSL controls have no effect.
+    bool tailscale = i == 2;
+    m_pCheckBoxEnableCrypto->setEnabled(!tailscale);
+    checkbox_require_client_certificate->setEnabled(!tailscale);
 }
 
 void SettingsDialog::on_m_pButtonBrowseLog_clicked()

--- a/src/gui/src/SettingsDialog.h
+++ b/src/gui/src/SettingsDialog.h
@@ -47,6 +47,7 @@ class SettingsDialog : public QDialog, public Ui::SettingsDialogBase
         void on_m_pComboLanguage_currentIndexChanged(int index);
         void on_m_pCheckBoxLogToFile_stateChanged(int );
         void on_m_pButtonBrowseLog_clicked();
+        void on_m_pCheckBoxTailscaleMode_stateChanged(int );
 };
 
 #endif

--- a/src/gui/src/SettingsDialogBase.ui
+++ b/src/gui/src/SettingsDialogBase.ui
@@ -202,6 +202,16 @@
         </property>
        </widget>
       </item>
+      <item row="4" column="0" colspan="2">
+       <widget class="QCheckBox" name="m_pCheckBoxTailscaleMode">
+        <property name="text">
+         <string>Use &amp;Tailscale (disables SSL — Tailscale handles encryption)</string>
+        </property>
+        <property name="toolTip">
+         <string>When checked, Barrier binds to the Tailscale network interface and disables its own TLS. Tailscale provides end-to-end encryption.</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -340,6 +350,7 @@
   <tabstop>m_pSpinBoxPort</tabstop>
   <tabstop>m_pLineEditInterface</tabstop>
   <tabstop>m_pCheckBoxEnableCrypto</tabstop>
+  <tabstop>m_pCheckBoxTailscaleMode</tabstop>
   <tabstop>m_pComboLogLevel</tabstop>
   <tabstop>m_pCheckBoxLogToFile</tabstop>
   <tabstop>m_pLineEditLogFilename</tabstop>

--- a/src/lib/barrier/App.h
+++ b/src/lib/barrier/App.h
@@ -168,6 +168,8 @@ private:
     "      --enable-drag-drop   enable file drag & drop.\n" \
     "      --enable-crypto      enable the crypto (ssl) plugin (default, deprecated).\n" \
     "      --disable-crypto     disable the crypto (ssl) plugin.\n" \
+    "      --tailscale-mode     bind to Tailscale interface, disable TLS\n" \
+    "                             (Tailscale handles encryption end-to-end).\n" \
     "      --profile-dir <path> use named profile directory instead.\n" \
     "      --drop-dir <path>    use named drop target directory instead.\n"
 

--- a/src/lib/barrier/ArgParser.cpp
+++ b/src/lib/barrier/ArgParser.cpp
@@ -289,6 +289,11 @@ ArgParser::parseGenericArgs(int argc, const char* const* argv, int& i)
     else if (isArg(i, argc, argv, NULL, "--disable-crypto")) {
         argsBase().m_enableCrypto = false;
     }
+    else if (isArg(i, argc, argv, NULL, "--tailscale-mode")) {
+        argsBase().m_tailscaleMode = true;
+        argsBase().m_enableCrypto = false;
+        LOG((CLOG_INFO "tailscale mode: binding to Tailscale interface, TLS disabled (Tailscale handles encryption)"));
+    }
     else if (isArg(i, argc, argv, NULL, "--profile-dir", 1)) {
         argsBase().m_profileDirectory = barrier::fs::u8path(argv[++i]);
     }

--- a/src/lib/barrier/ArgsBase.cpp
+++ b/src/lib/barrier/ArgsBase.cpp
@@ -43,6 +43,7 @@ m_dropTarget(""),
 m_shouldExit(false),
 m_barrierAddress(),
     m_enableCrypto(true),
+m_tailscaleMode(false),
 m_profileDirectory(),
 m_pluginDirectory("")
 {

--- a/src/lib/barrier/ArgsBase.h
+++ b/src/lib/barrier/ArgsBase.h
@@ -51,6 +51,7 @@ public:
     bool                m_shouldExit;
     String                m_barrierAddress;
     bool                m_enableCrypto;
+    bool                m_tailscaleMode;
     barrier::fs::path m_profileDirectory;
     barrier::fs::path m_pluginDirectory;
 };

--- a/src/lib/barrier/ClientApp.cpp
+++ b/src/lib/barrier/ClientApp.cpp
@@ -39,6 +39,7 @@
 #include "base/EventQueue.h"
 #include "base/Log.h"
 #include "common/Version.h"
+#include "net/TailscaleUtil.h"
 
 #if WINAPI_MSWINDOWS
 #include "platform/MSWindowsScreen.h"
@@ -387,6 +388,15 @@ ClientApp::foregroundStartup(int argc, char** argv)
 bool
 ClientApp::startClient()
 {
+    if (args().m_tailscaleMode) {
+        std::string tsAddr = barrier::get_tailscale_address();
+        if (tsAddr.empty()) {
+            LOG((CLOG_ERR "tailscale mode is active but no Tailscale interface found -- is Tailscale running?"));
+            return false;
+        }
+        LOG((CLOG_NOTE "tailscale mode active: TLS disabled, expecting server on Tailscale network (%s local)", tsAddr.c_str()));
+    }
+
     double retryTime;
     barrier::Screen* clientScreen = NULL;
     try {

--- a/src/lib/barrier/ServerApp.cpp
+++ b/src/lib/barrier/ServerApp.cpp
@@ -38,6 +38,7 @@
 #include "base/Log.h"
 #include "base/TMethodEventJob.h"
 #include "common/Version.h"
+#include "net/TailscaleUtil.h"
 #include "common/DataDirectories.h"
 
 #if SYSAPI_WIN32
@@ -564,6 +565,16 @@ ServerApp::startServer()
     ClientListener* listener = NULL;
     try {
         auto listenAddress = args().m_config->getBarrierAddress();
+        if (args().m_tailscaleMode) {
+            std::string tsAddr = barrier::get_tailscale_address();
+            if (tsAddr.empty()) {
+                LOG((CLOG_ERR "tailscale mode is active but no Tailscale interface found -- is Tailscale running?"));
+                return false;
+            }
+            LOG((CLOG_NOTE "tailscale mode: binding server to %s", tsAddr.c_str()));
+            listenAddress = NetworkAddress(tsAddr, listenAddress.getPort());
+            listenAddress.resolve();
+        }
         auto family = family_string(ARCH->getAddrFamily(listenAddress.getAddress()));
         listener   = openClientListener(listenAddress);
         m_server   = openServer(*args().m_config, m_primaryClient);

--- a/src/lib/net/TailscaleUtil.cpp
+++ b/src/lib/net/TailscaleUtil.cpp
@@ -1,0 +1,106 @@
+/*
+ * barrier -- mouse and keyboard sharing utility
+ * Copyright (C) 2024 Barrier Contributors
+ *
+ * This package is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * found in the file LICENSE that should have accompanied this file.
+ *
+ * This package is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "net/TailscaleUtil.h"
+
+#if SYSAPI_WIN32
+#  define WIN32_LEAN_AND_MEAN
+#  include <windows.h>
+#  include <iphlpapi.h>
+#  pragma comment(lib, "iphlpapi.lib")
+#else
+#  include <ifaddrs.h>
+#  include <netinet/in.h>
+#  include <arpa/inet.h>
+#endif
+
+#include <cstdint>
+
+namespace barrier {
+
+// Tailscale uses the 100.64.0.0/10 CGNAT block:
+//   first address: 100.64.0.0  → 0x64400000
+//   last  address: 100.127.255.255 → 0x647FFFFF
+static bool is_tailscale_addr(uint32_t addr_host_order)
+{
+    return (addr_host_order >= 0x64400000u) && (addr_host_order <= 0x647FFFFFu);
+}
+
+std::string get_tailscale_address()
+{
+#if SYSAPI_WIN32
+    // Use GetAdaptersAddresses to enumerate IPv4 addresses on Windows.
+    ULONG bufLen = 15000;
+    auto buf = std::make_unique<char[]>(bufLen);
+    IP_ADAPTER_ADDRESSES* adapters = reinterpret_cast<IP_ADAPTER_ADDRESSES*>(buf.get());
+
+    ULONG ret = GetAdaptersAddresses(AF_INET,
+        GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_SKIP_DNS_SERVER,
+        nullptr, adapters, &bufLen);
+
+    if (ret == ERROR_BUFFER_OVERFLOW) {
+        buf = std::make_unique<char[]>(bufLen);
+        adapters = reinterpret_cast<IP_ADAPTER_ADDRESSES*>(buf.get());
+        ret = GetAdaptersAddresses(AF_INET,
+            GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_SKIP_DNS_SERVER,
+            nullptr, adapters, &bufLen);
+    }
+
+    if (ret != NO_ERROR) {
+        return {};
+    }
+
+    for (auto* a = adapters; a != nullptr; a = a->Next) {
+        for (auto* ua = a->FirstUnicastAddress; ua != nullptr; ua = ua->Next) {
+            auto* sin = reinterpret_cast<sockaddr_in*>(ua->Address.lpSockaddr);
+            uint32_t addr = ntohl(sin->sin_addr.s_addr);
+            if (is_tailscale_addr(addr)) {
+                char buf[INET_ADDRSTRLEN];
+                inet_ntop(AF_INET, &sin->sin_addr, buf, sizeof(buf));
+                return buf;
+            }
+        }
+    }
+    return {};
+
+#else
+    // Use getifaddrs on Unix/macOS.
+    struct ifaddrs* ifap = nullptr;
+    if (getifaddrs(&ifap) != 0) {
+        return {};
+    }
+
+    std::string result;
+    for (auto* ifa = ifap; ifa != nullptr; ifa = ifa->ifa_next) {
+        if (ifa->ifa_addr == nullptr || ifa->ifa_addr->sa_family != AF_INET) {
+            continue;
+        }
+        auto* sin = reinterpret_cast<struct sockaddr_in*>(ifa->ifa_addr);
+        uint32_t addr = ntohl(sin->sin_addr.s_addr);
+        if (is_tailscale_addr(addr)) {
+            char buf[INET_ADDRSTRLEN];
+            inet_ntop(AF_INET, &sin->sin_addr, buf, sizeof(buf));
+            result = buf;
+            break;
+        }
+    }
+    freeifaddrs(ifap);
+    return result;
+#endif
+}
+
+} // namespace barrier

--- a/src/lib/net/TailscaleUtil.cpp
+++ b/src/lib/net/TailscaleUtil.cpp
@@ -35,10 +35,12 @@ namespace barrier {
 // Tailscale uses the 100.64.0.0/10 CGNAT block:
 //   first address: 100.64.0.0  → 0x64400000
 //   last  address: 100.127.255.255 → 0x647FFFFF
-static bool is_tailscale_addr(uint32_t addr_host_order)
+namespace detail {
+bool is_tailscale_addr(uint32_t addr_host_order)
 {
     return (addr_host_order >= 0x64400000u) && (addr_host_order <= 0x647FFFFFu);
 }
+} // namespace detail
 
 std::string get_tailscale_address()
 {
@@ -68,7 +70,7 @@ std::string get_tailscale_address()
         for (auto* ua = a->FirstUnicastAddress; ua != nullptr; ua = ua->Next) {
             auto* sin = reinterpret_cast<sockaddr_in*>(ua->Address.lpSockaddr);
             uint32_t addr = ntohl(sin->sin_addr.s_addr);
-            if (is_tailscale_addr(addr)) {
+            if (detail::is_tailscale_addr(addr)) {
                 char buf[INET_ADDRSTRLEN];
                 inet_ntop(AF_INET, &sin->sin_addr, buf, sizeof(buf));
                 return buf;
@@ -91,7 +93,7 @@ std::string get_tailscale_address()
         }
         auto* sin = reinterpret_cast<struct sockaddr_in*>(ifa->ifa_addr);
         uint32_t addr = ntohl(sin->sin_addr.s_addr);
-        if (is_tailscale_addr(addr)) {
+        if (detail::is_tailscale_addr(addr)) {
             char buf[INET_ADDRSTRLEN];
             inet_ntop(AF_INET, &sin->sin_addr, buf, sizeof(buf));
             result = buf;

--- a/src/lib/net/TailscaleUtil.h
+++ b/src/lib/net/TailscaleUtil.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 namespace barrier {
@@ -26,5 +27,11 @@ namespace barrier {
 // network interface.  Returns an empty string if Tailscale is not
 // running or no such address is present.
 std::string get_tailscale_address();
+
+namespace detail {
+// Returns true if addr (in host byte order) falls within the Tailscale
+// CGNAT range 100.64.0.0/10 (0x64400000–0x647FFFFF).
+bool is_tailscale_addr(uint32_t addr_host_order);
+} // namespace detail
 
 } // namespace barrier

--- a/src/lib/net/TailscaleUtil.h
+++ b/src/lib/net/TailscaleUtil.h
@@ -1,0 +1,30 @@
+/*
+ * barrier -- mouse and keyboard sharing utility
+ * Copyright (C) 2024 Barrier Contributors
+ *
+ * This package is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * found in the file LICENSE that should have accompanied this file.
+ *
+ * This package is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace barrier {
+
+// Returns the first IPv4 address in the Tailscale CGNAT range
+// (100.64.0.0/10, i.e. 100.64.x.x – 100.127.x.x) found on a local
+// network interface.  Returns an empty string if Tailscale is not
+// running or no such address is present.
+std::string get_tailscale_address();
+
+} // namespace barrier

--- a/src/test/unittests/CMakeLists.txt
+++ b/src/test/unittests/CMakeLists.txt
@@ -66,3 +66,5 @@ endif()
 add_executable(unittests ${sources})
 target_link_libraries(unittests
     arch base client server common io net platform server synlib mt ipc ${GTEST_LIBRARIES} ${GMOCK_LIBRARIES} ${libs} ${OPENSSL_LIBS})
+
+add_test(NAME unittests COMMAND unittests)

--- a/src/test/unittests/net/TailscaleUtilTests.cpp
+++ b/src/test/unittests/net/TailscaleUtilTests.cpp
@@ -1,0 +1,73 @@
+/*
+ * barrier -- mouse and keyboard sharing utility
+ * Copyright (C) 2024 Barrier Contributors
+ *
+ * This package is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * found in the file LICENSE that should have accompanied this file.
+ *
+ * This package is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "net/TailscaleUtil.h"
+
+#include "test/global/gtest.h"
+
+namespace barrier {
+namespace detail {
+
+// Tailscale CGNAT range: 100.64.0.0/10
+//   first: 100.64.0.0   = 0x64400000
+//   last:  100.127.255.255 = 0x647FFFFF
+
+TEST(TailscaleUtilTest, FirstAddressInRange)
+{
+    EXPECT_TRUE(is_tailscale_addr(0x64400000u)); // 100.64.0.0
+}
+
+TEST(TailscaleUtilTest, LastAddressInRange)
+{
+    EXPECT_TRUE(is_tailscale_addr(0x647FFFFFu)); // 100.127.255.255
+}
+
+TEST(TailscaleUtilTest, TypicalTailscaleAddress)
+{
+    // 100.100.100.100 = 0x64646464
+    EXPECT_TRUE(is_tailscale_addr(0x64646464u));
+}
+
+TEST(TailscaleUtilTest, AddressJustBelowRange)
+{
+    EXPECT_FALSE(is_tailscale_addr(0x6443FFFFu)); // 100.63.255.255
+}
+
+TEST(TailscaleUtilTest, AddressJustAboveRange)
+{
+    EXPECT_FALSE(is_tailscale_addr(0x64800000u)); // 100.128.0.0
+}
+
+TEST(TailscaleUtilTest, LoopbackNotInRange)
+{
+    EXPECT_FALSE(is_tailscale_addr(0x7F000001u)); // 127.0.0.1
+}
+
+TEST(TailscaleUtilTest, PrivateRfc1918NotInRange)
+{
+    EXPECT_FALSE(is_tailscale_addr(0xC0A80001u)); // 192.168.0.1
+    EXPECT_FALSE(is_tailscale_addr(0x0A000001u)); // 10.0.0.1
+    EXPECT_FALSE(is_tailscale_addr(0xAC100001u)); // 172.16.0.1
+}
+
+TEST(TailscaleUtilTest, ZeroAddressNotInRange)
+{
+    EXPECT_FALSE(is_tailscale_addr(0x00000000u)); // 0.0.0.0
+}
+
+} // namespace detail
+} // namespace barrier

--- a/src/test/unittests/net/TailscaleUtilTests.cpp
+++ b/src/test/unittests/net/TailscaleUtilTests.cpp
@@ -44,7 +44,7 @@ TEST(TailscaleUtilTest, TypicalTailscaleAddress)
 
 TEST(TailscaleUtilTest, AddressJustBelowRange)
 {
-    EXPECT_FALSE(is_tailscale_addr(0x6443FFFFu)); // 100.63.255.255
+    EXPECT_FALSE(is_tailscale_addr(0x643FFFFFu)); // 100.63.255.255
 }
 
 TEST(TailscaleUtilTest, AddressJustAboveRange)


### PR DESCRIPTION
## Summary

- Exposes `is_tailscale_addr()` in `barrier::detail` namespace so it can be tested without real network interfaces
- Adds 8 unit tests in `src/test/unittests/net/TailscaleUtilTests.cpp` covering:
  - First and last address in the 100.64.0.0/10 range (boundary)
  - Typical Tailscale address (100.100.100.100)
  - Addresses just below and just above the range
  - Loopback, RFC-1918, and zero address (all negative cases)

## Test plan

- [ ] Build `unittests` target and confirm new tests pass
- [ ] Confirm no regression in existing `net/` tests (FingerprintDatabase, SecureUtils)

🤖 Generated with [Claude Code](https://claude.com/claude-code)