### PR TITLE
feat: multi-address client support and stale connection fix on reconnect

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required (VERSION 3.4)
+cmake_minimum_required (VERSION 3.5)
 project (barrier C CXX)
 
 option (BARRIER_BUILD_GUI "Build the GUI" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -433,6 +433,14 @@ endif()
 #
 if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
         set (BARRIER_WIX_VERSION "${BARRIER_VERSION_MAJOR}.${BARRIER_VERSION_MINOR}.${BARRIER_VERSION_PATCH}")
+        # Multi-config generators (MSBuild/Visual Studio) place binaries in a
+        # per-config subdirectory, e.g. bin/Release/.  Single-config generators
+        # (Ninja, Makefiles) place them directly in bin/.
+        if (CMAKE_CONFIGURATION_TYPES)
+            set (BARRIER_INSTALLER_BIN_DIR "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Release")
+        else()
+            set (BARRIER_INSTALLER_BIN_DIR "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+        endif()
         message (STATUS "Configuring the wix installer")
         configure_files (${CMAKE_CURRENT_SOURCE_DIR}/dist/wix ${CMAKE_BINARY_DIR}/installer-wix)
         message (STATUS "Configuring the inno installer")

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ jobs:
 - job: WinBuild
   displayName: Windows Build
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-latest'
   strategy:
     matrix:
       Debug:
@@ -24,9 +24,9 @@ jobs:
       inputs:
         filePath: azure-pipelines/download_install_bonjour_sdk_like.ps1
     - task: UsePythonVersion@0
-      displayName: Selecting Python Installer for QLI Installer
+      displayName: Selecting Python Installer for Qt Installer
       inputs:
-        versionSpec: '3.7'
+        versionSpec: '3.x'
     - task: PowerShell@2
       displayName: Installing QT
       condition: ne(variables['CacheRestored'], 'true')
@@ -36,7 +36,8 @@ jobs:
     - powershell: Copy-Item azure-pipelines\build_env_tmpl.bat build_env.bat
       displayName: Layering Azure Pipeline's build_env.bat
     - script: |
-          call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Enterprise\\Common7\\Tools\\vsdevcmd" -arch=x64 && clean_build.bat
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=x64 2>nul || call "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\VsDevCmd.bat" -arch=x64 2>nul || call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\vsdevcmd" -arch=x64
+          clean_build.bat
       displayName: Clean Build
     - task: ArchiveFiles@2
       displayName: Archive Completed Build Directory
@@ -49,7 +50,7 @@ jobs:
       inputs:
         pathtoPublish: $(Build.ArtifactStagingDirectory)\$(CI_ENV_BUILD_TYPE).zip
         artifactName: Windows $(CI_ENV_BUILD_TYPE)
-    - script: choco install innosetup --version 5.6.1.20190126 --allow-downgrade
+    - script: choco install innosetup --version 6.2.2 --allow-downgrade
       displayName: Ensure desired version of Inno Setup is installed.
       condition: eq(variables['CI_ENV_BUILD_TYPE'], 'Release')
     - script: build_installer.bat
@@ -63,15 +64,9 @@ jobs:
         artifactName: Windows Release Installer
 
 - job: LinuxBuild
-  strategy:
-    matrix:
-      ubuntu-18.04:
-        imageName: 'ubuntu-18.04'
-      ubuntu-20.04:
-        imageName: 'ubuntu-20.04'
   displayName: Linux Build
   pool:
-    vmImage: $(imageName)
+    vmImage: 'ubuntu-latest'
   steps:
     - script: sudo apt-get update -y
     - script: sudo apt-get install -y libxtst-dev qtdeclarative5-dev libavahi-compat-libdnssd-dev libcurl4-openssl-dev
@@ -83,28 +78,17 @@ jobs:
   displayName: Mac Build
   strategy:
     matrix:
-      big-sur-Release:
-          imageName: "macOS-11"
-          B_BUILD_TYPE: Release
-          BARRIER_VERSION_STAGE: Release
-      catalina-Release:
-          imageName: "macOS-10.15"
-          B_BUILD_TYPE: Release
-          BARRIER_VERSION_STAGE: Release
-      mojave-Release:
-          imageName: "macOS-10.14"
+      macos-latest-Release:
           B_BUILD_TYPE: Release
           BARRIER_VERSION_STAGE: Release
   pool:
-    vmImage: $(imageName)
+    vmImage: 'macOS-latest'
   variables:
     VERBOSE: 1
     TERM: xterm-256color
   steps:
-    - script: rm -rf /usr/local/opt/openssl
-      displayName: Remove incompatible OpenSSL 1.0.2t from macOS-10.14 vmImage
     - script: brew reinstall openssl
-      displayName: Installed newer OpenSSL 1.1.x
+      displayName: Install newer OpenSSL
     - script: brew install pkg-config qt5
       displayName: Install Qt5 and pkg-config prereqs
     - script: sh -x ./clean_build.sh

--- a/azure-pipelines/build_env_tmpl.bat
+++ b/azure-pipelines/build_env_tmpl.bat
@@ -1,6 +1,5 @@
 set B_BUILD_TYPE=%CI_ENV_BUILD_TYPE%
 set B_QT_ROOT=%cd%\deps\Qt
-set B_QT_VER=Qt5.13.0\5.13.0
-set B_QT_MSVC=msvc2017_64
+set B_QT_VER=Qt5.15.2\5.15.2
+set B_QT_MSVC=msvc2019_64
 set B_BONJOUR=%cd%\deps\BonjourSDKLike
-

--- a/azure-pipelines/download_install_qt.ps1
+++ b/azure-pipelines/download_install_qt.ps1
@@ -1,25 +1,14 @@
 $ErrorActionPreference = "Stop"
 
-$qli_install_version = '2019.05.26.1'
-$qt_version = '5.13.0'
+$qt_version = '5.15.2'
 
 New-Item -Force -ItemType Directory -Path ".\deps\"
 
-Write-Output 'Downloading QLI Installer'
-Invoke-WebRequest "https://github.com/nelsonjchen/qli-installer/archive/v$qli_install_version.zip" -OutFile '.\deps\qli-installer.zip' ;
-Write-Output 'Downloaded QLI Installer'
+Write-Output 'Installing aqtinstall'
+pip install aqtinstall --quiet
+Write-Output 'Installed aqtinstall'
 
-Write-Output 'Extracting QLI Installer'
-Expand-Archive deps\qli-installer.zip deps\
-Move-Item .\deps\qli-installer-$qli_install_version\ .\deps\qli-installer
-Write-Output 'Extracted QLI Installer'
-
-Write-Output 'Installing QLI Installer Dependencies'
-pip install -r .\deps\qli-installer\requirements.txt
-Write-Output 'Installed QLI Installer Dependencies'
-
-Write-Output 'Starting QT Installer'
-$Env:QLI_OUT_DIR = ".\deps\Qt\Qt$qt_version"
-$Env:QLI_BASE_URL = "https://download.qt.io/online/qtsdkrepository/"
-python .\deps\qli-installer\qli-installer.py $qt_version windows desktop win64_msvc2017_64
-Write-Output 'Installed QT Installer'
+Write-Output 'Installing Qt'
+$Env:QT_BASE_DIR = ".\deps\Qt"
+python -m aqt install-qt windows desktop $qt_version win64_msvc2019_64 -O ".\deps\Qt\Qt$qt_version"
+Write-Output 'Installed Qt'

--- a/build_installer.bat
+++ b/build_installer.bat
@@ -1,5 +1,14 @@
 @echo off
-set INNO_ROOT=C:\Program Files (x86)\Inno Setup 5
+REM Detect Inno Setup location (6 installed per-user, 5 installed system-wide)
+if exist "%LOCALAPPDATA%\Programs\Inno Setup 6\ISCC.exe" (
+    set INNO_ROOT=%LOCALAPPDATA%\Programs\Inno Setup 6
+) else if exist "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" (
+    set INNO_ROOT=C:\Program Files (x86)\Inno Setup 6
+) else if exist "C:\Program Files (x86)\Inno Setup 5\ISCC.exe" (
+    set INNO_ROOT=C:\Program Files (x86)\Inno Setup 5
+) else (
+    set INNO_ROOT=C:\Program Files (x86)\Inno Setup 5
+)
 
 set savedir=%cd%
 cd /d %~dp0

--- a/build_installer.bat
+++ b/build_installer.bat
@@ -1,15 +1,25 @@
 @echo off
-REM Detect Inno Setup location (6 installed per-user, 5 installed system-wide)
-if exist "%LOCALAPPDATA%\Programs\Inno Setup 6\ISCC.exe" (
-    set INNO_ROOT=%LOCALAPPDATA%\Programs\Inno Setup 6
-) else if exist "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" (
-    set INNO_ROOT=C:\Program Files (x86)\Inno Setup 6
-) else if exist "C:\Program Files (x86)\Inno Setup 5\ISCC.exe" (
-    set INNO_ROOT=C:\Program Files (x86)\Inno Setup 5
-) else (
-    set INNO_ROOT=C:\Program Files (x86)\Inno Setup 5
-)
+REM Detect Inno Setup 6 or 5 location.
+REM Uses goto instead of else-if chains to avoid batch parser issues
+REM with parentheses in "Program Files (x86)" paths.
 
+set "INNO_ROOT="
+
+if exist "%LOCALAPPDATA%\Programs\Inno Setup 6\ISCC.exe" (
+    set "INNO_ROOT=%LOCALAPPDATA%\Programs\Inno Setup 6"
+    goto :inno_found
+)
+if exist "%ProgramFiles(x86)%\Inno Setup 6\ISCC.exe" (
+    set "INNO_ROOT=%ProgramFiles(x86)%\Inno Setup 6"
+    goto :inno_found
+)
+if exist "%ProgramFiles(x86)%\Inno Setup 5\ISCC.exe" (
+    set "INNO_ROOT=%ProgramFiles(x86)%\Inno Setup 5"
+    goto :inno_found
+)
+set "INNO_ROOT=%ProgramFiles(x86)%\Inno Setup 5"
+
+:inno_found
 set savedir=%cd%
 cd /d %~dp0
 
@@ -35,9 +45,9 @@ goto done
 
 :failed
 echo Build failed
+exit /b 1
 
 :done
-set INNO_ROOT=
-
+set "INNO_ROOT="
 cd /d %savedir%
 set savedir=

--- a/clean_build.bat
+++ b/clean_build.bat
@@ -15,11 +15,13 @@ if "%VisualStudioVersion%"=="15.0" (
     set cmake_gen=Visual Studio 15 2017
 ) else if "%VisualStudioVersion%"=="16.0" (
     set cmake_gen=Visual Studio 16 2019
+) else if "%VisualStudioVersion%"=="17.0" (
+    set cmake_gen=Visual Studio 17 2022
 ) else (
     echo Visual Studio version was not detected.
     echo Did you forget to run inside a VS developer prompt?
     echo Using the default cmake generator.
-    set cmake_gen=Visual Studio 16 2019
+    set cmake_gen=Visual Studio 17 2022
 )
 
 if exist build_env.bat call build_env.bat

--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.4)
+cmake_minimum_required (VERSION 3.5)
 
 set (BARRIER_VERSION_MAJOR 2)
 set (BARRIER_VERSION_MINOR 4)

--- a/dist/inno/barrier.iss.in
+++ b/dist/inno/barrier.iss.in
@@ -42,7 +42,7 @@ UninstallDisplayIcon={app}\{#MyAppExeName}
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: "@CMAKE_RUNTIME_OUTPUT_DIRECTORY@/*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "@BARRIER_INSTALLER_BIN_DIR@/*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Icons]

--- a/dist/inno/barrier.iss.in
+++ b/dist/inno/barrier.iss.in
@@ -33,7 +33,7 @@ VersionInfoCopyright={#MyAppCopyright}
 
 Compression=lzma
 SolidCompression=yes
-ArchitecturesInstallIn64BitMode=x64 ia64
+ArchitecturesInstallIn64BitMode=x64compatible
 UninstallDisplayIcon={app}\{#MyAppExeName}
 
 #include "scripts\lang\english.iss"
@@ -42,7 +42,7 @@ UninstallDisplayIcon={app}\{#MyAppExeName}
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: "@CMAKE_RUNTIME_OUTPUT_DIRECTORY@/Release/*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "@CMAKE_RUNTIME_OUTPUT_DIRECTORY@/*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Icons]

--- a/dist/inno/barrier.iss.in
+++ b/dist/inno/barrier.iss.in
@@ -33,7 +33,7 @@ VersionInfoCopyright={#MyAppCopyright}
 
 Compression=lzma
 SolidCompression=yes
-ArchitecturesInstallIn64BitMode=x64compatible
+ArchitecturesInstallIn64BitMode=x64
 UninstallDisplayIcon={app}\{#MyAppExeName}
 
 #include "scripts\lang\english.iss"

--- a/dist/inno/scripts/products.pas
+++ b/dist/inno/scripts/products.pas
@@ -284,22 +284,16 @@ function IsIA64: boolean;
 	Gets whether the computer is IA64 (Itanium 64 bits).
 }
 begin
-	Result := (not isForcedX86) and Is64BitInstallMode and (ProcessorArchitecture = paIA64);
+	Result := false; // ia64 (Itanium) removed in Inno Setup 6
 end;
 
 function GetString(x86, x64, ia64: String): String;
 {
 	Gets a string depending on the computer architecture.
-	Parameters:
-		x86: the string if the computer is x86
-		x64: the string if the computer is x64
-		ia64: the string if the computer is IA64
 }
 begin
 	if IsX64() and (x64 <> '') then begin
 		Result := x64;
-	end else if IsIA64() and (ia64 <> '') then begin
-		Result := ia64;
 	end else begin
 		Result := x86;
 	end;
@@ -308,13 +302,11 @@ end;
 function GetArchitectureString(): String;
 {
 	Gets the "standard" architecture suffix string.
-	Returns either _x64, _ia64 or nothing.
+	Returns either _x64 or nothing.
 }
 begin
 	if IsX64() then begin
 		Result := '_x64';
-	end else if IsIA64() then begin
-		Result := '_ia64';
 	end else begin
 		Result := '';
 	end;

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.4)
+cmake_minimum_required (VERSION 3.5)
 
 find_package (Qt5 REQUIRED COMPONENTS Core Widgets Network)
 set (CMAKE_AUTOMOC ON)

--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -646,7 +646,26 @@ bool MainWindow::clientArgs(QStringList& args, QString& app)
         return false;
     }
 
-    args << "[" + m_pLineEditHostname->text() + "]:" + QString::number(appConfig().port());
+    QString hostText = m_pLineEditHostname->text().trimmed();
+    if (hostText.contains(',')) {
+        // Multiple addresses: format each as host:port and join with comma
+        QStringList parts = hostText.split(',');
+        QStringList formatted;
+        for (QString part : parts) {
+            part = part.trimmed();
+            if (part.isEmpty()) continue;
+            // Append default port if no port specified (single colon = has port, no colon = no port)
+            int colonCount = part.count(':');
+            if (colonCount == 0) {
+                formatted << part + ":" + QString::number(appConfig().port());
+            } else {
+                formatted << part;
+            }
+        }
+        args << formatted.join(",");
+    } else {
+        args << "[" + hostText + "]:" + QString::number(appConfig().port());
+    }
 
     return true;
 }

--- a/src/gui/src/MainWindowBase.ui
+++ b/src/gui/src/MainWindowBase.ui
@@ -168,7 +168,7 @@
        <item row="2" column="0">
         <widget class="QLabel" name="m_pLabelServerName">
          <property name="text">
-          <string>&amp;Server IP:</string>
+          <string>&amp;Server IP / Hostname:</string>
          </property>
          <property name="buddy">
           <cstring>m_pLineEditHostname</cstring>

--- a/src/lib/barrier/ClientApp.cpp
+++ b/src/lib/barrier/ClientApp.cpp
@@ -62,7 +62,8 @@ ClientApp::ClientApp(IEventQueue* events, CreateTaskBarReceiverFunc createTaskBa
     App(events, createTaskBarReceiver, new ClientArgs()),
     m_client(NULL),
     m_clientScreen(NULL),
-    m_serverAddress(NULL)
+    m_serverAddress(NULL),
+    m_currentAddressIndex(0)
 {
 }
 
@@ -82,19 +83,60 @@ ClientApp::parseArgs(int argc, const char* const* argv)
     else {
         // save server address
         if (!args().m_barrierAddress.empty()) {
-            try {
-                *m_serverAddress = NetworkAddress(args().m_barrierAddress, kDefaultPort);
-                m_serverAddress->resolve();
-            }
-            catch (XSocketAddress& e) {
-                // allow an address that we can't look up if we're restartable.
-                // we'll try to resolve the address each time we connect to the
-                // server.  a bad port will never get better.  patch by Brent
-                // Priddy.
-                if (!args().m_restartable || e.getError() == XSocketAddress::kBadPort) {
-                    LOG((CLOG_PRINT "%s: %s" BYE,
-                        args().m_exename.c_str(), e.what(), args().m_exename.c_str()));
+            if (args().m_barrierAddress.find(',') != std::string::npos) {
+                // Multiple comma-separated addresses: parse each and store for cycling
+                m_serverAddresses.clear();
+                m_currentAddressIndex = 0;
+                std::istringstream ss(args().m_barrierAddress);
+                std::string token;
+                while (std::getline(ss, token, ',')) {
+                    size_t start = token.find_first_not_of(" \t");
+                    size_t end   = token.find_last_not_of(" \t");
+                    if (start == std::string::npos) continue;
+                    token = token.substr(start, end - start + 1);
+                    try {
+                        m_serverAddresses.emplace_back(token, kDefaultPort);
+                        m_serverAddresses.back().resolve();
+                    }
+                    catch (XSocketAddress& e) {
+                        if (e.getError() == XSocketAddress::kBadPort) {
+                            LOG((CLOG_PRINT "%s: %s" BYE,
+                                args().m_exename.c_str(), e.what(), args().m_exename.c_str()));
+                            m_bye(kExitFailed);
+                        }
+                        // unresolvable address at startup is allowed when restartable
+                        if (!args().m_restartable) {
+                            LOG((CLOG_WARN "could not resolve address '%s': %s",
+                                token.c_str(), e.what()));
+                        }
+                    }
+                }
+                if (m_serverAddresses.empty()) {
+                    LOG((CLOG_PRINT "%s: no valid server addresses found" BYE,
+                        args().m_exename.c_str(), args().m_exename.c_str()));
                     m_bye(kExitFailed);
+                }
+                *m_serverAddress = m_serverAddresses[0];
+                LOG((CLOG_NOTE "using %zu server address(es), starting with '%s'",
+                    m_serverAddresses.size(),
+                    m_serverAddresses[0].getHostname().c_str()));
+            }
+            else {
+                // Single address: existing behavior
+                try {
+                    *m_serverAddress = NetworkAddress(args().m_barrierAddress, kDefaultPort);
+                    m_serverAddress->resolve();
+                }
+                catch (XSocketAddress& e) {
+                    // allow an address that we can't look up if we're restartable.
+                    // we'll try to resolve the address each time we connect to the
+                    // server.  a bad port will never get better.  patch by Brent
+                    // Priddy.
+                    if (!args().m_restartable || e.getError() == XSocketAddress::kBadPort) {
+                        LOG((CLOG_PRINT "%s: %s" BYE,
+                            args().m_exename.c_str(), e.what(), args().m_exename.c_str()));
+                        m_bye(kExitFailed);
+                    }
                 }
             }
         }
@@ -305,7 +347,20 @@ ClientApp::handleClientFailed(const Event& e, void*)
     else {
         LOG((CLOG_WARN "failed to connect to server: %s", info->m_what.c_str()));
         if (!m_suspended) {
-            scheduleClientRestart(nextRestartTimeout());
+            if (m_serverAddresses.size() > 1) {
+                // Cycle to the next address before retrying
+                m_currentAddressIndex = (m_currentAddressIndex + 1) % m_serverAddresses.size();
+                *m_serverAddress = m_serverAddresses[m_currentAddressIndex];
+                if (m_client != NULL) {
+                    m_client->setServerAddress(*m_serverAddress);
+                }
+                LOG((CLOG_NOTE "trying next server address: '%s'",
+                    m_serverAddress->getHostname().c_str()));
+                scheduleClientRestart(0.5);
+            }
+            else {
+                scheduleClientRestart(nextRestartTimeout());
+            }
         }
     }
     delete info;

--- a/src/lib/barrier/ClientApp.h
+++ b/src/lib/barrier/ClientApp.h
@@ -19,11 +19,13 @@
 #pragma once
 
 #include "barrier/App.h"
+#include "net/NetworkAddress.h"
+
+#include <vector>
 
 namespace barrier { class Screen; }
 class Event;
 class Client;
-class NetworkAddress;
 class ClientArgs;
 
 class ClientApp : public App {
@@ -76,7 +78,9 @@ public:
     Client* getClientPtr() { return m_client; }
 
 private:
-    Client*            m_client;
-    barrier::Screen*m_clientScreen;
-    NetworkAddress*    m_serverAddress;
+    Client*                     m_client;
+    barrier::Screen*            m_clientScreen;
+    NetworkAddress*             m_serverAddress;
+    std::vector<NetworkAddress> m_serverAddresses;
+    size_t                      m_currentAddressIndex;
 };

--- a/src/lib/base/String.cpp
+++ b/src/lib/base/String.cpp
@@ -15,6 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <cstdint>
 #include "arch/Arch.h"
 #include "base/String.h"
 #include "common/common.h"

--- a/src/lib/base/String.h
+++ b/src/lib/base/String.h
@@ -21,6 +21,7 @@
 #include "common/common.h"
 #include "common/stdstring.h"
 
+#include <cstdint>
 #include <stdarg.h>
 #include <vector>
 

--- a/src/lib/client/Client.cpp
+++ b/src/lib/client/Client.cpp
@@ -216,6 +216,12 @@ Client::getServerAddress() const
     return m_serverAddress;
 }
 
+void
+Client::setServerAddress(const NetworkAddress& addr)
+{
+    m_serverAddress = addr;
+}
+
 void*
 Client::getEventTarget() const
 {

--- a/src/lib/client/Client.h
+++ b/src/lib/client/Client.h
@@ -119,6 +119,13 @@ public:
     */
     NetworkAddress        getServerAddress() const;
 
+    //! Set address of server
+    /*!
+    Updates the server address used for the next connection attempt.
+    Used when cycling through multiple configured addresses.
+    */
+    void                setServerAddress(const NetworkAddress& addr);
+
     //! Return true if received file size is valid
     bool                isReceivedFileSizeValid();
 

--- a/src/lib/net/FingerprintData.h
+++ b/src/lib/net/FingerprintData.h
@@ -18,6 +18,7 @@
 #ifndef BARRIER_LIB_NET_FINGERPRINT_DATA_H
 #define BARRIER_LIB_NET_FINGERPRINT_DATA_H
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/lib/net/SecureUtils.cpp
+++ b/src/lib/net/SecureUtils.cpp
@@ -43,6 +43,7 @@
     THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#include <cstdint>
 #include "SecureUtils.h"
 #include "base/String.h"
 #include "base/finally.h"

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -330,10 +330,25 @@ Server::adoptClient(BaseClientProxy* client)
 
 	// add client to client list
 	if (!addClient(client)) {
-		// can only have one screen with a given name at any given time
-		LOG((CLOG_WARN "a client with name \"%s\" is already connected", getName(client).c_str()));
-		closeClient(client, kMsgEBusy);
-		return;
+		// A client with the same name is already registered. This typically
+		// happens when the client reconnects after a network change before
+		// the server detects the old connection is dead. Close the stale
+		// connection and accept the new one instead of rejecting it.
+		std::string name = getName(client);
+		ClientList::iterator staleIt = m_clients.find(name);
+		if (staleIt != m_clients.end() && staleIt->second != m_primaryClient) {
+			LOG((CLOG_NOTE "client \"%s\" reconnected, closing stale connection", name.c_str()));
+			closeClient(staleIt->second, kMsgEBusy);
+			if (!addClient(client)) {
+				LOG((CLOG_WARN "a client with name \"%s\" is already connected", name.c_str()));
+				closeClient(client, kMsgEBusy);
+				return;
+			}
+		} else {
+			LOG((CLOG_WARN "a client with name \"%s\" is already connected", name.c_str()));
+			closeClient(client, kMsgEBusy);
+			return;
+		}
 	}
 	LOG((CLOG_NOTE "client \"%s\" has connected", getName(client).c_str()));
 

--- a/src/test/global/TestUtils.cpp
+++ b/src/test/global/TestUtils.cpp
@@ -15,8 +15,9 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "TestUtils.h"
+#include <cstdint>
 #include <random>
+#include "TestUtils.h"
 
 namespace barrier {
 

--- a/src/test/unittests/base/StringTests.cpp
+++ b/src/test/unittests/base/StringTests.cpp
@@ -15,6 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <cstdint>
 #include "base/String.h"
 
 #include "test/global/gtest.h"


### PR DESCRIPTION
## Summary

- **Multi-address / hostname support**: Server address field accepts comma-separated list (e.g. 192.168.1.1, myserver.ddns.net). Client cycles automatically when a connection fails.
- **Stale connection replaced on reconnect**: Server closes the dead connection and accepts the new one instead of rejecting the reconnecting client.
- **Build modernisation**: CMake 4.x compatibility, VS 2022 support, Inno Setup 6 compatibility.

## Test Plan
- [x] Multi-address: configure 192.168.1.x, yourdomain.ddns.net — verify LAN uses local IP
- [x] Change network — verify client reconnects via hostname within seconds
- [x] Abrupt disconnect — verify server accepts reconnection without already connected warning
- [x] CMake 4.x build — no cmake_minimum_required error
- [x] 139 unit tests pass